### PR TITLE
Added method updateDisplayName()

### DIFF
--- a/src/platformAccessory.spec.ts
+++ b/src/platformAccessory.spec.ts
@@ -49,6 +49,15 @@ describe("PlatformAccessory", () => {
 
   });
 
+  describe("PlatformAccessory.prototype.updateDisplayName",() => {
+    it("should mirror displayName correctly", function() {
+      const accessory = createAccessory("TestName");
+      accessory.updateDisplayName("NewTestName");
+      expect(accessory._associatedHAPAccessory.displayName).toBe(accessory.displayName);
+      expect(accessory.displayName).toBe("NewTestName");
+    });
+  });
+
   describe("PlatformAccessory.prototype.addService", () => {
     it("should forward add service", function() {
       const accessory = createAccessory();

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -168,6 +168,7 @@ export class PlatformAccessory<T extends UnknownContext = UnknownContext>  exten
 
   // private
   static serialize(accessory: PlatformAccessory): SerializedPlatformAccessory {
+    accessory._associatedHAPAccessory.displayName = accessory.displayName;
     return {
       plugin: accessory._associatedPlugin!,
       platform: accessory._associatedPlatform!,

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -90,6 +90,13 @@ export class PlatformAccessory<T extends UnknownContext = UnknownContext>  exten
     });
   }
 
+  public updateDisplayName(name: string): void {
+    if (name) {
+      this.displayName = name;
+      this._associatedHAPAccessory.displayName = name;
+    }
+  }
+
   public addService(service: Service): Service;
   public addService<S extends typeof Service>(serviceConstructor: S, ...constructorArgs: ConstructorArgs<S>): Service;
   public addService(service: Service | typeof Service, ...constructorArgs: any[]): Service { // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## :recycle: Current situation

When a cached plugin is deserialized, the cached values are loaded into the "private" property `_associatedHAPAccessory`. Even if `displayName` is changed, the properties of `_associatedHAPAccessory` are never modified. When the plugin is serialized back to cache, it reads the properties of `_associatedHAPAccessory`.

See [Accessory name cannot be updated](https://github.com/homebridge/homebridge/issues/3763)

## :bulb: Proposed solution

Add a method to update `displayName` in `_associatedHAPAccessory` without accessing the private variable.
<p>
However a user may modify `displayName` directly, so defensively sync `_associatedHAPAccessory.displayName` with `displayName` at the moment of serialization.


## :gear: Release Notes


### :heavy_plus_sign: Additional Information

**Note:** As `_associatedHAPAccessory.displayName` is sync'd with `displayName` at the moment of serialization, the method `updateDisplayName()` is not strictly needed. A better approach would be to remove the `displayName` property and replace it with getter and setter methods:
```
  public getDisplayName(): string {
    return  this._associatedHAPAccessory.displayName;
  }

  public setDisplayName(name: string): void {
    this._associatedHAPAccessory.displayName = name;
  }
```
Ideally `setDisplayName()` would have a check to make sure that `name` is not null, undefined, or "" and/or return an error. However this will likely break Homebridge UI and a whole lot of plugins.

### Testing

Added test method to verify that a call to `updateDisplayName()` updates both `displayName` and `_associatedHAPAccessory.displayName`.

### Reviewer Nudging

