### PR TITLE
Move to debug level for platform registration with do not match with the expected plugin name

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -154,7 +154,7 @@ export class PluginManager {
     }
 
     if (pluginIdentifier && pluginIdentifier !== this.currentInitializingPlugin.getPluginIdentifier()) {
-      log.info(`Plugin '${this.currentInitializingPlugin.getPluginIdentifier()}' tried to register with an incorrect plugin identifier: '${pluginIdentifier}'`);
+      log.info(`Plugin '${this.currentInitializingPlugin.getPluginIdentifier()}' tried to register with an incorrect plugin identifier: '${pluginIdentifier}'. Please report this to the developer!`);
       this.pluginIdentifierTranslation.set(pluginIdentifier, this.currentInitializingPlugin.getPluginIdentifier());
     }
 
@@ -174,7 +174,7 @@ export class PluginManager {
     }
 
     if (pluginIdentifier && pluginIdentifier !== this.currentInitializingPlugin.getPluginIdentifier()) {
-      log.info(`Plugin '${this.currentInitializingPlugin.getPluginIdentifier()}' tried to register with an incorrect plugin identifier: '${pluginIdentifier}'`);
+      log.debug(`Plugin '${this.currentInitializingPlugin.getPluginIdentifier()}' tried to register with an incorrect plugin identifier: '${pluginIdentifier}'. Please report this to the developer!`);
       this.pluginIdentifierTranslation.set(pluginIdentifier, this.currentInitializingPlugin.getPluginIdentifier());
     }
 


### PR DESCRIPTION
Move to debug level. I decided to still have a `info` level for accessory plugins, as changing the registration plugin name has no impact. That is only problematic for **Dynamic** platform plugins. As matching cached accessories would fail.