### PR TITLE
Making removing orphaned cached accessories the default behavior.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ not satisfy the current Node version of ${process.version}. You may need to upgr
 export = function cli(): void {
   let insecureAccess = false;
   let hideQRCode = false;
-  let cleanCachedAccessories = false;
+  let keepOrphans = false;
   let customPluginPath: string | undefined = undefined;
 
   let shuttingDown = false;
@@ -30,7 +30,11 @@ export = function cli(): void {
     .option("-I, --insecure", "allow unauthenticated requests (for easier hacking)", () => insecureAccess = true)
     .option("-P, --plugin-path [path]", "look for plugins installed at [path] as well as the default locations ([path] can also point to a single plugin)", path => customPluginPath = path)
     .option("-Q, --no-qrcode", "do not issue QRcode in logging", () => hideQRCode = true)
-    .option("-R, --remove-orphans", "remove cached accessories for which plugin is not loaded", () => cleanCachedAccessories = true)
+    .option("-R, --remove-orphans", "remove cached accessories for which plugin is not loaded (deprecated)", () => {
+      console.warn("The cli option '-R' or '--remove-orphans' is deprecated and has no effect anymore. " +
+        "Removing orphans is now the default behavior and can be turned off by supplying '-K' or '--keep-orphans'.");
+    })
+    .option("-K, --keep-orphans", "keep cached accessories for which the associated plugin is not loaded", () => keepOrphans = true)
     .option("-T, --no-timestamp", "do not issue timestamps in logging", () => Logger.setTimestampEnabled(false))
     .option("-U, --user-storage-path [path]", "look for homebridge user files at [path] instead of the default location (~/.homebridge)", path => User.setStoragePath(path))
     .parse(process.argv);
@@ -39,7 +43,7 @@ export = function cli(): void {
   HAPStorage.setCustomStoragePath(User.persistPath());
 
   const options: HomebridgeOptions = {
-    cleanCachedAccessories: cleanCachedAccessories,
+    keepOrphanedCachedAccessories: keepOrphans,
     insecureAccess: insecureAccess,
     hideQRCode: hideQRCode,
     customPluginPath: customPluginPath,

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ const log = Logger.internal;
 export interface HomebridgeOptions {
 
   config?: HomebridgeConfig;
-  cleanCachedAccessories?: boolean;
+  keepOrphanedCachedAccessories?: boolean;
   hideQRCode?: boolean;
   insecureAccess?: boolean;
   customPluginPath?: string;
@@ -101,7 +101,7 @@ export class Server {
   private readonly bridge: Bridge;
 
   private readonly config: HomebridgeConfig;
-  private readonly cleanCachedAccessories: boolean;
+  private readonly keepOrphanedCachedAccessories: boolean;
   private readonly hideQRCode: boolean;
   private readonly allowInsecureAccess: boolean;
 
@@ -116,7 +116,7 @@ export class Server {
     accessoryStorage.initSync({ dir: User.cachedAccessoryPath() }); // Setup Accessory Cache Storage
 
     this.config = options.config || Server._loadConfig();
-    this.cleanCachedAccessories = options.cleanCachedAccessories || false;
+    this.keepOrphanedCachedAccessories = options.keepOrphanedCachedAccessories || false;
     this.hideQRCode = options.hideQRCode || false;
     // Server is "secure by default", meaning it creates a top-level Bridge accessory that
     // will not allow unauthenticated requests. This matches the behavior of actual HomeKit
@@ -271,7 +271,7 @@ export class Server {
 
       if (!platformPlugins) {
         log.info(`Failed to find plugin to handle accessory ${accessory._associatedHAPAccessory.displayName}`);
-        if (this.cleanCachedAccessories) {
+        if (!this.keepOrphanedCachedAccessories) {
           log.info(`Removing orphaned accessory ${accessory._associatedHAPAccessory.displayName}`);
           return false; // filter it from the list
         }


### PR DESCRIPTION
This PR makes removing orphaned cached accessories the default behavior.
Usually homebridge crashes anyways (with colliding accessory uuids) when orphaned accessories where kept.

The `-R` flag was deprecated. A new `-K`/`--keep-orphans` flag was introduce to turn above described behavior off.

If it decides that https://github.com/homebridge/homebridge/pull/2527 is going to be accepted, it would be advised to merge https://github.com/homebridge/homebridge/pull/2527 first.