### PR TITLE
Update Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,13 +24,16 @@ assignees: ''
 **Expected behavior:**
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Logs:**
-<!-- Paste relevant output between the two ``` lines below -->
+[**Logs:**]()
+<!-- Please paste any relevant log output into a gist or using hastebin-->
+<!-- If using hastebin or other text sharing website please make the lifespan long-->
+<!-- Paste the link between the two () above -->
 <!-- Remove any sensitive information, passwords, etc. -->
 <!-- Please include the beginning of the log where the homebridge initialization happens -->
+<!-- If needing to link multiple log files please do so between the ``` lines below -->
 
 ```
-Show the Homebridge logs here.
+Secondary Homebridge Logs here
 ```
 
 **Homebridge Config:**

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -18,13 +18,16 @@ assignees: ''
 **Describe Your Problem:**
 <!-- A clear and concise description of what problem you are trying to solve. -->
 
-**Logs:**
-<!-- Paste relevant output between the two ``` lines below -->
+[**Logs:**]()
+<!-- Please paste any relevant log output into a gist or using hastebin-->
+<!-- If using hastebin or other text sharing website please make the lifespan long-->
+<!-- Paste the link between the two () above -->
 <!-- Remove any sensitive information, passwords, etc. -->
 <!-- Please include the beginning of the log where the homebridge initialization happens -->
+<!-- If needing to link multiple log files please do so between the ``` lines below -->
 
 ```
-Show the Homebridge logs here.
+Secondary Homebridge Logs here
 ```
 
 **Homebridge Config:**


### PR DESCRIPTION
Some people have pretty beefy Homebridge logs which can be a big wall of text. Now directs user to create a gist or use a text sharing website such as hastebin to make issues more legible reading inline. Not 100% comfortable with Github templates so I would appreciate a quick look over making sure I got the formatting down correctly.