### PR TITLE
Automatically pass the current plugin version to the FirmwareRevision characteristic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,9 +2254,9 @@
       "dev": true
     },
     "fast-srp-hap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-1.0.1.tgz",
-      "integrity": "sha1-N3Ek0Za8alFXquWze/X6NbtK0tk="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.1.tgz",
+      "integrity": "sha512-dClwnyfRd3BZxu3KAdhvAayozq7fLazXGlDc4HAHJV1M+olqGKAT52pygXQu5UiDSHxz/WB3KRvsojqQ5zmXOA=="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -2467,14 +2467,14 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.5.12-beta.3",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.5.12-beta.3.tgz",
-      "integrity": "sha512-GfqTxlykjkg20bp76VJJ6XlgTVzmv4K+wA0LtExW64H1tHzkrDswvop/+H7BRtU25DA/Y55UizqkBurDVabatw==",
+      "version": "0.5.12-beta.5",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.5.12-beta.5.tgz",
+      "integrity": "sha512-1GLIq6VZ+zW+ieNXhy0zYk51fgm2QIu58UlwPeQkeQ1uCX51U6bdC9r5Y0JRMylgL2vijtyNz8adhIau7L61vA==",
       "requires": {
-        "bonjour-hap": "^3.5.1",
+        "bonjour-hap": "3.5.4",
         "debug": "^4.1.1",
         "decimal.js": "^10.2.0",
-        "fast-srp-hap": "^1.0.1",
+        "fast-srp-hap": "2.0.1",
         "ip": "^1.1.3",
         "node-persist": "^0.0.11",
         "tweetnacl": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.5.12-beta.3",
+    "hap-nodejs": "0.5.12-beta.5",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -8,149 +8,149 @@ import {
   Service,
   WithUUID,
 } from "hap-nodejs";
-import { PlatformName, PluginName } from "./api";
+import { PlatformName, PluginIdentifier, PluginName } from "./api";
 
 export interface SerializedPlatformAccessory extends SerializedAccessory {
 
-    plugin: PluginName;
-    platform: PlatformName;
+  plugin: PluginName;
+  platform: PlatformName;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    context: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context: Record<string, any>;
 
 }
 
 export enum PlatformAccessoryEvent {
-    IDENTIFY = "identify",
+  IDENTIFY = "identify",
 }
 
 export declare interface PlatformAccessory {
 
-    on(event: "identify", listener: () => void): this;
+  on(event: "identify", listener: () => void): this;
 
-    emit(event: "identify"): boolean;
+  emit(event: "identify"): boolean;
 
 }
 
 export class PlatformAccessory extends EventEmitter {
 
-    // somewhat ugly way to inject custom Accessory object, while not changing the publicly exposed constructor signature
-    private static injectedAccessory?: Accessory;
+  // somewhat ugly way to inject custom Accessory object, while not changing the publicly exposed constructor signature
+  private static injectedAccessory?: Accessory;
 
-    _associatedPlugin?: PluginName; // present as soon as it is registered
-    _associatedPlatform?: PlatformName; // not present for external accessories
+  _associatedPlugin?: PluginIdentifier; // present as soon as it is registered
+  _associatedPlatform?: PlatformName; // not present for external accessories
 
-    _associatedHAPAccessory: Accessory;
+  _associatedHAPAccessory: Accessory;
 
-    // ---------------- HAP Accessory mirror ----------------
-    displayName: string;
-    UUID: string;
-    category: Categories;
-    services: Service[] = [];
-    // ------------------------------------------------------
+  // ---------------- HAP Accessory mirror ----------------
+  displayName: string;
+  UUID: string;
+  category: Categories;
+  services: Service[] = [];
+  // ------------------------------------------------------
 
-    /**
-     * This is a way for Plugin developers to store custom data with their accessory
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public context: Record<string, any> = {}; // providing something to store
+  /**
+   * This is a way for Plugin developers to store custom data with their accessory
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public context: Record<string, any> = {}; // providing something to store
 
-    constructor(displayName: string, uuid: string, category?: Categories) { // category is only useful for external accessories
-      super();
-      this._associatedHAPAccessory = PlatformAccessory.injectedAccessory
-        ? PlatformAccessory.injectedAccessory
-        : new Accessory(displayName, uuid);
+  constructor(displayName: string, uuid: string, category?: Categories) { // category is only useful for external accessories
+    super();
+    this._associatedHAPAccessory = PlatformAccessory.injectedAccessory
+      ? PlatformAccessory.injectedAccessory
+      : new Accessory(displayName, uuid);
 
-      if (category) {
-        this._associatedHAPAccessory.category = category;
-      }
-
-      this.displayName = this._associatedHAPAccessory.displayName;
-      this.UUID = this._associatedHAPAccessory.UUID;
-      this.category = category || Categories.OTHER;
-      this.services = this._associatedHAPAccessory.services;
-
-      // forward identify event
-      this._associatedHAPAccessory.on(AccessoryEventTypes.IDENTIFY, (paired, callback) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        this.emit(PlatformAccessoryEvent.IDENTIFY, () => {}); // empty callback for backwards compatibility
-        callback();
-      });
+    if (category) {
+      this._associatedHAPAccessory.category = category;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public addService(service: Service | typeof Service, ...constructorArgs: any[]): Service {
-      return this._associatedHAPAccessory.addService(service, ...constructorArgs);
-    }
+    this.displayName = this._associatedHAPAccessory.displayName;
+    this.UUID = this._associatedHAPAccessory.UUID;
+    this.category = category || Categories.OTHER;
+    this.services = this._associatedHAPAccessory.services;
 
-    public removeService(service: Service): void {
-      this._associatedHAPAccessory.removeService(service);
-    }
+    // forward identify event
+    this._associatedHAPAccessory.on(AccessoryEventTypes.IDENTIFY, (paired, callback) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      this.emit(PlatformAccessoryEvent.IDENTIFY, () => {}); // empty callback for backwards compatibility
+      callback();
+    });
+  }
 
-    public getService<T extends WithUUID<typeof Service>>(name: string | T): Service | undefined {
-      return this._associatedHAPAccessory.getService(name);
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public addService(service: Service | typeof Service, ...constructorArgs: any[]): Service {
+    return this._associatedHAPAccessory.addService(service, ...constructorArgs);
+  }
 
-    /**
-     *
-     * @param uuid
-     * @param subType
-     * @deprecated use {@link getServiceById} directly
-     */
-    public getServiceByUUIDAndSubType<T extends WithUUID<typeof Service>>(uuid: string | T, subType: string): Service | undefined {
-      return this.getServiceById(uuid, subType);
-    }
+  public removeService(service: Service): void {
+    this._associatedHAPAccessory.removeService(service);
+  }
 
-    public getServiceById<T extends WithUUID<typeof Service>>(uuid: string | T, subType: string): Service | undefined {
-      return this._associatedHAPAccessory.getServiceById(uuid, subType);
-    }
+  public getService<T extends WithUUID<typeof Service>>(name: string | T): Service | undefined {
+    return this._associatedHAPAccessory.getService(name);
+  }
 
-    /**
-     *
-     * @param reachable
-     * @deprecated reachability isn't supported anymore
-     */
-    public updateReachability(reachable: boolean): void {
-      this._associatedHAPAccessory.updateReachability(reachable);
-    }
+  /**
+   *
+   * @param uuid
+   * @param subType
+   * @deprecated use {@link getServiceById} directly
+   */
+  public getServiceByUUIDAndSubType<T extends WithUUID<typeof Service>>(uuid: string | T, subType: string): Service | undefined {
+    return this.getServiceById(uuid, subType);
+  }
 
-    /**
-     *
-     * @param cameraSource
-     * @deprecated see {@link Accessory.configureCameraSource}
-     */
-    public configureCameraSource(cameraSource: LegacyCameraSource): CameraController {
-      return this._associatedHAPAccessory.configureCameraSource(cameraSource);
-    }
+  public getServiceById<T extends WithUUID<typeof Service>>(uuid: string | T, subType: string): Service | undefined {
+    return this._associatedHAPAccessory.getServiceById(uuid, subType);
+  }
 
-    public configureController(controller: Controller | ControllerConstructor): void {
-      this._associatedHAPAccessory.configureController(controller);
-    }
+  /**
+   *
+   * @param reachable
+   * @deprecated reachability isn't supported anymore
+   */
+  public updateReachability(reachable: boolean): void {
+    this._associatedHAPAccessory.updateReachability(reachable);
+  }
 
-    // private
-    static serialize(accessory: PlatformAccessory): SerializedPlatformAccessory {
-      return {
-        plugin: accessory._associatedPlugin!,
-        platform: accessory._associatedPlatform!,
-        context: accessory.context,
-        ...Accessory.serialize(accessory._associatedHAPAccessory),
-      };
-    }
+  /**
+   *
+   * @param cameraSource
+   * @deprecated see {@link Accessory.configureCameraSource}
+   */
+  public configureCameraSource(cameraSource: LegacyCameraSource): CameraController {
+    return this._associatedHAPAccessory.configureCameraSource(cameraSource);
+  }
 
-    static deserialize(json: SerializedPlatformAccessory): PlatformAccessory {
-      const accessory = Accessory.deserialize(json);
+  public configureController(controller: Controller | ControllerConstructor): void {
+    this._associatedHAPAccessory.configureController(controller);
+  }
 
-      PlatformAccessory.injectedAccessory = accessory;
-      const platformAccessory = new PlatformAccessory(accessory.displayName, accessory.UUID);
-      PlatformAccessory.injectedAccessory = undefined;
+  // private
+  static serialize(accessory: PlatformAccessory): SerializedPlatformAccessory {
+    return {
+      plugin: accessory._associatedPlugin!,
+      platform: accessory._associatedPlatform!,
+      context: accessory.context,
+      ...Accessory.serialize(accessory._associatedHAPAccessory),
+    };
+  }
 
-      platformAccessory._associatedPlugin = json.plugin;
-      platformAccessory._associatedPlatform = json.platform;
-      platformAccessory.context = json.context;
+  static deserialize(json: SerializedPlatformAccessory): PlatformAccessory {
+    const accessory = Accessory.deserialize(json);
 
-      return platformAccessory;
-    }
+    PlatformAccessory.injectedAccessory = accessory;
+    const platformAccessory = new PlatformAccessory(accessory.displayName, accessory.UUID);
+    PlatformAccessory.injectedAccessory = undefined;
+
+    platformAccessory._associatedPlugin = json.plugin;
+    platformAccessory._associatedPlatform = json.platform;
+    platformAccessory.context = json.context;
+
+    return platformAccessory;
+  }
 
 }


### PR DESCRIPTION
As the title already says, the current plugin version is now automatically set as the `FirmwareRevision` value for external accessories, platform accessories and normal accessory plugins. If a developer wishes to expose another versioning system they are advised to fall back to the `SoftwareRevision ` or `HardwareRevision` characteristic.

Additionally the plugin class was optimized to never store the content of the package.json forever and hap-nodejs was updated to the latest beta.

No changes where made to the platformAccessory (except of one type correction). I only fixed the indents there to be 2 spaces. ESLint seems to be somewhat weird or not as aggressive for classes lol.