### PR TITLE
Feature: Soft-disabling of plugins

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -29,6 +29,8 @@ export class Plugin {
   private readonly scope?: string; // npm package scope
   private readonly pluginPath: string; // like "/usr/local/lib/node_modules/homebridge-lockitron"
 
+  public disabled = false; // mark the plugin as disabled
+
   // ------------------ package.json content ------------------
   readonly version: string;
   private readonly main: string;
@@ -78,7 +80,9 @@ export class Plugin {
       throw new Error(`Plugin '${this.getPluginIdentifier()}' tried to register an accessory '${name}' which has already been registered!`);
     }
 
-    log.info("Registering accessory '%s'", this.getPluginIdentifier() + "." + name);
+    if (!this.disabled) {
+      log.info("Registering accessory '%s'", this.getPluginIdentifier() + "." + name);
+    }
 
     this.registeredAccessories.set(name, constructor);
   }
@@ -88,7 +92,9 @@ export class Plugin {
       throw new Error(`Plugin '${this.getPluginIdentifier()}' tried to register a platform '${name}' which has already been registered!`);
     }
 
-    log.info("Registering platform '%s'", this.getPluginIdentifier() + "." + name);
+    if (!this.disabled) {
+      log.info("Registering platform '%s'", this.getPluginIdentifier() + "." + name);
+    }
 
     this.registeredPlatforms.set(name, constructor);
   }

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -77,7 +77,7 @@ export class PluginManager {
       }
 
       this.activePlugins = options.activePlugins;
-      this.disabledPlugins = options.disabledPlugins;
+      this.disabledPlugins = Array.isArray(options.disabledPlugins) ? options.disabledPlugins : undefined;
     }
 
     this.loadDefaultPaths();
@@ -134,7 +134,7 @@ export class PluginManager {
         return;
       }
 
-      if (Array.isArray(this.disabledPlugins) && this.disabledPlugins.includes(plugin.getPluginIdentifier())) {
+      if (this.disabledPlugins && this.disabledPlugins.includes(plugin.getPluginIdentifier())) {
         plugin.disabled = true;
       }
 
@@ -206,17 +206,24 @@ export class PluginManager {
   public getPluginForAccessory(accessoryIdentifier: AccessoryIdentifier | AccessoryName): Plugin {
     let plugin: Plugin;
     if (accessoryIdentifier.indexOf(".") === -1) { // see if it matches exactly one accessory
-      const found = this.accessoryToPluginMap.get(accessoryIdentifier);
+      let found = this.accessoryToPluginMap.get(accessoryIdentifier);
 
       if (!found) {
-        throw new Error(`The requested accessory '${accessoryIdentifier}' was not registered by any plugin.`);
-      } else if (found.length > 1) {
-        const options = found.map(plugin => plugin.getPluginIdentifier() + "." + accessoryIdentifier).join(", ");
-        throw new Error(`The requested accessory '${accessoryIdentifier}' has been registered multiple times. Please be more specific by writing one of: ${options}`);
-      } else {
-        plugin = found[0];
-        accessoryIdentifier = plugin.getPluginIdentifier() + "." + accessoryIdentifier;
+        throw new Error(`No plugin was found for the accessory "${accessoryIdentifier}" in your config.json. Please make sure the corresponding plugin is installed correctly.`);
       }
+
+      if (found.length > 1) {
+        const options = found.map(plugin => plugin.getPluginIdentifier() + "." + accessoryIdentifier).join(", ");
+        // check if only one of the multiple platforms is not disabled
+        found = found.filter(plugin => !plugin.disabled);
+        if (found.length !== 1) {
+          throw new Error(`The requested accessory '${accessoryIdentifier}' has been registered multiple times. Please be more specific by writing one of: ${options}`);
+        }
+      } 
+
+      plugin = found[0];
+      accessoryIdentifier = plugin.getPluginIdentifier() + "." + accessoryIdentifier;
+
     } else {
       const pluginIdentifier = PluginManager.getPluginIdentifier(accessoryIdentifier);
       if (!this.hasPluginRegistered(pluginIdentifier)) {
@@ -232,17 +239,24 @@ export class PluginManager {
   public getPluginForPlatform(platformIdentifier: PlatformIdentifier | PlatformName): Plugin {
     let plugin: Plugin;
     if (platformIdentifier.indexOf(".") === -1) { // see if it matches exactly one platform
-      const found = this.platformToPluginMap.get(platformIdentifier);
+      let found = this.platformToPluginMap.get(platformIdentifier);
 
-      if (!found) {
-        throw new Error(`The requested platform '${platformIdentifier}' was not registered by any plugin.`);
-      } else if (found.length > 1) {
-        const options = found.map(plugin => plugin.getPluginIdentifier() + "." + platformIdentifier).join(", ");
-        throw new Error(`The requested platform '${platformIdentifier}' has been registered multiple times. Please be more specific by writing one of: ${options}`);
-      } else {
-        plugin = found[0];
-        platformIdentifier = plugin.getPluginIdentifier() + "." + platformIdentifier;
+      if(!found) {
+        throw new Error(`No plugin was found for the platform "${platformIdentifier}" in your config.json. Please make sure the corresponding plugin is installed correctly.`);
       }
+
+      if (found.length > 1) {
+        const options = found.map(plugin => plugin.getPluginIdentifier() + "." + platformIdentifier).join(", ");
+        // check if only one of the multiple platforms is not disabled
+        found = found.filter(plugin => !plugin.disabled);
+        if (found.length !== 1) {
+          throw new Error(`The requested platform '${platformIdentifier}' has been registered multiple times. Please be more specific by writing one of: ${options}`);
+        }
+      }
+
+      plugin = found[0];
+      platformIdentifier = plugin.getPluginIdentifier() + "." + platformIdentifier;
+
     } else {
       const pluginIdentifier = PluginManager.getPluginIdentifier(platformIdentifier);
       if (!this.hasPluginRegistered(pluginIdentifier)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -437,7 +437,7 @@ export class Server {
       try {
         constructor = plugin.getPlatformConstructor(platformIdentifier);
       } catch (error) {
-        log.error(`Error loading the platform "${platformIdentifier} requested in your config.json at position ${index + 1} - this is likely an issue with the "${plugin.getPluginIdentifier()}" plugin.`);
+        log.error(`Error loading the platform "${platformIdentifier}" requested in your config.json at position ${index + 1} - this is likely an issue with the "${plugin.getPluginIdentifier()}" plugin.`);
         log.error(error); // error message contains more information and full stack trace
         return;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,7 +74,7 @@ export interface HomebridgeConfig {
    * Unlike the plugins[] config which prevents plugins from being initialised at all, disabled plugins still have their alias loaded so
    * we can match config blocks of disabled plugins and show an appropriate message in the logs.
    */
-  disabledPlugins?: PluginIdentifier[]; // 
+  disabledPlugins?: PluginIdentifier[];
 
   // This section is used to control the range of ports (inclusive) that separate accessory (like camera or television) should be bind to
   ports?: ExternalPortsConfiguration;
@@ -370,7 +370,7 @@ export class Server {
       try {
         plugin = this.pluginManager.getPluginForAccessory(accessoryIdentifier);
       } catch (error) {
-        log.error(`No plugin was found for the accessory "${accessoryIdentifier}" in your config.json at position ${index + 1}. Please make sure the plugin is installed correctly.`);
+        log.error(error.message);
         return;
       }
 
@@ -424,7 +424,7 @@ export class Server {
       try {
         plugin = this.pluginManager.getPluginForPlatform(platformIdentifier);
       } catch (error) {
-        log.error(`No plugin was found for the platform "${platformIdentifier}" in your config.json at position ${index + 1}. Please make sure the plugin is installed correctly.`);
+        log.error(error.message);
         return;
       }
 


### PR DESCRIPTION
## :recycle: Current situation

Currently if a user wants to disable a plugin, they have to remove the config from their config.json. For some users this can be quite the ordeal and I have received no less than 9 feature requests on the Homebridge UI to be able to disable a plugin in a simple way.

The existing plugins[] array is not suitable as it requires the config to be removed, and would be more complicated to implement in the UI for existing systems as it lists a list of plugins that "should" be enabled,  which means new plugins would need to be added to the array before they would work (troublesome if a user installs a plugin manually where the UI can't do this for them).

## :bulb: Proposed solution

Added new config option, `disabledPlugins: string[]` which soft-disables a plugin in Homebridge. If the full plugin name is entered into this array, the plugin is still initialised so we can extract the alias (used to log that a block is disabled), but it's constructor is not called.

### Problem that is solved

This will allow the Homebridge UI to provide users with a simple way to disable a plugin with a toggle switch; this will make it easier for users to try and debug which plugin is causing issues without having to fuss with their config.

This PR also prevents Homebridge from not loading when a config block exists for a plugin that is not installed, or a plugins constructor is throwing an error.

Log messages for the different situations:

* **Plugin disabled:** [WARN] *Ignoring config for the platform "ExamplePlatform" in your config.json as the plugin "homebridge-example" has been disabled.*
* **Plugin not installed:** [ERROR] *No plugin was found for the platform "ExamplePlatform" in your config.json at position 1. Please make sure the plugin is installed correctly.*
* **Plugin constructor throwing error:** [ERROR] *Error loading the platform "ExamplePlatform" requested in your config.json at position 1 - this is likely an issue with the "homebridge-example" plugin.* + error stack trace.

### Implications

A disabled plugin will still have it's accessories removed from the cache.

### Testing

No similar tests, or tests for this part of the code were found for me to copy from 😏 

### Reviewer Nudging

@Supereg 

