### PR TITLE
Do not call updateReachability anymore

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -121,7 +121,6 @@ export class PlatformAccessory extends EventEmitter {
    */
   public updateReachability(reachable: boolean): void {
     this.reachable = reachable;
-    this._associatedHAPAccessory.updateReachability(reachable);
   }
 
   /**


### PR DESCRIPTION
This is a mitigation for the following issue described here https://github.com/devbobo/homebridge-arlo/issues/40#issuecomment-620928214.

This was caused by the change, that with 1.0.0 the underlying HAP Accessory is now created immediately.
Before, a call to updateReachability would be cached and only when the HAP Accessory would be created and added to the bridge, the underlying accessory.updateReachability would have been called.

As reachability literally does nothing anymore we can just ignore the call and no pass the argument.