### PR TITLE
Incorporate a warning when a plugin brings its own copy of homebridge or hap-nodejs

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -26,6 +26,7 @@ export interface PackageJSON { // incomplete type for package.json (just stuff w
   main?: string;
 
   engines?: Record<string, string>;
+  dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 }


### PR DESCRIPTION
This PR raises awareness of badly written plugins at plugin load time.
Tested and works as expected.