### PR TITLE
Replace `git.io` link within the error message

### DIFF
--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -152,7 +152,7 @@ export class BridgeService {
 
   // characteristic warning event has additional parameter originatorChain: string[] which is currently unused
   public static printCharacteristicWriteWarning(plugin: Plugin, accessory: Accessory, opts: CharacteristicWarningOpts, warning: CharacteristicWarning): void {
-    const wikiInfo = "See https://git.io/JtMGR for more info.";
+    const wikiInfo = "See https://github.com/homebridge/homebridge/wiki/Characteristic-Warnings for more info.";
     switch (warning.type) {
       case CharacteristicWarningType.SLOW_READ:
       case CharacteristicWarningType.SLOW_WRITE:
@@ -528,7 +528,7 @@ export class BridgeService {
     return new Promise(resolve => {
       // warn the user if the static platform is blocking the startup of Homebridge for to long
       const loadDelayWarningInterval = setInterval(() => {
-        log.warn(getLogPrefix(plugin.getPluginIdentifier()), "This plugin is taking long time to load and preventing Homebridge from starting. See https://git.io/JtMGR for more info.");
+        log.warn(getLogPrefix(plugin.getPluginIdentifier()), "This plugin is taking long time to load and preventing Homebridge from starting. See https://github.com/homebridge/homebridge/wiki/Characteristic-Warnings for more info.");
       }, 20000);
 
       platformInstance.accessories(once((accessories: AccessoryPlugin[]) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ const log = Logger.internal;
 const requiredNodeVersion = getRequiredNodeVersion();
 if (requiredNodeVersion && !satisfies(process.version, requiredNodeVersion)) {
   log.warn(`Homebridge requires Node.js version of ${requiredNodeVersion} which does \
-not satisfy the current Node.js version of ${process.version}. You may need to upgrade your installation of Node.js - see https://git.io/JTKEF`);
+not satisfy the current Node.js version of ${process.version}. You may need to upgrade your installation of Node.js - see https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js`);
 }
 
 // noinspection JSUnusedGlobalSymbols

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -176,7 +176,7 @@ You may face unexpected issues or stability problems running this plugin.`);
     // make sure the version is satisfied by the currently running version of Node
     if (nodeVersionRequired && !satisfies(process.version, nodeVersionRequired)) {
       log.warn(`The plugin "${this.pluginName}" requires Node.js version of ${nodeVersionRequired} which does \
-not satisfy the current Node.js version of ${process.version}. You may need to upgrade your installation of Node.js - see https://git.io/JTKEF`);
+not satisfy the current Node.js version of ${process.version}. You may need to upgrade your installation of Node.js - see https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js`);
     }
 
     const dependencies = context.dependencies || {};


### PR DESCRIPTION
## :recycle: Current situation

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

## :bulb: Proposed solution

Replace all `git.io` links with their actual URLs.