### PR TITLE
add option to override firmware on bridge

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -4,6 +4,7 @@
     "username": "CC:22:3D:E3:CE:30",
     "manufacturer": "homebridge.io",
     "model": "homebridge",
+    "firmware": "1.5.0",
     "port": 51826,
     "pin": "031-45-154"
   },

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -57,6 +57,7 @@ export interface BridgeConfiguration {
   setupID?: string[4];
   manufacturer?: string;
   model?: string;
+  firmware?: string;
   disableIpc?: boolean;
 }
 
@@ -189,7 +190,7 @@ export class BridgeService {
     info.setCharacteristic(Characteristic.Manufacturer, bridgeConfig.manufacturer || "homebridge.io");
     info.setCharacteristic(Characteristic.Model, bridgeConfig.model || "homebridge");
     info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.username);
-    info.setCharacteristic(Characteristic.FirmwareRevision, getVersion());
+    info.setCharacteristic(Characteristic.FirmwareRevision, bridgeConfig.firmware || getVersion());
 
     this.bridge.on(AccessoryEventTypes.LISTENING, (port: number) => {
       log.info("Homebridge v%s (HAP v%s) (%s) is running on port %s.", getVersion(), HAPLibraryVersion(), bridgeConfig.name, port);

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -345,6 +345,7 @@ export class ChildBridgeService {
       setupID: this.bridgeConfig.setupID,
       manufacturer: this.bridgeConfig.manufacturer || this.homebridgeConfig.bridge.manufacturer,
       model: this.bridgeConfig.model || this.homebridgeConfig.bridge.model,
+      firmware: this.bridgeConfig.firmware || this.homebridgeConfig.bridge.firmware,
     };
 
     const bridgeOptions: BridgeOptions = {


### PR DESCRIPTION
## :recycle: Current situation

Currently you can't override the firmware of the bridge for customization

## :bulb: Proposed solution

add config.json option to be able to override firmware.

## :gear: Release Notes

Added option to be able to override bridge firmware version.


### Reviewer Nudging

@Supereg 
