### PR TITLE
Remember listeners on AccessoryInformation if returned by getServices

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -437,26 +437,39 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
       if (service instanceof Service.AccessoryInformation) {
         var existingService = accessory.getService(Service.AccessoryInformation);
 
-        // pull out any values you may have defined
-        var manufacturer = service.getCharacteristic(Characteristic.Manufacturer).value;
-        var model = service.getCharacteristic(Characteristic.Model).value;
-        var serialNumber = service.getCharacteristic(Characteristic.SerialNumber).value;
-        var firmwareRevision = service.getCharacteristic(Characteristic.FirmwareRevision).value;
-        var hardwareRevision = service.getCharacteristic(Characteristic.HardwareRevision).value;
-
-        if (manufacturer) existingService.setCharacteristic(Characteristic.Manufacturer, manufacturer);
-        if (model) existingService.setCharacteristic(Characteristic.Model, model);
-        if (serialNumber) existingService.setCharacteristic(Characteristic.SerialNumber, serialNumber);
-        if (firmwareRevision) existingService.setCharacteristic(Characteristic.FirmwareRevision, firmwareRevision);
-        if (hardwareRevision) existingService.setCharacteristic(Characteristic.HardwareRevision, hardwareRevision);
+        this._augmentService(service, existingService, Characteristic.Name);
+        this._augmentService(service, existingService, Characteristic.Manufacturer);
+        this._augmentService(service, existingService, Characteristic.Model);
+        this._augmentService(service, existingService, Characteristic.SerialNumber);
+        this._augmentService(service, existingService, Characteristic.FirmwareRevision);
+        this._augmentService(service, existingService, Characteristic.HardwareRevision);
       }
       else {
         accessory.addService(service);
       }
-    });
+    }.bind(this));
 
     return accessory;
   }
+}
+
+Server.prototype._augmentService = function(srcService, dstService, characteristicUUID) {
+  var srcCharacteristic = srcService.getCharacteristic(characteristicUUID);
+  var dstCharacteristic = dstService.getCharacteristic(characteristicUUID);
+
+  if (!srcCharacteristic) return;
+
+  if (srcCharacteristic.value) dstService.setCharacteristic(characteristicUUID, srcCharacteristic.value);
+
+  var listeners = srcCharacteristic.listeners('get');
+  if (listeners.length === 0) return;
+
+  listeners.reverse();
+  for (var index in listeners) {
+    var listener = listeners[index];
+
+    dstCharacteristic.prependListener('get', listener);
+  }  
 }
 
 Server.prototype._handleRegisterPlatformAccessories = function(accessories) {


### PR DESCRIPTION
if `getServices` returns a Service.AccessoryInformation instance, the  existing code copies the `value` but not the `listeners`. In some cases (e.g., in https://github.com/homespun/homebridge-accessory-apcupsd/blob/master/index.js#L344), it isn't "convenient" to retrieve model and serial number information synchronously (cf., https://github.com/nfarina/homebridge/issues/697) .

The proposed code copies any listeners in the returned Service.AccessoryInformation instance so as to defer binding of the value until "convenient"

Enjoy!