### PR TITLE
Add support for stopping / starting a child bridge, IPC events for pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The [Homebridge Wiki](https://github.com/homebridge/homebridge/wiki) contains st
 * [Setup Homebridge on macOS](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-macOS)
 * [Setup Homebridge on Windows 10](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Windows-10)
 * [Setup Homebridge on Docker (Linux)](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Docker)
+* [Setup Homebridge on a Synology NAS](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Synology-DSM)
 * [Other Platforms](https://github.com/homebridge/homebridge/wiki/Other-Platforms)
 
 ## Adding Homebridge to iOS

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "1.4.1",
+  "version": "1.5.0-beta.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -124,7 +124,7 @@ export class ChildBridgeFork {
     );
 
     // watch bridge events to check when server is online
-    this.bridgeService.bridge.on(AccessoryEventTypes.LISTENING, () => {
+    this.bridgeService.bridge.on(AccessoryEventTypes.ADVERTISED, () => {
       this.sendPairedStatusEvent();
     });
 

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -12,7 +12,7 @@ import { Plugin } from "./plugin";
 import { PluginManager } from "./pluginManager";
 import { Logger } from "./logger";
 import { User } from "./user";
-import { HAPStorage, MacAddress } from "hap-nodejs";
+import { AccessoryEventTypes, HAPStorage, MacAddress } from "hap-nodejs";
 import {
   ChildProcessMessageEventType,
   ChildProcessMessageEvent,
@@ -20,6 +20,7 @@ import {
   ChildProcessPortRequestEventData,
   ChildProcessPortAllocatedEventData,
   ChildProcessPluginLoadedEventData,
+  ChildBridgePairedStatusEventData,
 } from "./childBridgeService";
 import {
   AccessoryConfig,
@@ -122,6 +123,21 @@ export class ChildBridgeFork {
       this.homebridgeConfig,
     );
 
+    // watch bridge events to check when server is online
+    this.bridgeService.bridge.on(AccessoryEventTypes.LISTENING, () => {
+      this.sendPairedStatusEvent();
+    });
+
+    // watch for the paired event to update the server status
+    this.bridgeService.bridge.on(AccessoryEventTypes.PAIRED, () => {
+      this.sendPairedStatusEvent();
+    });
+
+    // watch for the unpaired event to update the server status
+    this.bridgeService.bridge.on(AccessoryEventTypes.UNPAIRED, () => {
+      this.sendPairedStatusEvent();
+    });
+
     // load the cached accessories
     await this.bridgeService.loadCachedPlatformAccessoriesFromDisk();
 
@@ -209,6 +225,16 @@ export class ChildBridgeFork {
     if (callback) {
       callback(data.port);
     }
+  }
+
+  /**
+   * Sends the current pairing status of the child bridge to the parent process
+   */
+  public sendPairedStatusEvent() {
+    this.sendMessage<ChildBridgePairedStatusEventData>(ChildProcessMessageEventType.STATUS_UPDATE, {
+      paired: this.bridgeService?.bridge?._accessoryInfo?.paired() ?? null,
+      setupUri: this.bridgeService?.bridge?.setupURI() ?? null,
+    });
   }
 
   shutdown(): void {

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -429,6 +429,7 @@ export class ChildBridgeService {
       this.log.warn("Stopping child bridge (will not restart)...");
       this.shuttingDown = true;
       this.manuallyStopped = true;
+      this.child?.removeAllListeners("close");
       this.teardown();
     } else {
       this.log.warn("Bridge already shutting down or stopped.");

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -429,7 +429,6 @@ export class ChildBridgeService {
       this.log.warn("Stopping child bridge (will not restart)...");
       this.shuttingDown = true;
       this.manuallyStopped = true;
-      this.child?.removeAllListeners("close");
       this.teardown();
     } else {
       this.log.warn("Bridge already shutting down or stopped.");

--- a/src/ipcService.ts
+++ b/src/ipcService.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "events";
 
 export const enum IpcIncomingEvent {
   RESTART_CHILD_BRIDGE = "restartChildBridge",
+  STOP_CHILD_BRIDGE = "stopChildBridge",
+  START_CHILD_BRIDGE = "startChildBridge",
   CHILD_BRIDGE_METADATA_REQUEST = "childBridgeMetadataRequest",
 }
 
@@ -13,6 +15,8 @@ export const enum IpcOutgoingEvent {
 
 export declare interface IpcService {
   on(event: IpcIncomingEvent.RESTART_CHILD_BRIDGE, listener: (childBridgeUsername: string) => void): this;
+  on(event: IpcIncomingEvent.STOP_CHILD_BRIDGE, listener: (childBridgeUsername: string) => void): this;
+  on(event: IpcIncomingEvent.START_CHILD_BRIDGE, listener: (childBridgeUsername: string) => void): this;
   on(event: IpcIncomingEvent.CHILD_BRIDGE_METADATA_REQUEST, listener: () => void): this;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,16 @@ export class Server {
     this.bridgeService.bridge.on(AccessoryEventTypes.LISTENING, () => {
       this.setServerStatus(ServerStatus.OK);
     });
+
+    // watch for the paired event to update the server status
+    this.bridgeService.bridge.on(AccessoryEventTypes.PAIRED, () => {
+      this.setServerStatus(this.serverStatus);
+    });
+
+    // watch for the unpaired event to update the server status
+    this.bridgeService.bridge.on(AccessoryEventTypes.UNPAIRED, () => {
+      this.setServerStatus(this.serverStatus);
+    });
   }
 
   /**
@@ -141,6 +151,8 @@ export class Server {
     this.serverStatus = status;
     this.ipcService.sendMessage(IpcOutgoingEvent.SERVER_STATUS_UPDATE, {
       status: this.serverStatus,
+      paired: this.bridgeService?.bridge?._accessoryInfo?.paired() ?? null,
+      setupUri: this.bridgeService?.bridge?.setupURI() ?? null,
     });
   }
 
@@ -501,7 +513,23 @@ export class Server {
     this.ipcService.on(IpcIncomingEvent.RESTART_CHILD_BRIDGE, (username) => {
       if (typeof username === "string") {
         const childBridge = this.childBridges.get(username.toUpperCase());
-        childBridge?.restartBridge();
+        childBridge?.restartChildBridge();
+      }
+    });
+
+    // handle stop child bridge event
+    this.ipcService.on(IpcIncomingEvent.STOP_CHILD_BRIDGE, (username) => {
+      if (typeof username === "string") {
+        const childBridge = this.childBridges.get(username.toUpperCase());
+        childBridge?.stopChildBridge();
+      }
+    });
+
+    // handle start child bridge event
+    this.ipcService.on(IpcIncomingEvent.START_CHILD_BRIDGE, (username) => {
+      if (typeof username === "string") {
+        const childBridge = this.childBridges.get(username.toUpperCase());
+        childBridge?.startChildBridge();
       }
     });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,6 +153,9 @@ export class Server {
       status: this.serverStatus,
       paired: this.bridgeService?.bridge?._accessoryInfo?.paired() ?? null,
       setupUri: this.bridgeService?.bridge?.setupURI() ?? null,
+      name: this.bridgeService?.bridge?.displayName || this.config.bridge.name,
+      username: this.config.bridge.username,
+      pin: this.config.bridge.pin,
     });
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -128,7 +128,7 @@ export class Server {
     );
 
     // watch bridge events to check when server is online
-    this.bridgeService.bridge.on(AccessoryEventTypes.LISTENING, () => {
+    this.bridgeService.bridge.on(AccessoryEventTypes.ADVERTISED, () => {
       this.setServerStatus(ServerStatus.OK);
     });
 


### PR DESCRIPTION
## :recycle: Current situation

Currently there is no way to stop and child bridge and keep it stopped.
Currently there is no way to get pairing information / status from a bridge without manually reading files on disk.

## :bulb: Proposed solution

This solution adds the ability to stop a child bridge, and keep it stopped, and to start it again, via IPC.

It also adds the current pairing status of the bridge/child bridge to the existing status events emitted via IPC. These events are are now also emitted as soon as the bridge/child bridge is paired or unpaired.

## :gear: Release Notes

* Added ability top stop child bridges via IPC. Stopped child bridges will remain stopped until manually re-started or until the main bridge is restarted.

### Reviewer Nudging

@Supereg 
