### PR TITLE
Prevent unintentional cache resets

### DIFF
--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -117,6 +117,8 @@ export class PluginManager {
   }
 
   public initializeInstalledPlugins(): void {
+    log.info("---");
+
     this.loadInstalledPlugins();
 
     this.plugins.forEach((plugin: Plugin, identifier: PluginIdentifier) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -194,8 +194,6 @@ export class Server {
     config.platforms = config.platforms || [];
     log.info("Loaded config.json with %s accessories and %s platforms.", config.accessories.length, config.platforms.length);
 
-    log.info("---");
-
     return config as HomebridgeConfig;
   }
 


### PR DESCRIPTION
This PR addresses an issue that could cause the Homebridge accessory cache to be deleted or overwritten unintentionally in some circumstances.

### Background:

Homebridge saves its accessory cache to disk every time a new platform accessory is registered, removed or updated.

We also save the accessory cache just before shutdown, after it receives a SIGTERM or SIGINT signal (except on Windows where shutdown signals are not a thing).

There is some code that deleted the cached accessories file if it had not yet been loaded, I'm not sure why this was needed historically - but it did mean the file could be deleted if Homebridge received a SIGTERM/SIGINT signal before it had loaded the cached accessories file.

### Solution:

This PR prevents the cached accessories file from being saved to disk if we have not yet attempted to load it. It also removes the unnecessary code that could delete the file.

### Issues:

#2697
#2753
