### PR TITLE
Make it possible to set Characteristic.SerialNumber via config.json

### DIFF
--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -54,6 +54,7 @@ export interface BridgeConfiguration {
   model?: string;
   disableIpc?: boolean;
   firmwareRevision?: string;
+  serialNumber?: string;
   env?: {
     DEBUG?: string;
     NODE_OPTIONS?: string;

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -188,7 +188,7 @@ export class BridgeService {
     const info = this.bridge.getService(Service.AccessoryInformation)!;
     info.setCharacteristic(Characteristic.Manufacturer, bridgeConfig.manufacturer || "homebridge.io");
     info.setCharacteristic(Characteristic.Model, bridgeConfig.model || "homebridge");
-    info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.username);
+    info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.serialNumber || bridgeConfig.username);
     info.setCharacteristic(Characteristic.FirmwareRevision, bridgeConfig.firmwareRevision || getVersion());
 
     this.bridge.on(AccessoryEventTypes.LISTENING, (port: number) => {

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -360,6 +360,7 @@ export class ChildBridgeService {
       manufacturer: this.bridgeConfig.manufacturer || this.homebridgeConfig.bridge.manufacturer,
       model: this.bridgeConfig.model || this.homebridgeConfig.bridge.model,
       firmwareRevision: this.bridgeConfig.firmwareRevision || this.homebridgeConfig.bridge.firmwareRevision,
+      serialNumber: this.bridgeConfig.serialNumber || this.bridgeConfig.username,
     };
 
     const bridgeOptions: BridgeOptions = {


### PR DESCRIPTION
## :recycle: Current situation

Right now Characteristic.SerialNumber for the bridge is only set to bridgeConfig.username, which may be good for functionality, but not so good for cosmetic purposes - when running on devices like Raspberry Pi it would be really cool to be able to set this to the real serial number.

## :bulb: Proposed solution

As said in title - make it possible to set Characteristic.SerialNumber via config.json. Proposed solution (sounds really pretentious for two strings of code) preserves current behaviour, meaning if no bridgeConfig.serialNumber is present it still defaults to bridgeConfig.username.