### PR TITLE
Homebridge 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## NEXT
+
+### Bug Fixes
+
+* [#2855](https://github.com/homebridge/homebridge/issues/2855) - Fixed an issue to handle the situation where Siri sends unexpected values for the characteristic format type.
+
+### Other Changes
+
+* [#2856](https://github.com/homebridge/homebridge/issues/2856) - Gracefully handle duplicate UUID errors when restoring the accessory cache.
+* Update [HAP-NodeJS](https://github.com/homebridge/HAP-NodeJS) to [v0.9.3](https://github.com/homebridge/HAP-NodeJS/releases/tag/v0.9.3).
+
 ## v1.3.2 (2021-03-04)
 
 Please make sure you have done the following before updating:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ Please make sure you have done the following before updating:
 
 ### Notable Changes
 
-* [#2845](https://github.com/homebridge/homebridge/issues/2820) - Added the ability for more than one accessory of the same type to be added to a single child bridge. [See docs for more info](https://github.com/homebridge/homebridge/wiki/Child-Bridges#multiple-accessories-on-the-same-child-bridge).
+* [#2849](https://github.com/homebridge/homebridge/issues/2849) - Added the ability for more than one accessory of the same type to be added to a single child bridge. [See docs for more info](https://github.com/homebridge/homebridge/wiki/Child-Bridges#multiple-accessories-on-the-same-child-bridge).
 
 ### Other Changes
 
-* Warnings about "slow" plugin characteristics will no longer be shown for external / unbridges accessories (typically Cameras or TVs) as these do not slow down the entire bridge.
+* Warnings about "slow" plugin characteristics will no longer be shown for external / unbridged accessories (typically Cameras or TVs) as these do not slow down the entire bridge.
 
 ## v1.3.1 (2021-02-23)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.11",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.11.tgz",
-      "integrity": "sha512-TUjBoLx53beeSiKGho7K+/mvzf0Mn4RqbzjshFlifi1hzEoxlqGvDwl1PPEUy+S5HBWhiUNW3LBrjog4/IEkRA==",
+      "version": "0.9.3-beta.12",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.12.tgz",
+      "integrity": "sha512-D9A/4WdDWiYLjtoBQqlQqUDcTOSdKo2FABLvsEmvMiiRGpigy2YzoqCV0Nd6ONxchJCuyFAdOzA100hS1JnlOw==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.12",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.12.tgz",
-      "integrity": "sha512-D9A/4WdDWiYLjtoBQqlQqUDcTOSdKo2FABLvsEmvMiiRGpigy2YzoqCV0Nd6ONxchJCuyFAdOzA100hS1JnlOw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3.tgz",
+      "integrity": "sha512-5CcoN86K2Kh9tm7gxK35uXb0ORWAANPr7UOorupOGs/Tb+3dAHgibwX3+w4MI2r2q7leZGQpKZQysUuowbiB9A==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.5",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.5.tgz",
-      "integrity": "sha512-NA7vPkLOKbdNap1Jk8rcjXGvX0bSvbYMbZp0bJcWiPQQ8ZJedpu61rzaEKLO5EncAffwGTI/KUVTPSrHduAjPw==",
+      "version": "0.9.3-beta.6",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.6.tgz",
+      "integrity": "sha512-T4YJWxmO/XWui2HvOvaw3NPR5sQgQOhS7E8D5eLjNY5Zot/skWiH+7AWEM/GxMTmbDc7dByzWVZkG0oxHLByUg==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.6",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.6.tgz",
-      "integrity": "sha512-T4YJWxmO/XWui2HvOvaw3NPR5sQgQOhS7E8D5eLjNY5Zot/skWiH+7AWEM/GxMTmbDc7dByzWVZkG0oxHLByUg==",
+      "version": "0.9.3-beta.8",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.8.tgz",
+      "integrity": "sha512-zOSh9LjbjZKGbn5LYPqIGTqcPzlLBJ/3c8RFIT16LY8rKPon8hF8Pl2IqjVFaR/G3Rakrj14MxcmkjFJVHSDFA==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.3",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.3.tgz",
-      "integrity": "sha512-xLcCZqHS0bxA7f7Zc08b8Y58OUs96QUaHrm8GLWmlmvL+yXm16/t3Oyvi9v+K1C6mvvNoEJTUrlO6GOJh9+/UA==",
+      "version": "0.9.3-beta.5",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.5.tgz",
+      "integrity": "sha512-NA7vPkLOKbdNap1Jk8rcjXGvX0bSvbYMbZp0bJcWiPQQ8ZJedpu61rzaEKLO5EncAffwGTI/KUVTPSrHduAjPw==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.1",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.1.tgz",
-      "integrity": "sha512-WmMVXHHTBdmp71Ijzi3odjfr7Dt77hS60f0MTjHNiN1R7ZHZkJfWslYSuSAURFQUs8qKxBNerCaKWZdBeuS/0A==",
+      "version": "0.9.3-beta.3",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.3.tgz",
+      "integrity": "sha512-xLcCZqHS0bxA7f7Zc08b8Y58OUs96QUaHrm8GLWmlmvL+yXm16/t3Oyvi9v+K1C6mvvNoEJTUrlO6GOJh9+/UA==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge",
-  "version": "1.3.2",
+  "version": "1.3.3-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3092,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.3-beta.8",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.8.tgz",
-      "integrity": "sha512-zOSh9LjbjZKGbn5LYPqIGTqcPzlLBJ/3c8RFIT16LY8rKPon8hF8Pl2IqjVFaR/G3Rakrj14MxcmkjFJVHSDFA==",
+      "version": "0.9.3-beta.11",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.11.tgz",
+      "integrity": "sha512-TUjBoLx53beeSiKGho7K+/mvzf0Mn4RqbzjshFlifi1hzEoxlqGvDwl1PPEUy+S5HBWhiUNW3LBrjog4/IEkRA==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,24 +2239,26 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-get-iterator": {
@@ -3090,9 +3092,9 @@
       }
     },
     "hap-nodejs": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.2.tgz",
-      "integrity": "sha512-Dm+jM8Fb0R0esDJ508NqluY/9J1azcP5vp2Y9jAGKs72X0HasyMvkMgMQoa/pqd6Psf22J3ohQYZ8rlE0RNspw==",
+      "version": "0.9.3-beta.1",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.3-beta.1.tgz",
+      "integrity": "sha512-WmMVXHHTBdmp71Ijzi3odjfr7Dt77hS60f0MTjHNiN1R7ZHZkJfWslYSuSAURFQUs8qKxBNerCaKWZdBeuS/0A==",
       "requires": {
         "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",
@@ -3137,15 +3139,20 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6130,20 +6137,20 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -6511,6 +6518,17 @@
       "integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
       "dev": true,
       "optional": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.5",
+    "hap-nodejs": "0.9.3-beta.6",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.3",
+    "hap-nodejs": "0.9.3-beta.5",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "^0.9.3-beta.12",
+    "hap-nodejs": "0.9.3",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.1",
+    "hap-nodejs": "0.9.3-beta.3",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    " Fixed an issue to handle the situation where Siri sends unexpected values for the characteristic format type.": "0.9.3",
+    "hap-nodejs": "0.9.3",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
   "version": "1.3.2",
-  "betaVersion": "1.3.2",
+  "betaVersion": "1.3.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.2",
+    "hap-nodejs": "0.9.3-beta.1",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.3.2",
+  "version": "1.3.3-beta.6",
   "betaVersion": "1.3.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.8",
+    "hap-nodejs": "0.9.3-beta.11",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.11",
+    "hap-nodejs": "^0.9.3-beta.12",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3-beta.6",
+    "hap-nodejs": "0.9.3-beta.8",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.3.3-beta.6",
+  "version": "1.3.2",
   "betaVersion": "1.3.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "chalk": "^4.1.0",
     "commander": "5.1.0",
     "fs-extra": "^9.1.0",
-    "hap-nodejs": "0.9.3",
+    " Fixed an issue to handle the situation where Siri sends unexpected values for the characteristic format type.": "0.9.3",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19"

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -169,6 +169,9 @@ export class BridgeService {
       case CharacteristicWarningType.ERROR_MESSAGE:
         log.error(getLogPrefix(plugin.getPluginIdentifier()), `This plugin threw an error from the characteristic '${warning.characteristic.displayName}':`, warning.message + ".", wikiInfo);
         break;
+      case CharacteristicWarningType.DEBUG_MESSAGE:
+        log.debug(getLogPrefix(plugin.getPluginIdentifier()), `Characteristic '${warning.characteristic.displayName}':`, warning.message + ".", wikiInfo);
+        break;
       default: // generic message for yet unknown types
         log.info(getLogPrefix(plugin.getPluginIdentifier()), `This plugin generated a warning from the characteristic '${warning.characteristic.displayName}':`, warning.message + ".", wikiInfo);
         break;

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -323,7 +323,12 @@ export class BridgeService {
         platformPlugins.configureAccessory(accessory);
       }
 
-      this.bridge.addBridgedAccessory(accessory._associatedHAPAccessory);
+      try {
+        this.bridge.addBridgedAccessory(accessory._associatedHAPAccessory);
+      } catch (e) {
+        log.warn(`${accessory._associatedPlugin ? getLogPrefix(accessory._associatedPlugin): ""} Could not restore cached accessory '${accessory._associatedHAPAccessory.displayName}':`, e?.message);
+        return false; // filter it from the list
+      }
       return true; // keep it in the list
     });
   }

--- a/src/ipcService.ts
+++ b/src/ipcService.ts
@@ -6,6 +6,7 @@ export const enum IpcIncomingEvent {
 }
 
 export const enum IpcOutgoingEvent {
+  SERVER_STATUS_UPDATE = "serverStatusUpdate",
   CHILD_BRIDGE_METADATA_RESPONSE = "childBridgeMetadataResponse",
   CHILD_BRIDGE_STATUS_UPDATE = "childBridgeStatusUpdate",
 }


### PR DESCRIPTION
* Gracefully handle duplicate UUID errors when restoring the accessory cache.
* Fixed an issue to handle the situation where Siri sends unexpected values for the characteristic format type.
* Add IPC events to get the running status of Homebridge (pending, running, going down) 
* Update [HAP-NodeJS](https://github.com/homebridge/HAP-NodeJS) to [v0.9.3](https://github.com/homebridge/HAP-NodeJS/releases/tag/v0.9.3).

Outstanding release chores will be done in master.