### PR TITLE
Adding support for plugins to expose their own (external) bridge accessories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Notable Changes
 
+* Bumped the api version to `2.6` with the following changes:
+    * Added the class `PlatformBridge` (which can be accessed via `api.platformBridge`) to add support to 
+        expose external bridge accessories. This allows plugin makers to better replicate device like the hue bridge,
+        which now can be exposed as their own HomeKit bridge accessory, needing separate pairing. 
 * Updated [HAP-Nodejs](https://github.com/homebridge/HAP-NodeJS) to v0.7.3.
     * Moved to the built in Node.js crypto library for *chacha20-poly1305* encryption and decryption. This gives a 10x performance boost when doing crypto.
     * All debuggers are now prefixed with the library name, `HAP-NodeJS:`.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from "events";
 import * as hapNodeJs from "hap-nodejs";
+import { Service } from "hap-nodejs";
 import getVersion from "./version";
-import { PlatformAccessory } from "./platformAccessory"; 
+import { PlatformAccessory, PlatformBridge } from "./platformAccessory";
 import { User } from "./user";
 import { Logger, Logging } from "./logger";
-import { Service } from "hap-nodejs";
 import { AccessoryConfig, PlatformConfig } from "./server";
 import { PluginManager } from "./pluginManager";
 
@@ -160,6 +160,7 @@ export interface API {
   readonly hap: HAP;
   readonly hapLegacyTypes: HAPLegacyTypes; // used for older accessories/platforms
   readonly platformAccessory: typeof PlatformAccessory;
+  readonly platformBridge: typeof PlatformBridge;
   // ------------------------------------------------------------------------
 
   registerAccessory(accessoryName: AccessoryName, constructor: AccessoryPluginConstructor): void;
@@ -210,7 +211,7 @@ export declare interface HomebridgeAPI {
 
 export class HomebridgeAPI extends EventEmitter implements API {
 
-  public readonly version = 2.5; // homebridge API version
+  public readonly version = 2.6; // homebridge API version
   public readonly serverVersion = getVersion(); // homebridge node module version
 
   // ------------------ LEGACY EXPORTS FOR PRE TYPESCRIPT  ------------------
@@ -218,6 +219,7 @@ export class HomebridgeAPI extends EventEmitter implements API {
   readonly hap = hapNodeJs;
   readonly hapLegacyTypes = hapNodeJs.LegacyTypes; // used for older accessories/platforms
   readonly platformAccessory = PlatformAccessory;
+  readonly platformBridge = PlatformBridge;
   // ------------------------------------------------------------------------
 
   constructor() {
@@ -292,6 +294,10 @@ export class HomebridgeAPI extends EventEmitter implements API {
       // noinspection SuspiciousTypeOfGuard
       if (!(accessory instanceof PlatformAccessory)) {
         throw new Error(`${pluginIdentifier} - ${platformName} attempt to register an accessory that isn't PlatformAccessory!`);
+      }
+
+      if (accessory instanceof PlatformBridge) {
+        throw new Error(`${pluginIdentifier} - ${platformName} attempt to register a bridge accessory to be added to the main bridge!`);
       }
 
       accessory._associatedPlugin = pluginIdentifier;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export {
  */
 export type {
   PlatformAccessory,
+  PlatformBridge,
 } from "./platformAccessory";
 
 /**

--- a/src/platformAccessory.spec.ts
+++ b/src/platformAccessory.spec.ts
@@ -1,9 +1,21 @@
 import { Service, Categories, Accessory, RemoteController, uuid } from "hap-nodejs";
-import { PlatformAccessory, SerializedPlatformAccessory } from "./platformAccessory";
+import { PlatformAccessory, PlatformBridge, SerializedPlatformAccessory } from "./platformAccessory";
 
 function createAccessory(name = "TestAccessory", category?: Categories): PlatformAccessory {
   const accessoryUUID = uuid.generate("test.uuid." + name);
   const accessory = new PlatformAccessory(name, accessoryUUID, category);
+  accessory._associatedPlatform = "TestPlatform";
+  accessory._associatedPlugin = "TestPlugin";
+  accessory.context = {
+    "test": "context",
+    "doing": 234,
+  };
+  return accessory;
+}
+
+function createBridge(name = "TestBridge"): PlatformBridge {
+  const accessoryUUID = uuid.generate("test.uuid." + name);
+  const accessory = new PlatformBridge(name, accessoryUUID);
   accessory._associatedPlatform = "TestPlatform";
   accessory._associatedPlugin = "TestPlugin";
   accessory.context = {
@@ -141,4 +153,22 @@ describe(PlatformAccessory, () => {
     });
   });
 
+});
+
+describe(PlatformBridge, () => {
+
+
+  describe(PlatformBridge.serialize, () => {
+    it("should be unsupported", function() {
+      expect(() => PlatformBridge.serialize(createBridge())).toThrow(Error);
+    });
+  });
+
+  describe(PlatformBridge.deserialize, () => {
+    it("should be unsupported", function() {
+      const sampleJson = PlatformAccessory.serialize(createAccessory());
+      expect(() => PlatformBridge.deserialize(sampleJson)).toThrow(Error);
+    });
+  });
+  
 });


### PR DESCRIPTION
* Raises api version to `2.6`
* Added `platformBridge` field to the api class
* Added `PlatformBridge` class (inheriting from `PlatformAccessory`)

A `PlatformBridge` can only be published via `publishExternalAccessories` (and you would only call that for the main bridge accessory).

A `PlatformBridge` has the method `addBridgedAccessory` which can be used to add `PlatformAccessory` instances to the bridge (before and after being published).