### PR TITLE
Print warning when a platform is configured multiple times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2467,9 +2467,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.5.12-beta.6",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.5.12-beta.6.tgz",
-      "integrity": "sha512-bXjF7Fc7gf1CggtIGeTgwVpqmTQvXZFegP9mHKY49YD61tYsgB1NMBDR1e/1CeX3tqRk5Q7EW7RByLdtxmjY0Q==",
+      "version": "0.5.12-beta.10",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.5.12-beta.10.tgz",
+      "integrity": "sha512-FPMZJKgwW3jhmw1GLt1OSP30EN/qj8SMEBuGgeE5Y2uZBuUU71SuCbWdQV/b8rfH6eA6XVpe39AxY1/126WaKQ==",
       "requires": {
         "bonjour-hap": "3.5.4",
         "debug": "^4.1.1",
@@ -3972,9 +3972,13 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
     },
     "object-keys": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.5.12-beta.6",
+    "hap-nodejs": "0.5.12-beta.10",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,9 +4,9 @@ import getVersion, { getRequiredNodeVersion } from "./version";
 import { Logger } from "./logger";
 import { User } from "./user";
 import { HomebridgeOptions, Server } from "./server";
-import { init } from "hap-nodejs";
-import Signals = NodeJS.Signals;
 import { satisfies } from "semver";
+import { HAPStorage } from "hap-nodejs";
+import Signals = NodeJS.Signals;
 
 const log = Logger.internal;
 
@@ -38,7 +38,7 @@ export = function cli(): void {
     .parse(process.argv);
 
   // Initialize HAP-NodeJS with a custom persist directory
-  init(User.persistPath());
+  HAPStorage.setCustomStoragePath(User.persistPath());
 
   const options: HomebridgeOptions = {
     cleanCachedAccessories: cleanCachedAccessories,

--- a/src/server.ts
+++ b/src/server.ts
@@ -260,16 +260,17 @@ export class Server {
   private restoreCachedPlatformAccessories(): void {
     this.cachedPlatformAccessories = this.cachedPlatformAccessories.filter(accessory => {
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!);
-      const platformPlugin = plugin && plugin.getActivePlatform(accessory._associatedPlatform!);
+      const platformPlugins = plugin && plugin.getActivePlatforms(accessory._associatedPlatform!);
 
-      if (!platformPlugin) {
-        console.log(`Failed to find plugin to handle accessory ${accessory._associatedHAPAccessory.displayName}`);
+      if (!platformPlugins) {
+        log.info(`Failed to find plugin to handle accessory ${accessory._associatedHAPAccessory.displayName}`);
         if (this.cleanCachedAccessories) {
-          console.log(`Removing orphaned accessory ${accessory._associatedHAPAccessory.displayName}`);
+          log.info(`Removing orphaned accessory ${accessory._associatedHAPAccessory.displayName}`);
           return false; // filter it from the list
         }
       } else {
-        platformPlugin.configureAccessory(accessory);
+        // we always use the last registered
+        platformPlugins[0].configureAccessory(accessory);
         accessory.getService(Service.AccessoryInformation)!
           .setCharacteristic(Characteristic.FirmwareRevision, plugin!.version);
       }
@@ -454,8 +455,8 @@ export class Server {
         accessory.getService(Service.AccessoryInformation)!
           .setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
 
-        const platform = plugin.getActivePlatform(accessory._associatedPlatform!);
-        if (!platform) {
+        const platforms = plugin.getActivePlatforms(accessory._associatedPlatform!);
+        if (!platforms) {
           log.warn("The plugin '%s' registered a new accessory for the platform '%s'. The platform couldn't be found though!", accessory._associatedPlugin!, accessory._associatedPlatform!);
         }
       } else {


### PR DESCRIPTION
This PR basically restores the previous behavior, where it was possible to configure a platform multiple times. But now it is in a controller manner and a warning is printed, that this functionality will be removed in the future!

Additionally it bumps HAP-NodeJS to the latest beta. This will be the last change made in HAP-NodeJS before release. This addresses issues happened for people incorrectly copying prototype values. Also the need to call the init function was removed.