### PR TITLE
Add support for ESM modules and async plugin initializers.

### DIFF
--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -60,7 +60,7 @@ export class ChildBridgeFork {
     }
   }
 
-  loadPlugin(data: ChildProcessLoadEventData): void {
+  async loadPlugin(data: ChildProcessLoadEventData): Promise<void> {
     // set data
     this.type = data.type;
     this.identifier = data.identifier;
@@ -100,9 +100,9 @@ export class ChildBridgeFork {
     this.externalPortService = new ChildBridgeExternalPortService(this);
 
     // load plugin
-    this.plugin = this.pluginManager.loadPlugin(data.pluginPath);
-    this.plugin.load();
-    this.pluginManager.initializePlugin(this.plugin, data.identifier);
+    this.plugin = await this.pluginManager.loadPlugin(data.pluginPath);
+    await this.plugin.load();
+    await this.pluginManager.initializePlugin(this.plugin, data.identifier);
 
     // change process title to include plugin name
     process.title = `homebridge: ${this.plugin.getPluginIdentifier()}`;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -28,6 +28,7 @@ export class Plugin {
   private readonly pluginName: PluginName;
   private readonly scope?: string; // npm package scope
   private readonly pluginPath: string; // like "/usr/local/lib/node_modules/homebridge-lockitron"
+  private readonly isESM: boolean;
 
   public disabled = false; // mark the plugin as disabled
 
@@ -54,6 +55,7 @@ export class Plugin {
 
     this.version = packageJSON.version || "0.0.0";
     this.main = packageJSON.main || "./index.js"; // figure out the main module - index.js unless otherwise specified
+    this.isESM = packageJSON.type === "module";
 
     // very temporary fix for first wave of plugins
     if (packageJSON.peerDependencies && (!packageJSON.engines || !packageJSON.engines.homebridge)) {
@@ -146,7 +148,7 @@ export class Plugin {
     return platforms && platforms[0];
   }
 
-  public load(): void {
+  public async load(): Promise<void> {
     const context = this.loadContext!;
     assert(context, "Reached illegal state. Plugin state is undefined!");
     this.loadContext = undefined; // free up memory
@@ -184,7 +186,7 @@ major incompatibility issues and thus is considered bad practice. Please inform 
 
     // try to require() it and grab the exported initialization hook
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const pluginModules = require(mainPath);
+    const pluginModules = this.isESM ? await import(mainPath) : require(mainPath);
 
     if (typeof pluginModules === "function") {
       this.pluginInitializer = pluginModules;

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -24,6 +24,7 @@ export interface PackageJSON { // incomplete type for package.json (just stuff w
   keywords?: string[];
 
   main?: string;
+  type?: "module" | "commonjs";
 
   engines?: Record<string, string>;
   dependencies?: Record<string, string>;
@@ -116,14 +117,14 @@ export class PluginManager {
     return identifier.split(".")[0];
   }
 
-  public initializeInstalledPlugins(): void {
+  public async initializeInstalledPlugins(): Promise<void> {
     log.info("---");
 
     this.loadInstalledPlugins();
 
-    this.plugins.forEach((plugin: Plugin, identifier: PluginIdentifier) => {
+    for(const [identifier, plugin] of this.plugins) {
       try {
-        plugin.load();
+        await plugin.load();
       } catch (error) {
         log.error("====================");
         log.error(`ERROR LOADING PLUGIN ${identifier}:`);
@@ -144,18 +145,18 @@ export class PluginManager {
         log.info(`Loaded plugin: ${identifier}@${plugin.version}`);
       }
 
-      this.initializePlugin(plugin, identifier);
+      await this.initializePlugin(plugin, identifier);
 
       log.info("---");
-    });
+    }
 
     this.currentInitializingPlugin = undefined;
   }
 
-  public initializePlugin(plugin: Plugin, identifier: string): void {
+  public async initializePlugin(plugin: Plugin, identifier: string): Promise<void> {
     try {
       this.currentInitializingPlugin = plugin;
-      plugin.initialize(this.api); // call the plugin's initializer and pass it our API instance
+      await plugin.initialize(this.api); // call the plugin's initializer and pass it our API instance
     } catch (error) {
       log.error("====================");
       log.error(`ERROR INITIALIZING PLUGIN ${identifier}:`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,7 +153,7 @@ export class Server {
     await this.bridgeService.loadCachedPlatformAccessoriesFromDisk();
 
     // initialize plugins
-    this.pluginManager.initializeInstalledPlugins();
+    await this.pluginManager.initializeInstalledPlugins();
 
     if (this.config.platforms.length > 0) {
       promises.push(...this.loadPlatforms());


### PR DESCRIPTION
# Name of the PR

Add support for ESM modules and async plugin initializers.

## :recycle: Current situation

Today, if you try to load a package which `type=module` in package.json it throws an error as it tries to use `require()` on a ESM module.

## :bulb: Proposed solution

This PR introduces detection of ESM module and if detect it uses `await import()`.

### Implications

By using `await import`, by definition the entire plugin loading phase has become asynchronous. All affected code places have been refactored to be `async function` and to `await` for plugin loading and initialization.

Almost for free, HomeBridge plugins can now export a `async function` as default and this will be awaited. This means that now plugin can do async initialization.

### Reviewer Nudging

Plugin and PluginManager code.