### PR TITLE
Fixed a crash occurring for any encrypted communication when running NodeJs 17 on linux based machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,33 @@
 # Change Log
 
+## 1.3.9 (2021-12-29)
+
+### Bug Fixes
+
+- Fixed a crash occurring for any encrypted communication when running NodeJs 17 on linux based machines [#3046](https://github.com/homebridge/homebridge/issues/3046)
+
+
+## 1.3.8 (2021-10-22)
+
+### Featured Changes
+
+- PluginManager would abort plugin loading if one plugin encounters a loading error  [#3017](https://github.com/homebridge/homebridge/issues/3017)
+
+### Other Changes
+
+- Move to centrally managed Issue form templates and GitHub Action workflows [#3011](https://github.com/homebridge/homebridge/issues/3011)
+
+
+## 1.3.6 (2021-11-10)
+
+### Notable changes
+
+* Added support for ESM modules and async plugin initializers [#2915](https://github.com/homebridge/homebridge/issues/2915)
+* Upgraded HAP-NodeJS to [v0.9.7](https://github.com/homebridge/HAP-NodeJS/releases/tag/v0.9.7) providing bug fixes  [#3008](https://github.com/homebridge/homebridge/issues/3008)
+
 ## v1.3.5 (2021-10-08)
 
-## Notable changes
+### Notable changes
 
 This version adds new services and characteristics introduced with iOS 15.
 
@@ -11,7 +36,7 @@ This version adds new services and characteristics introduced with iOS 15.
     * The following services were newly added: `Assistant`, `SiriEndpoint`
     * The following services received new optional characteristics: `Siri` and `SmartSpeaker`
 
-## Bug Fixes
+### Bug Fixes
 
 This release upgrades various dependencies with bug fixes and security fixes.
 
@@ -20,7 +45,7 @@ Only users who use the `bonjour` mdns advertiser are impacted by this vulnerabil
 
 ## v1.3.4 (2021-03-16)
 
-## Bug Fixes
+### Bug Fixes
 
 * Fixed a characteristic warning for Cameras or Video Doorbells, which might be emitted on startup under certain conditions.  
    _This warning had no impact on the functionality of Cameras_.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "5.1.0",
         "fs-extra": "^10.0.0",
-        "hap-nodejs": "0.9.7",
+        "hap-nodejs": "0.9.8-beta.0",
         "qrcode-terminal": "^0.12.0",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.20"
@@ -3366,9 +3366,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "node_modules/hap-nodejs": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.7.tgz",
-      "integrity": "sha512-DrXqNK+vrdjABKxKg0XNdgrycEHEwmSg81AMX8dmp86inex+rvx4qPd9fJRktt3Ed+u8I7ePDy26T4xGxdgc0g==",
+      "version": "0.9.8-beta.0",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8-beta.0.tgz",
+      "integrity": "sha512-WZrzudQvgMsGF9dbqi2a3r4zYPpHAJIQvcHAlRWw5vFNAh/cUnk9dNWCqLUPp5tlQu0oNSNRDVglSFvitCBNrQ==",
       "dependencies": {
         "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",
@@ -9608,9 +9608,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "hap-nodejs": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.7.tgz",
-      "integrity": "sha512-DrXqNK+vrdjABKxKg0XNdgrycEHEwmSg81AMX8dmp86inex+rvx4qPd9fJRktt3Ed+u8I7ePDy26T4xGxdgc0g==",
+      "version": "0.9.8-beta.0",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8-beta.0.tgz",
+      "integrity": "sha512-WZrzudQvgMsGF9dbqi2a3r4zYPpHAJIQvcHAlRWw5vFNAh/cUnk9dNWCqLUPp5tlQu0oNSNRDVglSFvitCBNrQ==",
       "requires": {
         "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "5.1.0",
         "fs-extra": "^10.0.0",
-        "hap-nodejs": "0.9.8-beta.0",
+        "hap-nodejs": "0.9.8",
         "qrcode-terminal": "^0.12.0",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.20"
@@ -3366,9 +3366,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "node_modules/hap-nodejs": {
-      "version": "0.9.8-beta.0",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8-beta.0.tgz",
-      "integrity": "sha512-WZrzudQvgMsGF9dbqi2a3r4zYPpHAJIQvcHAlRWw5vFNAh/cUnk9dNWCqLUPp5tlQu0oNSNRDVglSFvitCBNrQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8.tgz",
+      "integrity": "sha512-+IENi8nFh/yOvVZEEIgY+nVppoXgY3mN8CfRh/I9tlhDbp3rXlsjdvHFVOgk7qJNa6cwzKu0KzNUs+n3XpO1Iw==",
       "dependencies": {
         "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",
@@ -9608,9 +9608,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "hap-nodejs": {
-      "version": "0.9.8-beta.0",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8-beta.0.tgz",
-      "integrity": "sha512-WZrzudQvgMsGF9dbqi2a3r4zYPpHAJIQvcHAlRWw5vFNAh/cUnk9dNWCqLUPp5tlQu0oNSNRDVglSFvitCBNrQ==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.8.tgz",
+      "integrity": "sha512-+IENi8nFh/yOvVZEEIgY+nVppoXgY3mN8CfRh/I9tlhDbp3rXlsjdvHFVOgk7qJNa6cwzKu0KzNUs+n3XpO1Iw==",
       "requires": {
         "@homebridge/ciao": "~1.1.3",
         "bonjour-hap": "~3.6.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.2",
     "commander": "5.1.0",
     "fs-extra": "^10.0.0",
-    "hap-nodejs": "0.9.8-beta.0",
+    "hap-nodejs": "0.9.8",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.20"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^4.1.2",
     "commander": "5.1.0",
     "fs-extra": "^10.0.0",
-    "hap-nodejs": "0.9.7",
+    "hap-nodejs": "0.9.8-beta.0",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.20"


### PR DESCRIPTION
## :recycle: Current situation

As reported in https://github.com/homebridge/HAP-NodeJS/issues/916 (and https://github.com/homebridge/homebridge/issues/2999), nodejs v17 ships with OpenSSL 3 on linux machines which require 96 bits nonce length for chacha20-poly1305 (OpneSSL 1.x did automatically fill up with zeros).

_This is the PR for release 1.3.9 and is available as a beta release already._

## :bulb: Proposed solution

This PR upgrades the `HAP-NodeJS` library with an according fix in the crypto handling.

## :gear: Release Notes

* Fixed a crash handling cipher texts when running node 17 on linux based machines.

## :heavy_plus_sign: Additional Information

### Testing
--

### Reviewer Nudging

--
