### PR TITLE
Adding support for Controllers to be used by AccessoryPlugins and StaticPlatformPlugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Notable Changes
 
+* Bumped API version to `2.6` with the following changes:
+    * AccessoryPlugins and Accessory objects returned by StaticPlatformPlugins can now define the optional 
+        `getControllers` method to configure controllers like the RemoteController or CameraController
 * Updated [HAP-Nodejs](https://github.com/homebridge/HAP-NodeJS) to v0.7.3.
     * Moved to the built in Node.js crypto library for *chacha20-poly1305* encryption and decryption. This gives a 10x performance boost when doing crypto.
     * All debuggers are now prefixed with the library name, `HAP-NodeJS:`.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from "events";
 import * as hapNodeJs from "hap-nodejs";
 import getVersion from "./version";
-import { PlatformAccessory } from "./platformAccessory"; 
+import { PlatformAccessory } from "./platformAccessory";
 import { User } from "./user";
 import { Logger, Logging } from "./logger";
-import { Service } from "hap-nodejs";
+import { Controller, Service } from "hap-nodejs";
 import { AccessoryConfig, PlatformConfig } from "./server";
 import { PluginManager } from "./pluginManager";
 
@@ -56,12 +56,27 @@ export interface AccessoryPlugin {
   identify?(): void;
 
   /**
-   * This method will be called once on startup to query all services to be exposed by the Accessory.
+   * This method will be called once on startup, to query all services to be exposed by the Accessory.
    * All event handlers for characteristics should be set up before the array is returned.
    *
    * @returns {Service[]} services - returned services will be added to the Accessory
    */
   getServices(): Service[];
+
+  /**
+   * This method will be called once on startup, to query all controllers to be exposed by the Accessory.
+   * It is optional to implement.
+   *
+   * This includes controllers like the RemoteController or the CameraController.
+   * Any necessary controller specific setup should have been done when returning the array.
+   * In most cases the plugin will only return a array of the size 1.
+   *
+   * In the case that the Plugin does not add any additional services (returned by {@link getServices}) the
+   * method {@link getServices} must defined in any way and should just return an empty array.
+   *
+   * @returns {Controller[]} controllers - returned controllers will be configured for the Accessory
+   */
+  getControllers?(): Controller[];
 
 }
 
@@ -210,7 +225,7 @@ export declare interface HomebridgeAPI {
 
 export class HomebridgeAPI extends EventEmitter implements API {
 
-  public readonly version = 2.5; // homebridge API version
+  public readonly version = 2.6; // homebridge API version
   public readonly serverVersion = getVersion(); // homebridge node module version
 
   // ------------------ LEGACY EXPORTS FOR PRE TYPESCRIPT  ------------------

--- a/src/server.ts
+++ b/src/server.ts
@@ -438,9 +438,12 @@ export class Server {
   }
 
   private createHAPAccessory(plugin: Plugin, accessoryInstance: AccessoryPlugin, displayName: string, accessoryType: AccessoryName | AccessoryIdentifier, uuidBase?: string): Accessory | undefined {
-    const services = (accessoryInstance.getServices() || []).filter(service => !!service);
+    const services = (accessoryInstance.getServices() || [])
+      .filter(service => !!service); // filter out undefined values; a common mistake
+    const controllers = (accessoryInstance.getControllers && accessoryInstance.getControllers() || [])
+      .filter(controller => !!controller);
 
-    if (services.length === 0) { // check that we only add valid services
+    if (services.length === 0 && controllers.length === 0) { // check that we only add valid accessory with at least one service
       return undefined;
     }
 
@@ -489,6 +492,10 @@ export class Server {
         // overwrite the default value with the actual plugin version
         informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
       }
+
+      controllers.forEach(controller => {
+        accessory.configureController(controller);
+      });
 
       return accessory;
     }
@@ -627,4 +634,3 @@ export class Server {
   }
 
 }
- 


### PR DESCRIPTION
This PR adds support for AccessoryPlugins and StaticPlaformPlugins to configure HAP-NodeJS style controllers (like the RemoteController or a CameraController).

It is done by defining the optional method `getControllers` inside the accessory object. It is called when setting up the accessory and configures any controllers returned by the method.

This change raises the API version to `2.6`.