### PR TITLE
Update bridgeService.ts: make publishInfo.addIdentifyingMaterial opt-out

### DIFF
--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -204,7 +204,7 @@ export class BridgeService {
       category: Categories.BRIDGE,
       bind: bridgeConfig.bind,
       mdns: this.config.mdns, // this is deprecated now
-      addIdentifyingMaterial: true,
+      addIdentifyingMaterial: bridgeConfig.addNameSuffix !== false,
       advertiser: bridgeConfig.advertiser,
     };
 


### PR DESCRIPTION
## :recycle: Current situation

Currently homebridge forcefully adds unique suffix to whatever homebridge name is chosen and resulting name may make things confusing for end-users.

## :bulb: Proposed solution

This makes it optional. Needs documentation though.

## :gear: Release Notes

Make bridge name suffix optional.

## :heavy_plus_sign: Additional Information

If admin decides to name a bridge a certain way, respect it.

### Testing

None

### Reviewer Nudging

Self evident