### PR TITLE
Added log messaging about upcoming updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 
 - Detect config interface on registerPlatform (#3609) (@duddu)
 - Updated dependencies, fix `typedoc` generation
+- Added log messaging about upcoming updates
 
 ## v1.8.3 (2024-06-19)
 

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -192,7 +192,14 @@ export class BridgeService {
     info.setCharacteristic(Characteristic.FirmwareRevision, bridgeConfig.firmwareRevision || getVersion());
 
     this.bridge.on(AccessoryEventTypes.LISTENING, (port: number) => {
-      log.info("Homebridge v%s (HAP v%s) (%s) is running on port %s.", getVersion(), HAPLibraryVersion(), bridgeConfig.name, port);
+      log.success("Homebridge v%s (HAP v%s) (%s) is running on port %s.", getVersion(), HAPLibraryVersion(), bridgeConfig.name, port);
+
+      log.warn(
+        "\n\nNOTICE TO USERS AND PLUGIN DEVELOPERS"
+        + "\n> Homebridge 2.0 is on the way and brings some breaking changes to existing plugins.\n"
+        + "> Please visit the following link to learn more about the changes and how to prepare:\n"
+        + "> https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0\n",
+      );
     });
 
     // noinspection JSDeprecatedSymbols
@@ -422,7 +429,7 @@ export class BridgeService {
       }
 
       hapAccessory.on(AccessoryEventTypes.LISTENING, (port: number) => {
-        log.info("%s is running on port %s.", hapAccessory.displayName, port);
+        log.success("%s is running on port %s.", hapAccessory.displayName, port);
         log.info("Please add [%s] manually in Home app. Setup Code: %s", hapAccessory.displayName, accessoryPin);
       });
 


### PR DESCRIPTION
Adds something like this on homebridge startup. Please make suggestions to change the text if you have better ideas!

<img width="814" alt="Screenshot 2024-07-14 at 18 45 17" src="https://github.com/user-attachments/assets/f0eae83c-1173-446e-ba06-20b0b2af09ff">

https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0
