### PR TITLE
Add IPC option to get status of child bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The [Homebridge Wiki](https://github.com/homebridge/homebridge/wiki) contains st
 * [Official Homebridge Raspberry Pi Image](https://github.com/homebridge/homebridge-raspbian-image/wiki/Getting-Started)
 * [Setup Homebridge on a Raspberry Pi (Raspbian)](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Raspbian)
 * [Setup Homebridge on Debian or Ubuntu Linux](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Debian-or-Ubuntu-Linux)
+* [Setup Homebridge on Red Hat, CentOS or Fedora Linux](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Red-Hat%2C-CentOS-or-Fedora-Linux)
 * [Setup Homebridge on macOS](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-macOS)
 * [Setup Homebridge on Windows 10](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Windows-10)
 * [Setup Homebridge on Docker (Linux)](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "1.3.0-beta.4",
+  "version": "1.3.0-beta.48",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.3.0-beta.4",
+  "version": "1.3.0-beta.48",
   "betaVersion": "1.3.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -156,6 +156,9 @@ export class ChildBridgeFork {
 
     this.bridgeService.publishBridge();
     this.api.signalFinished();
+
+    // tell the parent we are online
+    this.sendMessage(ChildProcessMessageEventType.ONLINE);
   }
 
   shutdown(): void {

--- a/src/ipcService.ts
+++ b/src/ipcService.ts
@@ -1,11 +1,18 @@
 import { EventEmitter } from "events";
 
-export const enum IpcApiEvent {
-  RESTART_CHILD_BRIDGE = "restartChildBridge"
+export const enum IpcIncomingEvent {
+  RESTART_CHILD_BRIDGE = "restartChildBridge",
+  CHILD_BRIDGE_METADATA_REQUEST = "childBridgeMetadataRequest",
+}
+
+export const enum IpcOutgoingEvent {
+  CHILD_BRIDGE_METADATA_RESPONSE = "childBridgeMetadataResponse",
+  CHILD_BRIDGE_STATUS_UPDATE = "childBridgeStatusUpdate",
 }
 
 export declare interface IpcService {
-  on(event: IpcApiEvent.RESTART_CHILD_BRIDGE, listener: (childBridgeUsername: string) => void): this;
+  on(event: IpcIncomingEvent.RESTART_CHILD_BRIDGE, listener: (childBridgeUsername: string) => void): this;
+  on(event: IpcIncomingEvent.CHILD_BRIDGE_METADATA_REQUEST, listener: () => void): this;
 }
 
 export class IpcService extends EventEmitter {
@@ -13,6 +20,10 @@ export class IpcService extends EventEmitter {
     super();
   }
 
+  /**
+   * Start the IPC service listeners/
+   * Currently this will only listen for messages from a parent process.
+   */
   public start(): void {
     process.on("message", (message) => {
       if (typeof message !== "object" || !message.id) {
@@ -21,4 +32,19 @@ export class IpcService extends EventEmitter {
       this.emit(message.id, message.data);
     });
   }
+
+  /**
+   * Send a message to connected IPC clients.
+   * Currently this will only send messages if Homebridge was launched as a child_process.fork()
+   * from another Node.js process (such as hb-service).
+   */
+  public sendMessage(id: IpcOutgoingEvent, data: unknown): void {
+    if (process.send) {
+      process.send({
+        id,
+        data,
+      });
+    }
+  }
+
 }


### PR DESCRIPTION
This will allow services, such as the Homebridge UI, to get a list of the running child bridges and its current status.