### PR TITLE
Replace mdns.legacyAdvertiser with bridge.advertiser enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,9 +3090,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.0-beta.123",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.0-beta.123.tgz",
-      "integrity": "sha512-bZj9+5DaIIrxu5rWNvBPZqPjFC6dU/2z3Hcq/tJ7MHWzF8KNC0qOE1qWQCna2NTaGrWNOrMdqeag9RHw3LK+5Q==",
+      "version": "0.9.0-beta.126",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.0-beta.126.tgz",
+      "integrity": "sha512-RiGBB+IQ6TcKMxy8WUeyNjXofRenVeLxk/qNMuk6BtTG39vJDCteD+sHf6qgZ8M8Vjo/ZvLRGHZQgF1QiBprhA==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.3.0-beta.53",
+  "version": "1.3.0-beta.56",
   "betaVersion": "1.3.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "^0.9.0-beta.123",
+    "hap-nodejs": "^0.9.0-beta.126",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -25,6 +25,7 @@ import {
   Service,
   uuid,
   VoidCallback,
+  MDNSAdvertiser,
 } from "hap-nodejs";
 import {
   AccessoryIdentifier,
@@ -45,16 +46,11 @@ import { HomebridgeOptions } from "./server";
 
 const log = Logger.internal;
 
-export const enum HomebridgeAdvertiser {
-  BONJOUR_HAP = 'bonjour-hap',
-  CIAO = 'ciao',
-}
-
 export interface BridgeConfiguration {
   name: string;
   username: MacAddress;
   pin: string; // format like "000-00-000"
-  advertiser: HomebridgeAdvertiser;
+  advertiser: MDNSAdvertiser;
   port?: number;
   bind?: (InterfaceName | IPAddress) | (InterfaceName | IPAddress)[];
   setupID?: string[4];
@@ -195,7 +191,7 @@ export class BridgeService {
       bind: bridgeConfig.bind,
       mdns: this.config.mdns, // this is deprecated now
       addIdentifyingMaterial: true,
-      useLegacyAdvertiser: bridgeConfig.advertiser === HomebridgeAdvertiser.BONJOUR_HAP,
+      advertiser: bridgeConfig.advertiser,
     };
 
     if (bridgeConfig.setupID && bridgeConfig.setupID.length === 4) {
@@ -434,7 +430,7 @@ export class BridgeService {
         bind: this.bridgeConfig.bind,
         mdns: this.config.mdns, // this is deprecated and not used anymore
         addIdentifyingMaterial: true,
-        useLegacyAdvertiser: this.bridgeConfig.advertiser === HomebridgeAdvertiser.BONJOUR_HAP,
+        advertiser: this.bridgeConfig.advertiser,
       }, this.allowInsecureAccess);
     }
   }

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -45,10 +45,16 @@ import { HomebridgeOptions } from "./server";
 
 const log = Logger.internal;
 
+export const enum HomebridgeAdvertiser {
+  BONJOUR_HAP = 'bonjour-hap',
+  CIAO = 'ciao',
+}
+
 export interface BridgeConfiguration {
   name: string;
   username: MacAddress;
   pin: string; // format like "000-00-000"
+  advertiser: HomebridgeAdvertiser;
   port?: number;
   bind?: (InterfaceName | IPAddress) | (InterfaceName | IPAddress)[];
   setupID?: string[4];
@@ -189,7 +195,7 @@ export class BridgeService {
       bind: bridgeConfig.bind,
       mdns: this.config.mdns, // this is deprecated now
       addIdentifyingMaterial: true,
-      useLegacyAdvertiser: this.config.mdns?.legacyAdvertiser ?? true,
+      useLegacyAdvertiser: bridgeConfig.advertiser === HomebridgeAdvertiser.BONJOUR_HAP,
     };
 
     if (bridgeConfig.setupID && bridgeConfig.setupID.length === 4) {
@@ -428,7 +434,7 @@ export class BridgeService {
         bind: this.bridgeConfig.bind,
         mdns: this.config.mdns, // this is deprecated and not used anymore
         addIdentifyingMaterial: true,
-        useLegacyAdvertiser: this.config.mdns?.legacyAdvertiser ?? true,
+        useLegacyAdvertiser: this.bridgeConfig.advertiser === HomebridgeAdvertiser.BONJOUR_HAP,
       }, this.allowInsecureAccess);
     }
   }

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -287,6 +287,7 @@ export class ChildBridgeService {
       name: this.bridgeConfig.name || this.pluginConfig.name || this.plugin.getPluginIdentifier(),
       port: this.bridgeConfig.port,
       username: this.bridgeConfig.username,
+      advertiser: this.homebridgeConfig.bridge.advertiser,
       pin: this.bridgeConfig.pin || this.homebridgeConfig.bridge.pin,
       bind: this.homebridgeConfig.bridge.bind,
       setupID: this.bridgeConfig.setupID,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import chalk from "chalk";
 import qrcode from "qrcode-terminal";
 
-import { MacAddress } from "hap-nodejs";
+import { MacAddress, MDNSAdvertiser } from "hap-nodejs";
 import * as mac from "./util/mac";
 import { Logger } from "./logger";
 import { User } from "./user";
@@ -23,7 +23,6 @@ import {
   BridgeConfiguration, 
   HomebridgeConfig, 
   BridgeOptions,
-  HomebridgeAdvertiser, 
 } from "./bridgeService";
 import {
   AccessoryIdentifier,
@@ -147,7 +146,7 @@ export class Server {
       name: "Homebridge",
       username: "CC:22:3D:E3:CE:30",
       pin: "031-45-154",
-      advertiser: HomebridgeAdvertiser.BONJOUR_HAP,
+      advertiser: MDNSAdvertiser.BONJOUR,
     };
 
     if (!fs.existsSync(configPath)) {
@@ -198,19 +197,19 @@ export class Server {
 
     if (config.bridge.advertiser) {
       if (![
-        HomebridgeAdvertiser.BONJOUR_HAP,
-        HomebridgeAdvertiser.CIAO
+        MDNSAdvertiser.BONJOUR,
+        MDNSAdvertiser.CIAO,
       ].includes(config.bridge.advertiser)) {
-        config.bridge.advertiser = HomebridgeAdvertiser.BONJOUR_HAP;
-        log.error(`Value provided in bridge.advertiser is not valid, reverting to "${HomebridgeAdvertiser.BONJOUR_HAP}".`);
+        config.bridge.advertiser = MDNSAdvertiser.BONJOUR;
+        log.error(`Value provided in bridge.advertiser is not valid, reverting to "${MDNSAdvertiser.BONJOUR}".`);
       }
     } else {
-      config.bridge.advertiser = HomebridgeAdvertiser.BONJOUR_HAP;
+      config.bridge.advertiser = MDNSAdvertiser.BONJOUR;
     }
 
     // Warn existing Homebridge 1.3.0 beta users they need to swap to bridge.advertiser
-    if (config.mdns && config.mdns.legacyAdvertiser === false && config.bridge.advertiser === HomebridgeAdvertiser.BONJOUR_HAP) {
-      log.error(`The "mdns"."legacyAdvertiser" = false option has been removed. Please use "bridge"."advertiser" = "ciao" to enable the Ciao mDNS advertiser. You should remove the "mdns"."legacyAdvertiser" section from your config.json.`)
+    if (config.mdns && config.mdns.legacyAdvertiser === false && config.bridge.advertiser === MDNSAdvertiser.BONJOUR) {
+      log.error(`The "mdns"."legacyAdvertiser" = false option has been removed. Please use "bridge"."advertiser" = "${MDNSAdvertiser.CIAO}" to enable the Ciao mDNS advertiser. You should remove the "mdns"."legacyAdvertiser" section from your config.json.`);
     }
 
     return config as HomebridgeConfig;


### PR DESCRIPTION
As discussed with @Supereg.

Example:

```json
{
  "bridge": {
     "advertiser": "ciao"
  }
}
```

```json
{
  "bridge": {
     "advertiser": "bonjour-hap"
  }
}
```

Defaults to `bonjour-hap` when no value is provided, or when an invalid value is provided (displays warning in log if invalid value is provided).

Warns existing beta users that have `mdns.legacyAdvertiser` set to false this option is no longer valid.

---

If approved I'll update the UI in this weeks release cycle.