### PR TITLE
support plugins with dots in their @scope

### DIFF
--- a/src/pluginManager.spec.ts
+++ b/src/pluginManager.spec.ts
@@ -9,6 +9,10 @@ describe("PluginManager", () => {
     it("should match scoped plugin names", () => {
       expect(PluginManager.isQualifiedPluginIdentifier("@organisation/homebridge-dummy-plugin")).toBeTruthy();
     });
+
+    it("should match scoped plugin names with dots", () => {
+      expect(PluginManager.isQualifiedPluginIdentifier("@organisation.com/homebridge-dummy-plugin")).toBeTruthy();
+    });
   });
 
   describe("PluginManager.extractPluginName", () => {
@@ -19,6 +23,10 @@ describe("PluginManager", () => {
     it("should extract scoped plugin names", function() {
       expect(PluginManager.extractPluginName("@organisation/homebridge-dummy-plugin")).toBe("homebridge-dummy-plugin");
     });
+
+    it("should extract scoped plugin names with scopes with dots in their name", function() {
+      expect(PluginManager.extractPluginName("@organisation.com/homebridge-dummy-plugin")).toBe("homebridge-dummy-plugin");
+    });
   });
 
   describe("PluginManager.extractPluginScope", () => {
@@ -28,6 +36,10 @@ describe("PluginManager", () => {
 
     it("should extract scope for scoped plugin names", function() {
       expect(PluginManager.extractPluginScope("@organisation/homebridge-dummy-plugin")).toBe("@organisation");
+    });
+
+    it("should extract scope for scoped plugin names with dots in their name", function() {
+      expect(PluginManager.extractPluginScope("@organisation.com/homebridge-dummy-plugin")).toBe("@organisation.com");
     });
   });
 

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -64,7 +64,7 @@ export interface PluginManagerOptions {
 export class PluginManager {
 
   // name must be prefixed with 'homebridge-' or '@scope/homebridge-'
-  private static readonly PLUGIN_IDENTIFIER_PATTERN = /^((@[\w-]*)\/)?(homebridge-[\w-]*)$/;
+  private static readonly PLUGIN_IDENTIFIER_PATTERN = /^((@[\w-]+(\.[\w-]+)*)\/)?(homebridge-[\w-]+)$/;
 
   private readonly api: HomebridgeAPI;
 
@@ -104,7 +104,7 @@ export class PluginManager {
   }
 
   public static extractPluginName(name: string): PluginName { // extract plugin name without @scope/ prefix
-    return name.match(PluginManager.PLUGIN_IDENTIFIER_PATTERN)![3];
+    return name.match(PluginManager.PLUGIN_IDENTIFIER_PATTERN)![4];
   }
 
   public static extractPluginScope(name: string): string { // extract the "@scope" of a npm module name


### PR DESCRIPTION
## :recycle: Current situation

I'm writing a plugin and my npm @scope has a '.' in it.  Homebridge won't load it.

## :bulb: Proposed solution

Changing PLUGIN_IDENTIFIER_PATTERN to include a period in the regex. 

## :gear: Release Notes

Support plugins with dots in their @scope

## :heavy_plus_sign: Additional Information

N/A

### Testing

Add corresponding tests to pluginManager.spec.ts.

### Reviewer Nudging


