### PR TITLE
Do not prevent Homebridge loading plugins based on Homebridge engines req.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "0.4.53",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true",
     "lint": "eslint 'src/**/*.{js,ts,json}'",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -141,8 +141,10 @@ export class Plugin {
 
     // make sure the version is satisfied by the currently running version of HomeBridge
     if (!satisfies(getVersion(), versionRequired, { includePrerelease: true })) {
-      throw new Error(`Plugin ${this.pluginPath} requires a HomeBridge version of ${versionRequired} which does \
-not satisfy the current HomeBridge version of ${getVersion()}. You may need to upgrade your installation of HomeBridge.`);
+      // TODO - change this back to an error
+      log.error(`The plugin "${this.pluginName}" requires a Homebridge version of ${versionRequired} which does \
+not satisfy the current Homebridge version of ${getVersion()}. You may need to update this plugin (or Homebridge) to a newer version. \
+You may face unexpected issues or stablity problems running this plugin.`);
     }
 
     // make sure the version is satisfied by the currently running version of Node


### PR DESCRIPTION
This is a temporary solution to the issue many people are facing and unfortuately wasn't caught in the beta due to our version numbers. While this might not be an ideal solution long-term it will reduce the amount of immediate issues our users face and allow us to focus on other issues.

Users will still get a RED error message:

![image](https://user-images.githubusercontent.com/3979615/80372186-783f1380-88d6-11ea-8375-309ceebb9ad8.png)

