### PR TITLE
Fix @scoped plugin registration to avoid warnings

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -340,7 +340,7 @@ export class PluginManager {
     }
 
     const plugin = new Plugin(name, absolutePath, packageJson, scope);
-    this.plugins.set(name, plugin);
+    this.plugins.set(packageJson.name, plugin);
     return plugin;
   }
 

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -340,7 +340,7 @@ export class PluginManager {
     }
 
     const plugin = new Plugin(name, absolutePath, packageJson, scope);
-    this.plugins.set(packageJson.name, plugin);
+    this.plugins.set(identifier, plugin);
     return plugin;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -519,7 +519,7 @@ export class Server {
           log.warn("The plugin '%s' registered a new accessory for the platform '%s'. The platform couldn't be found though!", accessory._associatedPlugin!, accessory._associatedPlatform!);
         }
       } else {
-        log.warn("A platform configure a new accessory under the plugin name '%s'. However no loaded plugin could be found for the name!", accessory._associatedPlugin);
+        log.warn("A platform configured a new accessory under the plugin name '%s'. However no loaded plugin could be found for the name!", accessory._associatedPlugin);
       }
 
       return accessory._associatedHAPAccessory;


### PR DESCRIPTION
This fixes warnings such as:

```
A platform configure a new accessory under the plugin name '@oznu/homebridge-plugin-name'. However no loaded plugin could be found for the name!
```

and:

```
When searching for the associated plugin of the accessory 'Wifi fan' it seems like the plugin name changed from '@milo526/homebridge-tuya-web' to '@milo526/homebridge-tuya-web'. Plugin association is now being transformed!
```