### PR TITLE
Preparing release of 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.6.tgz",
-      "integrity": "sha512-O3iqjaymOByckYA7IISko+M6wn0e8nvKiNuVOzp5LKQ0RMtlXwMAko4nygZjyCHoAhZHjhs7Myqd5M40gJQHuA==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.7.tgz",
+      "integrity": "sha512-RQhKnOIchphZBqEkmEWNDsKvsa7SC0VzsPv41IElMpVrqwowMVLWnLCsCBrSKPR9GknxX7681DZgJa61e22HcQ==",
       "requires": {
         "bonjour-hap": "3.5.7",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.7.tgz",
-      "integrity": "sha512-RQhKnOIchphZBqEkmEWNDsKvsa7SC0VzsPv41IElMpVrqwowMVLWnLCsCBrSKPR9GknxX7681DZgJa61e22HcQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.8.tgz",
+      "integrity": "sha512-bxySLydx5h2Jc6T+/LTaMpMU5hvyMe6/S/R/MPNAzmXVIMeI2IkmaNyJsZXCgy+0WtlZBgcQc1YrETpNuIijSg==",
       "requires": {
         "bonjour-hap": "3.5.7",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.8.tgz",
-      "integrity": "sha512-bxySLydx5h2Jc6T+/LTaMpMU5hvyMe6/S/R/MPNAzmXVIMeI2IkmaNyJsZXCgy+0WtlZBgcQc1YrETpNuIijSg==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.9.tgz",
+      "integrity": "sha512-sMkSQnM4JKVLHTK2BJiQ9wbSp+iK3aj/iHAtY/CIPLnrmMgR6b1qIrSXMoITR8z49rxdsLyhU9nreWV040A3jg==",
       "requires": {
         "bonjour-hap": "3.5.7",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,12 +1216,13 @@
       }
     },
     "bonjour-hap": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.6.tgz",
-      "integrity": "sha512-CvplTZdbkghTzl29SCqw2bAlkJZAgGQ1cz7/WeorMNmTZkeSf1HOL+deL48Vx6O+50VMCgFldVBEM3fZZT3Sjw==",
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.7.tgz",
+      "integrity": "sha512-pWRH68oWPelu9Exo5DtbBe1mHOH9v9I9Az+MlXbwrNqX/b5sddxKNGCv9eL56VofHAV1N2R2pKhyAo7VwUITqA==",
       "requires": {
         "array-flatten": "^2.1.2",
         "deep-equal": "^2.0.2",
+        "ip": "^1.1.5",
         "multicast-dns": "^7.2.2",
         "multicast-dns-service-types": "^1.1.0"
       }
@@ -2501,11 +2502,11 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.5.tgz",
-      "integrity": "sha512-+/9YbOK39W5z+9Z/UOnbdRyo0+AuEq2rvsehrvMdLYcn5jZulGOqXJBdIc2RkbUrsWTDH2OcgNdC7V+vmCMohw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.6.tgz",
+      "integrity": "sha512-O3iqjaymOByckYA7IISko+M6wn0e8nvKiNuVOzp5LKQ0RMtlXwMAko4nygZjyCHoAhZHjhs7Myqd5M40gJQHuA==",
       "requires": {
-        "bonjour-hap": "3.5.6",
+        "bonjour-hap": "3.5.7",
         "debug": "^4.1.1",
         "decimal.js": "^10.2.0",
         "fast-srp-hap": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,11 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -1063,6 +1068,14 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1203,15 +1216,13 @@
       }
     },
     "bonjour-hap": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.4.tgz",
-      "integrity": "sha512-MgU27SEZYQ09Skm71Xa7SZoAg259V4IlAJNWaloFVMlYDn1OjJy3nkwSixRHnDzrcLWocVI84f9exI1ObZChBw==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.6.tgz",
+      "integrity": "sha512-CvplTZdbkghTzl29SCqw2bAlkJZAgGQ1cz7/WeorMNmTZkeSf1HOL+deL48Vx6O+50VMCgFldVBEM3fZZT3Sjw==",
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^7.2.0",
+        "array-flatten": "^2.1.2",
+        "deep-equal": "^2.0.2",
+        "multicast-dns": "^7.2.2",
         "multicast-dns-service-types": "^1.1.0"
       }
     },
@@ -1279,11 +1290,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "buffer-indexof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1589,16 +1595,31 @@
       "dev": true
     },
     "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+      "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
       "requires": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
         "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.2",
         "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
+        "object.assign": "^4.1.0",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "deep-is": {
@@ -1686,11 +1707,6 @@
       "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
       "dev": true
     },
-    "dns-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
-    },
     "dns-packet": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
@@ -1698,14 +1714,6 @@
       "requires": {
         "ip": "^1.1.5",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "dns-txt": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "requires": {
-        "buffer-indexof": "^1.0.0"
       }
     },
     "doctrine": {
@@ -1767,6 +1775,27 @@
         "object.assign": "^4.1.0",
         "string.prototype.trimleft": "^2.1.1",
         "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "es-to-primitive": {
@@ -2338,6 +2367,11 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2467,11 +2501,11 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.4.tgz",
-      "integrity": "sha512-pUv1J5mnRPhc84XDlieaH5/F12zGLWW5dagSmhVKCq3GQggtLhtmPCUY5rFRE1Y308OGKNPkb/WQKv9ENhYung==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.5.tgz",
+      "integrity": "sha512-+/9YbOK39W5z+9Z/UOnbdRyo0+AuEq2rvsehrvMdLYcn5jZulGOqXJBdIc2RkbUrsWTDH2OcgNdC7V+vmCMohw==",
       "requires": {
-        "bonjour-hap": "3.5.4",
+        "bonjour-hap": "3.5.6",
         "debug": "^4.1.1",
         "decimal.js": "^10.2.0",
         "fast-srp-hap": "2.0.1",
@@ -2735,6 +2769,16 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
+    "is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
+    },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -2832,11 +2876,21 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2861,11 +2915,21 @@
         "has": "^1.0.3"
       }
     },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -2875,11 +2939,32 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4691,6 +4776,15 @@
       "dev": true,
       "optional": true
     },
+    "side-channel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "object-inspect": "^1.7.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -5578,11 +5672,47 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "requires": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.6",
+    "hap-nodejs": "0.6.7",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.7",
+    "hap-nodejs": "0.6.8",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.4",
+    "hap-nodejs": "0.6.5",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.5",
+    "hap-nodejs": "0.6.6",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.8",
+    "hap-nodejs": "0.6.9",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true",
     "lint": "eslint 'src/**/*.{js,ts,json}'",

--- a/src/server.ts
+++ b/src/server.ts
@@ -456,21 +456,22 @@ export class Server {
         });
       }
 
-      accessory.getService(Service.AccessoryInformation)!
-        .setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
-
+      const informationService = accessory.getService(Service.AccessoryInformation)!;
       services.forEach(service => {
         // if you returned an AccessoryInformation service, merge its values with ours
         if (service instanceof Service.AccessoryInformation) {
-          const existingService = accessory.getService(Service.AccessoryInformation)!;
-
           service.setCharacteristic(Characteristic.Name, displayName); // ensure display name is set
           // pull out any values you may have defined
-          existingService.replaceCharacteristicsFromService(service);
+          informationService.replaceCharacteristicsFromService(service);
         } else {
           accessory.addService(service);
         }
       });
+
+      if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
+        // overwrite the default value with the actual plugin version
+        informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
+      }
 
       return accessory;
     }
@@ -483,7 +484,8 @@ export class Server {
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!);
       if (plugin) {
         const informationService = accessory.getService(Service.AccessoryInformation)!;
-        if (!informationService.testCharacteristic(Characteristic.FirmwareRevision)) {
+        if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
+          // overwrite the default value with the actual plugin version
           informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
         }
 
@@ -553,7 +555,8 @@ export class Server {
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!);
       if (plugin) {
         const informationService = hapAccessory.getService(Service.AccessoryInformation)!;
-        if (!informationService.testCharacteristic(Characteristic.FirmwareRevision)) {
+        if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
+          // overwrite the default value with the actual plugin version
           informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
         }
       } else if (PluginManager.isQualifiedPluginIdentifier(accessory._associatedPlugin!)) { // we did already complain in api.ts if it wasn't a qualified name


### PR DESCRIPTION
The version contains the following changes.

* Added check that we don't publish an empty accessory
* Bumped hap-nodejs to v0.6.8
  * Bonjour address resolution was improved
  * Introduce a fix for #2518 and #2520: Added a fix where in some circumstances (when a plugin supplied empty values for mandatory AccessoryInformation service characteristics) the instance would become unresponsive.