### PR TITLE
Release of 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.9.tgz",
-      "integrity": "sha512-sMkSQnM4JKVLHTK2BJiQ9wbSp+iK3aj/iHAtY/CIPLnrmMgR6b1qIrSXMoITR8z49rxdsLyhU9nreWV040A3jg==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.10.tgz",
+      "integrity": "sha512-rjpGhHWa4x15ClzQrfuchOqL+8e7qAX6ExB5w4L2gLc4sAN0U8o7ziJhzieeUUM9r+7SCdCAK70PDnc3BdvusA==",
       "requires": {
         "bonjour-hap": "3.5.7",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,9 +1216,9 @@
       }
     },
     "bonjour-hap": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.7.tgz",
-      "integrity": "sha512-pWRH68oWPelu9Exo5DtbBe1mHOH9v9I9Az+MlXbwrNqX/b5sddxKNGCv9eL56VofHAV1N2R2pKhyAo7VwUITqA==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.8.tgz",
+      "integrity": "sha512-bH3XOPr3zQKuDV/LYytY6b4tRD3t0kGHwcV+f8iV7BYLBadZx4V+rYm9+HNBibXdVGxHkYJn8eSWldz0bz43fQ==",
       "requires": {
         "array-flatten": "^2.1.2",
         "deep-equal": "^2.0.2",
@@ -2502,11 +2502,11 @@
       "optional": true
     },
     "hap-nodejs": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.10.tgz",
-      "integrity": "sha512-rjpGhHWa4x15ClzQrfuchOqL+8e7qAX6ExB5w4L2gLc4sAN0U8o7ziJhzieeUUM9r+7SCdCAK70PDnc3BdvusA==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.6.11.tgz",
+      "integrity": "sha512-mYy+m/ghmnEGwr+g7UeanEu+vYdTWddCM3paycbljBwcmYGpu13cqyx0dGZ36tWtWt8WZeCEl9FoE10MlYO0oQ==",
       "requires": {
-        "bonjour-hap": "3.5.7",
+        "bonjour-hap": "~3.5.8",
         "debug": "^4.1.1",
         "decimal.js": "^10.2.0",
         "fast-srp-hap": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.9",
+    "hap-nodejs": "0.6.10",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true",
     "lint": "eslint 'src/**/*.{js,ts,json}'",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "commander": "5.0.0",
-    "hap-nodejs": "0.6.10",
+    "hap-nodejs": "0.6.11",
     "node-persist": "^0.0.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.1.3",

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -121,7 +121,6 @@ export class PlatformAccessory extends EventEmitter {
    */
   public updateReachability(reachable: boolean): void {
     this.reachable = reachable;
-    this._associatedHAPAccessory.updateReachability(reachable);
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import * as mac from "./util/mac";
 import { MacAddress } from "./util/mac";
 import { PluginManager, PluginManagerOptions } from "./pluginManager";
 import { Plugin } from "./plugin";
+import { CharacteristicEventTypes } from "hap-nodejs";
 
 const accessoryStorage: LocalStorage = storage.create();
 const log = Logger.internal;
@@ -473,7 +474,11 @@ export class Server {
         // if you returned an AccessoryInformation service, merge its values with ours
         if (service instanceof Service.AccessoryInformation) {
           service.setCharacteristic(Characteristic.Name, displayName); // ensure display name is set
-          // pull out any values you may have defined
+          // ensure the plugin has not hooked already some listeners (some weird ones do).
+          // Otherwise they would override our identify listener registered by the HAP-NodeJS accessory
+          service.getCharacteristic(Characteristic.Identify).removeAllListeners(CharacteristicEventTypes.SET);
+
+          // pull out any values and listeners (get and set) you may have defined
           informationService.replaceCharacteristicsFromService(service);
         } else {
           accessory.addService(service);


### PR DESCRIPTION
* Fixed a crash that could occur if a plugin called `updateReachability` before the accessory was added to the bridge (https://github.com/devbobo/homebridge-arlo/issues/40#issuecomment-620928214)
* Fixed a crash that could occur while pairing when running plugins (like homebridge-nest) which register a AccessoryInformation service that already has added a Identify listener of HAP-NodeJS (https://github.com/homebridge/homebridge/issues/2548)
* Fixed mdns advertising to include all (and only) reachable public addresses for the given machine
