### PR TITLE
Filter out broken symlinks in node_modules folder

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -15,7 +15,6 @@ import fs from "fs";
 import { Plugin } from "./plugin";
 import { Logger } from "./logger";
 import { execSync } from "child_process";
-import { dir } from "console";
 
 const log = Logger.internal;
 

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -15,6 +15,7 @@ import fs from "fs";
 import { Plugin } from "./plugin";
 import { Logger } from "./logger";
 import { execSync } from "child_process";
+import { dir } from "console";
 
 const log = Logger.internal;
 
@@ -288,7 +289,13 @@ export class PluginManager {
         }
       } else { // read through each directory in this node_modules folder
         const relativePluginPaths = fs.readdirSync(searchPath) // search for directories only
-          .filter(relativePath => fs.statSync(path.resolve(searchPath, relativePath)).isDirectory());
+          .filter(relativePath => {
+            try {
+              return fs.statSync(path.resolve(searchPath, relativePath)).isDirectory();
+            } catch (e) {
+              return false;
+            }
+          });
 
         // expand out @scoped plugins
         relativePluginPaths.slice()
@@ -301,7 +308,13 @@ export class PluginManager {
             const absolutePath = path.join(searchPath, scopeDirectory);
             fs.readdirSync(absolutePath)
               .filter(name => PluginManager.isQualifiedPluginIdentifier(name))
-              .filter(name => fs.statSync(path.resolve(absolutePath, name)).isDirectory())
+              .filter(name => {
+                try {
+                  return fs.statSync(path.resolve(absolutePath, name)).isDirectory();
+                } catch (e) {
+                  return false;
+                }
+              })
               .forEach(name => relativePluginPaths.push(scopeDirectory + "/" + name));
           });
 

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -292,6 +292,7 @@ export class PluginManager {
             try {
               return fs.statSync(path.resolve(searchPath, relativePath)).isDirectory();
             } catch (e) {
+              log.debug(`Ignoring path ${path.resolve(searchPath, relativePath)} - ${e.message}`);
               return false;
             }
           });
@@ -311,6 +312,7 @@ export class PluginManager {
                 try {
                   return fs.statSync(path.resolve(absolutePath, name)).isDirectory();
                 } catch (e) {
+                  log.debug(`Ignoring path ${path.resolve(absolutePath, name)} - ${e.message}`);
                   return false;
                 }
               })


### PR DESCRIPTION
This fixes #2678.

I did think about doing various checks to see if the item is a symlink, then making sure then symlink target exists, but it's probably faster, and will cover more edge cases, to just `try...catch` the `fs.stat` call.