### PR TITLE
Child Bridges: External Ports Support

### DIFF
--- a/src/externalPortService.ts
+++ b/src/externalPortService.ts
@@ -1,0 +1,76 @@
+import type { MacAddress } from "hap-nodejs";
+import type { ChildBridgeFork } from "./childBridgeFork";
+import { Logger } from "./logger";
+
+export interface ExternalPortsConfiguration {
+  start: number;
+  end: number;
+}
+
+/**
+ * Allocates ports from the user defined config.ports option
+ * This service is used to allocate ports for external accessories on the main bridge, and child bridges.
+ */
+export class ExternalPortService {
+  private nextExternalPort?: number;
+  private allocatedPorts: Map<MacAddress, number | undefined> = new Map();
+
+  constructor(
+    private externalPorts?: ExternalPortsConfiguration,
+  ) { }
+
+  /**
+   * Returns the next available port in the external port config.
+   * If the external port is not configured by the user it will return null.
+   * If the port range has ben exhausted it will return null.
+   */
+  public async requestPort(username: MacAddress): Promise<number | undefined> {
+    // check to see if this device has already requested an external port
+    const existingPortAllocation = this.allocatedPorts.get(username);
+    if (existingPortAllocation) {
+      return existingPortAllocation;
+    }
+
+    // get the next unused port
+    const port = this.getNextFreePort();
+    this.allocatedPorts.set(username, port);
+    return port;
+  }
+
+  private getNextFreePort(): number | undefined  {
+    if (!this.externalPorts) {
+      return undefined;
+    }
+
+    if (this.nextExternalPort === undefined) {
+      this.nextExternalPort = this.externalPorts.start;
+      return this.nextExternalPort;
+    }
+
+    this.nextExternalPort++;
+    
+    if (this.nextExternalPort <= this.externalPorts.end) {
+      return this.nextExternalPort;
+    }
+
+    Logger.internal.warn("External port pool ran out of ports. Falling back to random port assignment.");
+
+    return undefined;
+  }
+}
+
+/**
+ * This is the child bridge version of the port allocation service.
+ * It requests a free port from the main bridge's port service.
+ */
+export class ChildBridgeExternalPortService extends ExternalPortService {
+  constructor(
+    private childBridge: ChildBridgeFork,
+  ) {
+    super();
+  }
+
+  public async requestPort(username: MacAddress): Promise<number | undefined> {
+    return await this.childBridge.requestExternalPort(username);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,14 @@ export type {
   BridgeConfiguration,
   AccessoryConfig,
   PlatformConfig,
-  ExternalPortsConfiguration,
 } from "./bridgeService";
+
+/**
+ * Export port types
+ */
+export type {
+  ExternalPortsConfiguration,
+} from "./externalPortService";
 
 /**
  * Export User Types

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,13 @@ import * as mac from "./util/mac";
 import { Logger } from "./logger";
 import { User } from "./user";
 import { Plugin } from "./plugin";
+import { ChildBridgeService } from "./childBridgeService";
+import { ExternalPortService } from "./externalPortService";
+import {
+  IpcIncomingEvent,
+  IpcOutgoingEvent,
+  IpcService,
+} from "./ipcService";
 import { 
   PluginManager, 
   PluginManagerOptions, 
@@ -29,8 +36,6 @@ import {
   PlatformPluginConstructor,
   PluginType,
 } from "./api";
-import { ChildBridgeService } from "./childBridgeService";
-import { IpcIncomingEvent, IpcOutgoingEvent, IpcService } from "./ipcService";
 
 const log = Logger.internal;
 
@@ -50,6 +55,7 @@ export class Server {
   private readonly pluginManager: PluginManager;
   private readonly bridgeService: BridgeService;
   private readonly ipcService: IpcService;
+  private readonly externalPortService: ExternalPortService;
 
   private readonly config: HomebridgeConfig;
   
@@ -63,8 +69,8 @@ export class Server {
 
     // object we feed to Plugins and BridgeService
     this.api = new HomebridgeAPI(); 
-
     this.ipcService = new IpcService();
+    this.externalPortService = new ExternalPortService(this.config.ports);
 
     // create new plugin manager
     const pluginManagerOptions: PluginManagerOptions = {
@@ -86,6 +92,7 @@ export class Server {
     this.bridgeService = new BridgeService(
       this.api,
       this.pluginManager,
+      this.externalPortService,
       bridgeConfig,
       this.config.bridge,
       this.config,
@@ -257,6 +264,7 @@ export class Server {
           this.options,
           this.api,
           this.ipcService,
+          this.externalPortService,
         );
 
         this.childBridges.set(accessoryConfig._bridge.username, childBridge);
@@ -343,6 +351,7 @@ export class Server {
           this.options,
           this.api,
           this.ipcService,
+          this.externalPortService,
         );
 
         this.childBridges.set(platformConfig._bridge.username, childBridge);


### PR DESCRIPTION
This PR allows child bridges to expose their own external accessories and have their port allocated in the range defined in the users  optional `ports` property of the config.json.

Note that the `handlePublishExternalAccessories` is now async rather than sync, in my testing this did not impact the overall behaviour.

#### Port request flow in child bridge:

External accessory published -> requests port -> child bridge external port service sends IPC message to parent requesting port -> parent requests port from the main external port service -> send port allocation back to child process -> resolve.

#### Port request flow in main bridge:

External accessory published -> requests port from main external port service -> resolve.

As child bridges can be restarted independently of the main bridge, the external port service will keep track of which port was assigned to which device and re-use it when requested again so the port pool does not get exhausted simply by restarting the child bridge multiple times.

Fixes  #2790.