### PR TITLE
Fixed: a plugin returning an error for one characteristic would sometimes result in the whole room being displayed as "no response"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2467,9 +2467,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.1.tgz",
-      "integrity": "sha512-u0bsEXerSc/uO+TyT7bEbz+nq1nyfcq31zIIcBbEv50vByy8PveZ4L2xifU/v0B5dBUGKE97UBliA9GrEYJuDA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.2.tgz",
+      "integrity": "sha512-/LlRaYCtcwC4jBUKRJeBUdUfKEp8w/NK3PNYXaAOngQL9uVnqsvQ0Gce/mUhSXPhsxfdnxbHVT870W9OEnV6+A==",
       "requires": {
         "bonjour-hap": "3.5.4",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.1",
+    "hap-nodejs": "0.6.2",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",


### PR DESCRIPTION
When a HomeKit controller would send a /characteristics request and one of the requested characteristics would return with an error, all requested characteristics would show up with "No response".
Huge thanks to "@psumstr" on the discord for pointing me towards this issue.

This was fixed in HAP-NodeJS 0.6.2 with https://github.com/homebridge/HAP-NodeJS/commit/392e5a6b404ffd78bf395e1ce02eac2c965d806d