### PR TITLE
Strict plugin resolution proposal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ export = function cli(): void {
   let hideQRCode = false;
   let keepOrphans = false;
   let customPluginPath: string | undefined = undefined;
+  let strictPluginResolution = false;
   let noLogTimestamps = false;
   let debugModeEnabled = false;
   let forceColourLogging = false;
@@ -44,6 +45,7 @@ export = function cli(): void {
     .option("-K, --keep-orphans", "keep cached accessories for which the associated plugin is not loaded", () => keepOrphans = true)
     .option("-T, --no-timestamp", "do not issue timestamps in logging", () => noLogTimestamps = true)
     .option("-U, --user-storage-path [path]", "look for homebridge user files at [path] instead of the default location (~/.homebridge)", path => customStoragePath = path)
+    .option("--strict-plugin-resolution", "only load plugins from the --plugin-path if set, otherwise from the primary global node_modules", () => strictPluginResolution = true)
     .parse(process.argv);
 
   if (noLogTimestamps) {
@@ -74,6 +76,7 @@ export = function cli(): void {
     debugModeEnabled: debugModeEnabled,
     forceColourLogging: forceColourLogging,
     customStoragePath: customStoragePath,
+    strictPluginResolution: strictPluginResolution,
   };
 
   const server = new Server(options);

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -42,6 +42,10 @@ export interface PluginManagerOptions {
    */
   customPluginPath?: string;
   /**
+   * If set, only load plugins from the customPluginPath, if set, otherwise only from the primary global node_modules.
+   */
+  strictPluginResolution?: boolean;
+  /**
    * When defined, only plugins specified here will be initialized.
    */
   activePlugins?: PluginIdentifier[];
@@ -62,6 +66,7 @@ export class PluginManager {
   private readonly api: HomebridgeAPI;
 
   private readonly searchPaths: Set<string> = new Set(); // unique set of search paths we will use to discover installed plugins
+  private readonly strictPluginResolution: boolean = false;
   private readonly activePlugins?: PluginIdentifier[];
   private readonly disabledPlugins?: PluginIdentifier[];
 
@@ -80,6 +85,8 @@ export class PluginManager {
       if (options.customPluginPath) {
         this.searchPaths.add(path.resolve(process.cwd(), options.customPluginPath));
       }
+
+      this.strictPluginResolution = options.strictPluginResolution || false;
 
       this.activePlugins = options.activePlugins;
       this.disabledPlugins = Array.isArray(options.disabledPlugins) ? options.disabledPlugins : undefined;
@@ -427,6 +434,16 @@ export class PluginManager {
   }
 
   private loadDefaultPaths(): void {
+    if (this.strictPluginResolution) {
+      // if strict plugin resolution is enabled:
+      // * only use custom plugin path, if set;
+      // * otherwise add the current npm global prefix (eg. /usr/local/lib/node_modules)
+      if (this.searchPaths.size === 0) {
+        this.addNpmPrefixToSearchPaths();
+      }
+      return;
+    }
+
     if (require.main) {
       // add the paths used by require()
       require.main.paths.forEach(path => this.searchPaths.add(path));
@@ -444,14 +461,20 @@ export class PluginManager {
         .filter(path => !!path) // trim out empty values
         .forEach(path => this.searchPaths.add(path));
     } else {
-      // Default paths for each system
-      if (process.platform === "win32") {
-        this.searchPaths.add(path.join(process.env.APPDATA!, "npm/node_modules"));
-      } else {
+      // Default paths for non-windows systems
+      if (process.platform !== "win32") {
         this.searchPaths.add("/usr/local/lib/node_modules");
         this.searchPaths.add("/usr/lib/node_modules");
-        this.searchPaths.add(execSync("/bin/echo -n \"$(npm --no-update-notifier -g prefix)/lib/node_modules\"").toString("utf8"));
       }
+      this.addNpmPrefixToSearchPaths();
+    }
+  }
+
+  private addNpmPrefixToSearchPaths(): void {
+    if (process.platform === "win32") {
+      this.searchPaths.add(path.join(process.env.APPDATA!, "npm/node_modules"));
+    } else {
+      this.searchPaths.add(execSync("/bin/echo -n \"$(npm --no-update-notifier -g prefix)/lib/node_modules\"").toString("utf8"));
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ export interface HomebridgeOptions {
   debugModeEnabled?: boolean;
   forceColourLogging?: boolean;
   customStoragePath?: string;
+  strictPluginResolution?: boolean;
 }
 
 export const enum ServerStatus {
@@ -104,6 +105,7 @@ export class Server {
       activePlugins: this.config.plugins,
       disabledPlugins: this.config.disabledPlugins,
       customPluginPath: options.customPluginPath,
+      strictPluginResolution: options.strictPluginResolution,
     };
     this.pluginManager = new PluginManager(this.api, pluginManagerOptions);
 


### PR DESCRIPTION
## :recycle: Current situation

Currently Homebridge will attempt to load plugins from all `require` paths, default global node module paths, and the custom plugin path if set.

## :bulb: Proposed solution

The optional `--strict-plugin-resolution` flag will ensure Homebridge only loads plugins from the desired location.

If the  `--strict-plugin-resolution`  **and** `-P --plugin-path [path]` flags are set together, Homebridge will only load plugins from the location set from ` --plugin-path`, ignoring any globally installed modules or default system paths.

If the  `--strict-plugin-resolution` is set, **without** the `-P` flag, Homebridge will only load plugins from the current context's global node module install location as resolved by `$(npm -g prefix)/lib/node_modules`. It will ignore all other default system paths.

## :gear: Release Notes

* Added the optional `--strict-plugin-resolution` flag which will ensure Homebridge only loads plugins from the desired location if set.

## :heavy_plus_sign: Additional Information

This is to facilitate isolated, self contained Homebridge installs that do not interact with global installs of node, npm or npm modules.

### Reviewer Nudging

@Supereg 
