### PR TITLE
Link Service.AccessoryInformation to the accessory's one to keep it to date

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,20 +30,28 @@ function toTitleCase(str) {
 }
 
 function linkAccessoryInformationService(sourceService, targetService, characteristic) {
-  var value = sourceService.getCharacteristic(characteristic).value;
-  if (value) {
-    targetService.setCharacteristic(characteristic, value);
-    targetService.getCharacteristic(characteristic).on('get', function (callback) {
-      try {
-        sourceService.getCharacteristic(characteristic).getValue(callback);
-      } catch (err) {
-        callback(err);
-      }
-    })
+  log.debug(`Linking characteristic ${characteristic}...`);
+  try {
+    var value = sourceService.getCharacteristic(characteristic).value;
+    if (value) {
+      targetService.setCharacteristic(characteristic, value);
+      targetService.getCharacteristic(characteristic).on('get', function (callback) {
+        log.debug(`Characteristic ${characteristic}: GET event triggered!!`);
+        try {
+          sourceService.getCharacteristic(characteristic).getValue(callback);
+        } catch (err) {
+          log.error(`Characteristic ${characteristic}: GET event error!!`, err);
+          callback(err);
+        }
+      })
+    }
+    sourceService.getCharacteristic(characteristic).on('change', function (oldValue, newValue) {
+      log.debug(`Characteristic ${characteristic}: CHANGE event triggered ${oldValue} => ${newValue}!!`);
+      targetService.setCharacteristic(characteristic, newValue);
+    });
+  } catch (error) {
+    log.error(`Linking characteristic ${characteristic}: Error`, error);
   }
-  sourceService.getCharacteristic(characteristic).on('change', function (oldValue, newValue) {
-    targetService.setCharacteristic(characteristic, newValue);
-  });
 }
 
 function Server(opts) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,10 +45,10 @@ function linkAccessoryInformationService(sourceService, targetService, character
         }
       })
     }
-    sourceService.getCharacteristic(characteristic).on('change', function (oldValue, newValue) {
-      log.debug(`Characteristic ${characteristic}: CHANGE event triggered ${oldValue} => ${newValue}!!`, oldValue, newValue);
-      if (newValue) {
-        targetService.setCharacteristic(characteristic, newValue);
+    sourceService.getCharacteristic(characteristic).on('change', function (update) {
+      log.debug(`Characteristic ${characteristic}: CHANGE event triggered!!`, update);
+      if (update.newValue) {
+        targetService.setCharacteristic(characteristic, update.newValue);
       }
     });
   } catch (error) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -46,8 +46,10 @@ function linkAccessoryInformationService(sourceService, targetService, character
       })
     }
     sourceService.getCharacteristic(characteristic).on('change', function (oldValue, newValue) {
-      log.debug(`Characteristic ${characteristic}: CHANGE event triggered ${oldValue} => ${newValue}!!`);
-      targetService.setCharacteristic(characteristic, newValue);
+      log.debug(`Characteristic ${characteristic}: CHANGE event triggered ${oldValue} => ${newValue}!!`, oldValue, newValue);
+      if (newValue) {
+        targetService.setCharacteristic(characteristic, newValue);
+      }
     });
   } catch (error) {
     log.error(`Linking characteristic ${characteristic}: Error`, error);

--- a/lib/server.js
+++ b/lib/server.js
@@ -455,17 +455,11 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
         var existingService = accessory.getService(Service.AccessoryInformation);
 
         // pull out any values you may have defined
-        var manufacturer = service.getCharacteristic(Characteristic.Manufacturer).value;
-        var model = service.getCharacteristic(Characteristic.Model).value;
-        var serialNumber = service.getCharacteristic(Characteristic.SerialNumber).value;
-        var firmwareRevision = service.getCharacteristic(Characteristic.FirmwareRevision).value;
-        var hardwareRevision = service.getCharacteristic(Characteristic.HardwareRevision).value;
-
-        if (manufacturer) existingService.setCharacteristic(Characteristic.Manufacturer, manufacturer);
-        if (model) existingService.setCharacteristic(Characteristic.Model, model);
-        if (serialNumber) existingService.setCharacteristic(Characteristic.SerialNumber, serialNumber);
-        if (firmwareRevision) existingService.setCharacteristic(Characteristic.FirmwareRevision, firmwareRevision);
-        if (hardwareRevision) existingService.setCharacteristic(Characteristic.HardwareRevision, hardwareRevision);
+        this._linkAccessoryInformationService(service, existingService, Characteristic.Manufacturer);
+        this._linkAccessoryInformationService(service, existingService, Characteristic.Model);
+        this._linkAccessoryInformationService(service, existingService, Characteristic.SerialNumber);
+        this._linkAccessoryInformationService(service, existingService, Characteristic.FirmwareRevision);
+        this._linkAccessoryInformationService(service, existingService, Characteristic.HardwareRevision);
       }
       else {
         accessory.addService(service);
@@ -473,6 +467,20 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
     });
 
     return accessory;
+  }
+}
+
+Server.prototype._linkAccessoryInformationService = function(sourceService, targetService, characteristic) {
+  var value = sourceService.getCharacteristic(characteristic).value;
+  if (value) {
+    targetService.setCharacteristic(characteristic, value);
+    targetService.getCharacteristic(characteristic).on('get', function (callback) {
+      try {
+        sourceService.getCharacteristic(characteristic).getValue(callback);
+      } catch (err) {
+        callback(err);
+      }
+    })
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,6 +29,20 @@ function toTitleCase(str) {
   return str.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 }
 
+function linkAccessoryInformationService(sourceService, targetService, characteristic) {
+  var value = sourceService.getCharacteristic(characteristic).value;
+  if (value) {
+    targetService.setCharacteristic(characteristic, value);
+    targetService.getCharacteristic(characteristic).on('get', function (callback) {
+      try {
+        sourceService.getCharacteristic(characteristic).getValue(callback);
+      } catch (err) {
+        callback(err);
+      }
+    })
+  }
+}
+
 function Server(opts) {
   opts = opts || {};
 
@@ -455,11 +469,11 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
         var existingService = accessory.getService(Service.AccessoryInformation);
 
         // pull out any values you may have defined
-        this._linkAccessoryInformationService(service, existingService, Characteristic.Manufacturer);
-        this._linkAccessoryInformationService(service, existingService, Characteristic.Model);
-        this._linkAccessoryInformationService(service, existingService, Characteristic.SerialNumber);
-        this._linkAccessoryInformationService(service, existingService, Characteristic.FirmwareRevision);
-        this._linkAccessoryInformationService(service, existingService, Characteristic.HardwareRevision);
+        linkAccessoryInformationService(service, existingService, Characteristic.Manufacturer);
+        linkAccessoryInformationService(service, existingService, Characteristic.Model);
+        linkAccessoryInformationService(service, existingService, Characteristic.SerialNumber);
+        linkAccessoryInformationService(service, existingService, Characteristic.FirmwareRevision);
+        linkAccessoryInformationService(service, existingService, Characteristic.HardwareRevision);
       }
       else {
         accessory.addService(service);
@@ -467,20 +481,6 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
     });
 
     return accessory;
-  }
-}
-
-Server.prototype._linkAccessoryInformationService = function(sourceService, targetService, characteristic) {
-  var value = sourceService.getCharacteristic(characteristic).value;
-  if (value) {
-    targetService.setCharacteristic(characteristic, value);
-    targetService.getCharacteristic(characteristic).on('get', function (callback) {
-      try {
-        sourceService.getCharacteristic(characteristic).getValue(callback);
-      } catch (err) {
-        callback(err);
-      }
-    })
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,6 +41,9 @@ function linkAccessoryInformationService(sourceService, targetService, character
       }
     })
   }
+  sourceService.getCharacteristic(characteristic).on('change', function (oldValue, newValue) {
+    targetService.setCharacteristic(characteristic, newValue);
+  });
 }
 
 function Server(opts) {


### PR DESCRIPTION
A plugin I'm maintaining needs to perform some asynchronous operations before grabbing the SerialNumber or the FirmwareRevision.

I was trying to update the parameters via myAccessoryInformation.setCharacteristics calls but nothing was working and found we are copying the values to the Service.AccessoryInformation instantiated by HAP.

This MR intends to keep the HAP instance updated with any updates from the accessory itself.

I know the SerialNumber won't change over time, but the Firmware might because of updates :)