### PR TITLE
Add node version check for homebridge required node version

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,20 @@
 import "source-map-support/register"; // registering node-source-map-support for typescript stack traces
 import commander from "commander";
-import getVersion from "./version";
+import getVersion, { getRequiredNodeVersion } from "./version";
 import { Logger } from "./logger";
 import { User } from "./user";
 import { HomebridgeOptions, Server } from "./server";
 import { init } from "hap-nodejs";
 import Signals = NodeJS.Signals;
+import { satisfies } from "semver";
 
 const log = Logger.internal;
+
+const requiredNodeVersion = getRequiredNodeVersion();
+if (requiredNodeVersion && !satisfies(process.version, requiredNodeVersion)) {
+  log.warn(`Homebridge requires Node version of ${requiredNodeVersion} which does \
+not satisfy the current Node version of ${process.version}. You may need to upgrade your installation of Node.`);
+}
 
 // noinspection JSUnusedGlobalSymbols
 export = function cli(): void {

--- a/src/version.spec.ts
+++ b/src/version.spec.ts
@@ -1,4 +1,4 @@
-import getVersion from "./version";
+import getVersion, { getRequiredNodeVersion } from "./version";
 import fs, { PathLike } from "fs";
 import path from "path";
 
@@ -25,7 +25,35 @@ describe("version", () => {
       });
 
       const version = getVersion();
-      expect(version).toBe(version);
+      expect(version).toBe(expectedVersion);
+    });
+  });
+
+  describe(getRequiredNodeVersion, () => {
+    it("should read correct node version from package.json", function() {
+      const expectedVersion = ">=10.17.0";
+      const expectedPath = path.resolve(__dirname, "../package.json");
+
+      const mock = jest.spyOn(fs, "readFileSync");
+      // mock only once, otherwise we break the whole test runner
+      mock.mockImplementationOnce((path: PathLike | number, options?: { encoding?: string | null; flag?: string } | string | null) => {
+        expect(path).toBe(expectedPath);
+        expect(options).toBeDefined();
+        expect(typeof options).toBe("object");
+        const opt = options as {encoding: string};
+        expect(opt.encoding).toBe("utf8");
+
+        const fakeJson = {
+          engines: {
+            node: expectedVersion,
+          },
+        };
+
+        return JSON.stringify(fakeJson, null, 4); // pretty print
+      });
+
+      const version = getRequiredNodeVersion();
+      expect(version).toBe(expectedVersion);
     });
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,8 +1,17 @@
 import fs from "fs";
 import path from "path";
 
-export default function getVersion(): string {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function loadPackageJson(): any {
   const packageJSONPath = path.join(__dirname, "../package.json");
   const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, { encoding: "utf8" }));
-  return packageJSON.version;
+  return packageJSON;
+}
+
+export default function getVersion(): string {
+  return loadPackageJson().version;
+}
+
+export function getRequiredNodeVersion(): string {
+  return loadPackageJson().engines.node;
 }


### PR DESCRIPTION
as discussed. A warning will be printed if a node version is detected less than what is specified to be a requirement.