### PR TITLE
Update HAP-NodeJS to v0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "5.1.0",
         "fs-extra": "^10.0.0",
-        "hap-nodejs": "0.9.6",
+        "hap-nodejs": "0.9.7",
         "qrcode-terminal": "^0.12.0",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.20"
@@ -730,14 +730,14 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
-      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.3.tgz",
+      "integrity": "sha512-p9WgcSYUj3rtC1g3ywJpKxvIZXPkkv88JxbuW6idMHrUOqDMJlWIsWF0yXynQf8Z28gA0j6AJN9EnAr+hg5gNA==",
       "dependencies": {
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "fast-deep-equal": "^3.1.3",
-        "source-map-support": "^0.5.19",
-        "tslib": "^2.0.3"
+        "source-map-support": "^0.5.20",
+        "tslib": "^2.3.1"
       },
       "bin": {
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
@@ -3366,11 +3366,11 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "node_modules/hap-nodejs": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.6.tgz",
-      "integrity": "sha512-5I7bXDa2eizDpPSybJB5W+py7O1NxIDVZEKukX97gDhkc8d9TkVWJw+kgC4qr8qeLjQxqG/ZTr8BLsrtYmJaKw==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.7.tgz",
+      "integrity": "sha512-DrXqNK+vrdjABKxKg0XNdgrycEHEwmSg81AMX8dmp86inex+rvx4qPd9fJRktt3Ed+u8I7ePDy26T4xGxdgc0g==",
       "dependencies": {
-        "@homebridge/ciao": "~1.1.2",
+        "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",
         "debug": "^4.3.2",
         "fast-srp-hap": "2.0.4",
@@ -7580,14 +7580,14 @@
       }
     },
     "@homebridge/ciao": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
-      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.3.tgz",
+      "integrity": "sha512-p9WgcSYUj3rtC1g3ywJpKxvIZXPkkv88JxbuW6idMHrUOqDMJlWIsWF0yXynQf8Z28gA0j6AJN9EnAr+hg5gNA==",
       "requires": {
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "fast-deep-equal": "^3.1.3",
-        "source-map-support": "^0.5.19",
-        "tslib": "^2.0.3"
+        "source-map-support": "^0.5.20",
+        "tslib": "^2.3.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -9608,11 +9608,11 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "hap-nodejs": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.6.tgz",
-      "integrity": "sha512-5I7bXDa2eizDpPSybJB5W+py7O1NxIDVZEKukX97gDhkc8d9TkVWJw+kgC4qr8qeLjQxqG/ZTr8BLsrtYmJaKw==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.7.tgz",
+      "integrity": "sha512-DrXqNK+vrdjABKxKg0XNdgrycEHEwmSg81AMX8dmp86inex+rvx4qPd9fJRktt3Ed+u8I7ePDy26T4xGxdgc0g==",
       "requires": {
-        "@homebridge/ciao": "~1.1.2",
+        "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",
         "debug": "^4.3.2",
         "fast-srp-hap": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.2",
     "commander": "5.1.0",
     "fs-extra": "^10.0.0",
-    "hap-nodejs": "0.9.6",
+    "hap-nodejs": "0.9.7",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.20"


### PR DESCRIPTION
# Update HAP-NodeJS to v0.9.7

## :recycle: Current situation
--

## :bulb: Proposed solution

--

### Problem that is solved

HAP-NodeJS is updated to the latest [v0.9.7 release](https://github.com/homebridge/HAP-NodeJS/releases/tag/v0.9.7).

### Implications

Two notable changes in the v0.9.7 release affecting home bridge:
* Moved the `Initializing HAP vX.X.X ...` to debug level
* Removed logging of mDNS advertiser

As both of these informations are crucial for homebridge support, homebridge was modified to include this information in its own log messages (see new [HAPLibraryVersion()](https://developers.homebridge.io/HAP-NodeJS/modules.html#HAPLibraryVersion).

## :heavy_plus_sign: Additional Information

### Testing
--

### Reviewer Nudging
--

<!-- Credits to @lschlesinger for creating this PR template :) -->
