### PR TITLE
FirmwareRevision fixes

### DIFF
--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -321,10 +321,8 @@ export class BridgeService {
           return false; // filter it from the list
         }
       } else {
-        // we set the current plugin version before configureAccessory is called, so the dev has the opportunity to override it
-        accessory.getService(Service.AccessoryInformation)!
-          .setCharacteristic(Characteristic.FirmwareRevision, plugin!.version);
-
+        // We set a placeholder for FirmwareRevision before configureAccessory is called so the plugin has the opportunity to override it.
+        accessory.getService(Service.AccessoryInformation)?.setCharacteristic(Characteristic.FirmwareRevision, "0");
         platformPlugins.configureAccessory(accessory);
       }
 
@@ -361,12 +359,6 @@ export class BridgeService {
 
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!);
       if (plugin) {
-        const informationService = accessory.getService(Service.AccessoryInformation)!;
-        if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
-          // overwrite the default value with the actual plugin version
-          informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
-        }
-
         const platforms = plugin.getActiveDynamicPlatform(accessory._associatedPlatform!);
 
         if (!platforms) {
@@ -423,12 +415,6 @@ export class BridgeService {
 
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!);
       if (plugin) {
-        const informationService = hapAccessory.getService(Service.AccessoryInformation)!;
-        if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
-          // overwrite the default value with the actual plugin version
-          informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
-        }
-
         hapAccessory.on(AccessoryEventTypes.CHARACTERISTIC_WARNING, BridgeService.printCharacteristicWriteWarning.bind(this, plugin, hapAccessory, { ignoreSlow: true }));
       } else if (PluginManager.isQualifiedPluginIdentifier(accessory._associatedPlugin!)) {
         // we did already complain in api.ts if it wasn't a qualified name
@@ -507,11 +493,6 @@ export class BridgeService {
           accessory.addService(service);
         }
       });
-
-      if (informationService.getCharacteristic(Characteristic.FirmwareRevision).value === "0.0.0") {
-        // overwrite the default value with the actual plugin version
-        informationService.setCharacteristic(Characteristic.FirmwareRevision, plugin.version);
-      }
 
       accessory.on(AccessoryEventTypes.CHARACTERISTIC_WARNING, BridgeService.printCharacteristicWriteWarning.bind(this, plugin, accessory, {}));
 

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -7,6 +7,8 @@ import { User } from "./user";
 describe("Server", () => {
   const homebridgeStorageFolder = path.resolve(__dirname, "../mock");
   const configPath = path.resolve(homebridgeStorageFolder, "config.json");
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
 
   const mockConfig = {
     bridge: {
@@ -19,6 +21,8 @@ describe("Server", () => {
   };
 
   beforeAll(async () => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await fs.ensureDir(homebridgeStorageFolder);
     await fs.writeJson(configPath, mockConfig);
     User.setStoragePath(homebridgeStorageFolder);
@@ -27,6 +31,8 @@ describe("Server", () => {
   
   afterAll(async () => {
     await fs.remove(homebridgeStorageFolder);
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## :recycle: Current situation

Currently, Homebridge sets the FirmwareRevision characteristic prospectively before instantiating an accessory. Further, if the firmware revision is “0.0.0” it forces the firmware revision to be the same as the current version number of the plugin. This causes a number of problems. If you have a plugin that has a high version number, let’s say 5.0.0 and the accessory has a firmware revision of 2.0.0, HomeKit will not process that change. Why? HomeKit rules state that firmware revisions can only increase in number, never decrease. The minimum version number supported is “0”.
 
## :bulb: Proposed solution

Homebridge should not proactively set the FirmwareRevision characteristic to any other value than “0” and allow the plugin to manage firmware revisions.

## :gear: Release Notes

FirmwareRevision characteristic will be initialized to “0” on accessories.
