### PR TITLE
Pull zero conf platform loading

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -32,7 +32,6 @@ export interface PluginInitializer {
 }
 
 export interface AccessoryPluginConstructor {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     new(logger: Logging, config: AccessoryConfig): AccessoryPlugin;
 }
 
@@ -45,8 +44,7 @@ export interface AccessoryPlugin {
 }
 
 export interface PlatformPluginConstructor {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    new(logger: Logging, config: PlatformConfig | null, api: API): PlatformPlugin; // config=null for dynamic plugins which did not get mentioned in the config.json
+    new(logger: Logging, config: PlatformConfig, api: API): PlatformPlugin;
 }
 
 export interface PlatformPlugin { // also referred to as "dynamic" platform plugin
@@ -152,7 +150,6 @@ export class HomebridgeAPI extends EventEmitter implements API {
     private readonly _platforms: Record<PlatformIdentifier, PlatformPluginConstructor> = {};
 
     // private readonly _configurableAccessories: Record<AccessoryIdentifier, ConfigurablePlatformPlugin> = {}; // accessory configuration is not (yet) supported by BridgeSetupManager
-    readonly _dynamicPlatforms: Map<PlatformIdentifier, PlatformPluginConstructor> = new Map();
 
     constructor() {
       super();
@@ -266,7 +263,7 @@ export class HomebridgeAPI extends EventEmitter implements API {
       }
     }
 
-    registerPlatform(pluginName: PluginName, platformName: PlatformName, constructor: PlatformPluginConstructor, dynamic?: boolean): void {
+    registerPlatform(pluginName: PluginName, platformName: PlatformName, constructor: PlatformPluginConstructor): void {
       const fullName = pluginName + "." + platformName;
 
       if (this._platforms[fullName]) {
@@ -276,10 +273,6 @@ export class HomebridgeAPI extends EventEmitter implements API {
       log.info("Registering platform '%s'", fullName);
 
       this._platforms[fullName] = constructor;
-
-      if (dynamic) {
-        this._dynamicPlatforms.set(fullName, constructor);
-      }
     }
 
     registerPlatformAccessories(pluginName: PlatformName, platformName: PlatformName, accessories: PlatformAccessory[]): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -163,7 +163,6 @@ export class Server {
       if (this._config.accessories.length > 0) {
         this._loadAccessories();
       }
-      this._loadDynamicPlatforms();
       this._configCachedPlatformAccessories();
       this._bridge.addService(this._setupManager.getService());
 
@@ -405,24 +404,6 @@ export class Server {
           throw new Error(`Detected malformed Platform in your config.json at position ${index + 1}! Please contact Platform developer!`);
         }
       });
-    }
-
-    private _loadDynamicPlatforms(): void {
-      for (const [name, platformConstructor] of this.api._dynamicPlatforms.entries()) {
-        if (this._activeDynamicPlugins.has(name) || this._activeDynamicPlugins.has(HomebridgeAPI.getPlatformName(name))) {
-          continue;
-        }
-
-        console.log("Load " + name);
-
-        const platformLogger = Logger.withPrefix(name);
-        const platformInstance = new platformConstructor(platformLogger, null, this.api);
-        this._activeDynamicPlugins.set(name, platformInstance); // name is here type "PlatformIdentifier"
-
-        if (HomebridgeAPI.isConfigurablePlugin(platformInstance)) {
-          this._configurablePlatformPlugins.set(name, platformInstance); // name is here type "PlatformIdentifier"
-        }
-      }
     }
 
     private _configCachedPlatformAccessories(): void {


### PR DESCRIPTION
As discussed, this PR drops the feature, that Platforms which indicate that they are "dynamic" would get automatically loaded and enabled without the user noticing it when they are not mentioned in the config.json.