### PR TITLE
Execute publish job only if inside homebridge repository

### DIFF
--- a/.github/workflows/npmpublish-beta.yml
+++ b/.github/workflows/npmpublish-beta.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm install
 
   publish-npm:
+    if: github.repository == 'homebridge/homebridge'
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,6 +14,7 @@ jobs:
       - run: npm ci
 
   publish-npm:
+    if: github.repository == 'homebridge/homebridge'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This changes the `publish-npm` to only run if push/release happened actually in the homebridge repo. This improves the situation for forks and reduces the amount of illegal publishes 😅 

`homebridge/homebridge` should be alright I guess? 