### PR TITLE
Improve cached accessory resolution 

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -126,8 +126,10 @@ export class Plugin {
     platforms.unshift(platformPlugin);
   }
 
-  public getActiveDynamicPlatforms(platformName: PlatformName): DynamicPlatformPlugin[] | undefined {
-    return this.activeDynamicPlatforms.get(platformName);
+  public getActiveDynamicPlatform(platformName: PlatformName): DynamicPlatformPlugin | undefined {
+    const platforms = this.activeDynamicPlatforms.get(platformName);
+    // we always use the last registered
+    return platforms && platforms[0];
   }
 
   public load(): void {

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -258,6 +258,20 @@ export class PluginManager {
     return undefined;
   }
 
+  public getPluginByActiveDynamicPlatform(platformName: PlatformName): Plugin | undefined {
+    const found = (this.platformToPluginMap.get(platformName) || [])
+      .filter(plugin => !!plugin.getActiveDynamicPlatform(platformName));
+
+    if (found.length === 0) {
+      return undefined;
+    } else if (found.length > 1) {
+      const plugins = found.map(plugin => plugin.getPluginIdentifier()).join(", ");
+      throw new Error(`'${platformName}' is an ambiguous platform name. It was registered by multiple plugins: ${plugins}`);
+    } else {
+      return found[0];
+    }
+  }
+
   private loadInstalledPlugins(): void{ // Gets all plugins installed on the local system
     this.searchPaths.forEach(searchPath => { // search for plugins among all known paths
       if (!fs.existsSync(searchPath)) { // just because this path is in require.main.paths doesn't mean it necessarily exists!


### PR DESCRIPTION
This PR tries to improve the plugin resolution of cached accessories by trying to find a plugin just by the associated platform name.

This change was done in order to mitigate issues arising when dynamic platform plugins decided to change the plugin identifier. When the associated plugin for a given cached accessory is not found, homebridge will retry by searching for plugins which have registered the associated platform name. If the result is unique the ownership of the accessory is transferred.

This basically mimics the way how platform configurations are resolved (with the addition of updating the associatedPlugin property)