### PR TITLE
Bump Homebridge API version to 2.5

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -129,7 +129,7 @@ export declare interface HomebridgeAPI {
 
 export class HomebridgeAPI extends EventEmitter implements API {
 
-    public readonly version = 2.4; // homebridge API version
+    public readonly version = 2.5; // homebridge API version
     public readonly serverVersion = getVersion(); // homebridge node module version
 
     // ------------------ LEGACY EXPORTS FOR PRE TYPESCRIPT  ------------------


### PR DESCRIPTION
A 0.x version bump should be enough I think