### PR TITLE
Adding plugin version to the log output when a plugin was loaded

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -127,7 +127,7 @@ export class PluginManager {
         return;
       }
 
-      log.info(`Loaded plugin: ${identifier}`);
+      log.info(`Loaded plugin: ${identifier}@${plugin.version}`);
 
       try {
         this.currentInitializingPlugin = plugin;


### PR DESCRIPTION
Prints now something like the following on startup
```
Loaded plugin: homebridge-example@2.1.4
```