### PR TITLE
Update the way AccessoryInformationService is merged

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -455,17 +455,13 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
         var existingService = accessory.getService(Service.AccessoryInformation);
 
         // pull out any values you may have defined
-        var manufacturer = service.getCharacteristic(Characteristic.Manufacturer).value;
-        var model = service.getCharacteristic(Characteristic.Model).value;
-        var serialNumber = service.getCharacteristic(Characteristic.SerialNumber).value;
-        var firmwareRevision = service.getCharacteristic(Characteristic.FirmwareRevision).value;
-        var hardwareRevision = service.getCharacteristic(Characteristic.HardwareRevision).value;
+        service.characteristics.forEach(characteristic => {
+          if (characteristic.UUID === Characteristic.Identifier.UUID || characteristic.UUID === Characteristic.Name.UUID) {
+            return;
+          }
 
-        if (manufacturer) existingService.setCharacteristic(Characteristic.Manufacturer, manufacturer);
-        if (model) existingService.setCharacteristic(Characteristic.Model, model);
-        if (serialNumber) existingService.setCharacteristic(Characteristic.SerialNumber, serialNumber);
-        if (firmwareRevision) existingService.setCharacteristic(Characteristic.FirmwareRevision, firmwareRevision);
-        if (hardwareRevision) existingService.setCharacteristic(Characteristic.HardwareRevision, hardwareRevision);
+          existingService.getCharacteristic(characteristic).updateValue(characteristic.value);
+        });
       }
       else {
         accessory.addService(service);


### PR DESCRIPTION
The definition of the AccessoryInformationService changed lately:
https://github.com/KhaosT/HAP-NodeJS/blob/a3a49491c00e91ffb2a6dd4d3628e917cf61ddba/src/lib/gen/HomeKit.ts#L3651-L3664

This change makes the whole process a bit more future proof.

Currently pretty much all Characteristics are READ only and are meant to not change over the time, except of `ConfiguredName` (READ, WRITE, NOTIFY) and `ProductData` (READ, NOTIFY).
I would guess that ConfiguredName could be used to listen for any name changes done inside the Home App.
What the PR does not cover currently is, that event handlers are transferred as well (only really useful for those mentioned services). Don't know what would be the best practice for that.
