### PR TITLE
Import hap-nodejs files from one central location only

### DIFF
--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -1,6 +1,5 @@
 import { AccessoryPlugin, HomebridgeAPI, InternalAPIEvent, PlatformPlugin } from "./api";
-import { Service } from "hap-nodejs";
-import { PlatformAccessory } from "./platformAccessory";
+import { PlatformAccessory, Service } from "./";
 
 const api = new HomebridgeAPI();
 const emitSpy = jest.spyOn(api, "emit");

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,7 @@
 import { EventEmitter } from "events";
 import getVersion from "./version";
-import { Logger, Logging } from "./logger";
-import * as hapNodeJs from "hap-nodejs";
-import { Service } from "hap-nodejs";
-import { PlatformAccessory } from "./platformAccessory";
-import { User } from "./user";
+import * as hapNodeJs from "./";
+import { Logger, Logging, PlatformAccessory, Service, User } from "./";
 import { AccessoryConfig, PlatformConfig } from "./server";
 import { PluginManager } from "./pluginManager";
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,9 @@
 import "source-map-support/register"; // registering node-source-map-support for typescript stack traces
 import commander from "commander";
 import getVersion, { getRequiredNodeVersion } from "./version";
-import { Logger } from "./logger";
-import { User } from "./user";
+import { HAPStorage, Logger, User } from "./";
 import { HomebridgeOptions, Server } from "./server";
 import { satisfies } from "semver";
-import { HAPStorage } from "hap-nodejs";
 import Signals = NodeJS.Signals;
 
 const log = Logger.internal;

--- a/src/platformAccessory.spec.ts
+++ b/src/platformAccessory.spec.ts
@@ -1,5 +1,12 @@
-import { PlatformAccessory, SerializedPlatformAccessory } from "./platformAccessory";
-import { Accessory, Categories, RemoteController, Service, uuid } from "hap-nodejs";
+import {
+  Accessory,
+  Categories,
+  PlatformAccessory,
+  RemoteController,
+  SerializedPlatformAccessory,
+  Service,
+  uuid,
+} from "./";
 
 function createAccessory(name = "TestAccessory", category?: Categories): PlatformAccessory {
   const accessoryUUID = uuid.generate("test.uuid." + name);

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -1,13 +1,16 @@
 import { EventEmitter } from "events";
 import {
   Accessory,
-  AccessoryEventTypes, CameraController,
-  Categories, Controller, ControllerConstructor,
+  AccessoryEventTypes,
+  CameraController,
+  Categories,
+  Controller,
+  ControllerConstructor,
   LegacyCameraSource,
   SerializedAccessory,
   Service,
   WithUUID,
-} from "hap-nodejs";
+} from "./";
 import { PlatformName, PluginIdentifier, PluginName } from "./api";
 
 export interface SerializedPlatformAccessory extends SerializedAccessory {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import {
   PublishInfo,
   Service,
   uuid,
-} from "hap-nodejs";
+} from "./";
 import { Logger } from "./logger";
 import { User } from "./user";
 import {

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,8 +4,7 @@ import path from "path";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function loadPackageJson(): any {
   const packageJSONPath = path.join(__dirname, "../package.json");
-  const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, { encoding: "utf8" }));
-  return packageJSON;
+  return JSON.parse(fs.readFileSync(packageJSONPath, { encoding: "utf8" }));
 }
 
 export default function getVersion(): string {


### PR DESCRIPTION
index.ts is now the only file which directly imports from the module "hap-nodejs"