### PR TITLE
Fixed method handleUpdatePlatformAccessories()

### DIFF
--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -388,7 +388,7 @@ export class BridgeService {
     const nonUpdatedPlugins = this.cachedPlatformAccessories.filter(
       cachedPlatformAccessory => (
         accessories.find(accessory => accessory.UUID === cachedPlatformAccessory._associatedHAPAccessory.UUID) === undefined
-      )
+      ),
     );
 
     this.cachedPlatformAccessories = [ ...nonUpdatedPlugins, ...accessories];

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -384,11 +384,10 @@ export class BridgeService {
     this.saveCachedPlatformAccessoriesOnDisk();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleUpdatePlatformAccessories(accessories: PlatformAccessory[]): void {
     const nonUpdatedPlugins = this.cachedPlatformAccessories.filter(
       cachedPlatformAccessory => (
-        accessories.find(accessory => accessory.UUID === cachedPlatformAccessory._associatedHAPAccessory.UUID) !== undefined
+        accessories.find(accessory => accessory.UUID === cachedPlatformAccessory._associatedHAPAccessory.UUID) === undefined
       )
     );
 

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -386,6 +386,14 @@ export class BridgeService {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleUpdatePlatformAccessories(accessories: PlatformAccessory[]): void {
+    const nonUpdatedPlugins = this.cachedPlatformAccessories.filter(
+      cachedPlatformAccessory => (
+        accessories.find(accessory => accessory.UUID === cachedPlatformAccessory._associatedHAPAccessory.UUID) !== undefined
+      )
+    );
+
+    this.cachedPlatformAccessories = [ ...nonUpdatedPlugins, ...accessories];
+
     // Update persisted accessories
     this.saveCachedPlatformAccessoriesOnDisk();
   }


### PR DESCRIPTION
## :recycle: Current situation

The method handleUpdatePlatformAccessories() is not properly implemented. In this method, the array of PlatformAccessory objects is lost, as it is not used in the handleUpdatePlatformAccessories() method. The method just saves the currently cached platform accessories back to disc without updating anything.

See [Updating Platform Accessories does nothing - method is not implemented](https://github.com/homebridge/homebridge/issues/3762).


## :bulb: Proposed solution

1. Find cached platform accessories that do not have matching UUIDs with the updated accessories.
2. Overwrite the cached platform accessories array with the non-matching accessories plus the updated accessories.
3. Save the cached platform accessories array with the new entries.


## :gear: Release Notes


## :heavy_plus_sign: Additional Information


### Testing


### Reviewer Nudging

