### PR TITLE
Scoped plugins support

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -101,6 +101,7 @@ Plugin.loadPackageJSON = function(pluginPath) {
     throw new Error("Plugin " + pluginPath + " does not have a package name.");
   }
 
+  // maybe this is a @scope/homebridge-plugin ?
   var nameParts = pjson.name.split('/');
   var pName = nameParts[0];
   if (nameParts.length > 1 && pName.indexOf('@') === 0) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -96,8 +96,19 @@ Plugin.loadPackageJSON = function(pluginPath) {
     throw new Error("Plugin " + pluginPath + " contains an invalid package.json. Error: " + err);
   }
 
+  // make sure there is name for this package
+  if (!pjson.name) {
+    throw new Error("Plugin " + pluginPath + " does not have a package name.");
+  }
+
+  var nameParts = pjson.name.split('/');
+  var pName = nameParts[0];
+  if (nameParts.length > 1 && pName.indexOf('@') === 0) {
+    pName = nameParts[1];
+  }
+
   // make sure the name is prefixed with 'homebridge-'
-  if (!pjson.name || pjson.name.indexOf('homebridge-') != 0) {
+  if (pName.indexOf('homebridge-') !== 0) {
     throw new Error("Plugin " + pluginPath + " does not have a package name that begins with 'homebridge-'.");
   }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -205,7 +205,7 @@ Plugin.installed = function() {
       }
       catch (err) {
         // is this "trying" to be a homebridge plugin? if so let you know what went wrong.
-        if (!name || name.indexOf('homebridge-') == 0) {
+        if (!name || name.indexOf('homebridge-') === 0 || name.indexOf('/homebridge-') === 0) {
           log.warn(err.message);
         }
 


### PR DESCRIPTION
I had this in mind before I saw #1842 , and it helped me remote-testing features I developed for existing plugins (by asking the other party to install my published scoped plugin.)

It allows loading any _@scope/homebridge-XXX_ plugins as well as the original _homebridge-XXX_ plugins.