### PR TITLE
Add support for @scoped/homebridge- plugins

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,13 +17,14 @@ module.exports = {
  * Allows for discovering and loading installed Homebridge plugins.
  */
 
-function Plugin(pluginPath) {
+function Plugin(pluginPath, pluginName) {
   this.pluginPath = pluginPath; // like "/usr/local/lib/node_modules/homebridge-lockitron"
+  this.pluginName = pluginName; // like "homebridge-dummy" or "@scope/homebridge-dummy"
   this.initializer; // exported function from the plugin that initializes it
 }
 
 Plugin.prototype.name = function() {
-  return path.basename(this.pluginPath);
+  return this.pluginName.charAt(0) === '@' ? this.pluginName : path.basename(this.pluginPath);
 }
 
 Plugin.prototype.load = function(options) {
@@ -96,9 +97,9 @@ Plugin.loadPackageJSON = function(pluginPath) {
     throw new Error("Plugin " + pluginPath + " contains an invalid package.json. Error: " + err);
   }
 
-  // make sure the name is prefixed with 'homebridge-'
-  if (!pjson.name || pjson.name.indexOf('homebridge-') != 0) {
-    throw new Error("Plugin " + pluginPath + " does not have a package name that begins with 'homebridge-'.");
+  // make sure the name is prefixed with 'homebridge-' or '@scope/homebridge-'
+  if (!pjson.name || (pjson.name.indexOf('homebridge-') !== 0 && (pjson.name.charAt(0) === '@' && pjson.name.split('/')[1].indexOf('homebridge-') !== 0))) {
+    throw new Error("Plugin " + pluginPath + " does not have a package name that begins with 'homebridge-' or '@scope/homebridge-.");
   }
 
   // verify that it's tagged with the correct keyword
@@ -170,6 +171,21 @@ Plugin.installed = function() {
 
     var names = fs.readdirSync(requirePath);
 
+    // expand out @scoped plugins
+    for (var index3 in names) {
+      if (names[index3].charAt(0) === '@' && fs.statSync(path.join(requirePath, names[index3])).isDirectory()) {
+        var scopedNames = fs.readdirSync(path.join(requirePath, names[index3]));
+        scopedNames
+        .filter(function(name) {
+          return (name.indexOf('homebridge-') == 0);
+        })
+        .forEach(function(name) {
+          names.push(path.join(names[index3], name))
+          return;
+        });
+      }
+    }
+
     // does this path point inside a single plugin and not a directory containing plugins?
     if (fs.existsSync(path.join(requirePath, "package.json")))
       names = [""];
@@ -194,7 +210,7 @@ Plugin.installed = function() {
       }
       catch (err) {
         // is this "trying" to be a homebridge plugin? if so let you know what went wrong.
-        if (!name || name.indexOf('homebridge-') == 0) {
+        if (!name || name.indexOf('homebridge-') === 0 || (name.charAt(0) === '@' && name.split(path.sep).length > 1 && name.split(path.sep)[1].indexOf('homebridge-') === 0)) {
           log.warn(err.message);
         }
 
@@ -208,7 +224,7 @@ Plugin.installed = function() {
       // add it to the return list
       if (!pluginsByName[name]) {
         pluginsByName[name] = pluginPath;
-        plugins.push(new Plugin(pluginPath));
+        plugins.push(new Plugin(pluginPath, name));
       }
       else {
         log.warn("Warning: skipping plugin found at '" + pluginPath + "' since we already loaded the same plugin from '" + pluginsByName[name] + "'.");


### PR DESCRIPTION
This pull request adds support for scoped npm packages as Homebridge plugins.

Plugins in the following format will be matched:

```
@scope/homebridge-dummy
```

Plugins are registered in Homebridge under their scope:

```
Loaded plugin: @scope/homebridge-dummy
```

Tested and working with globally installed plugins, as well as when Homebridge is pointing to a specific folder for a plugin using the `-P` flag.