### PR TITLE
fix: Matter crash when bridge bind config is set (network.interface env var)

### DIFF
--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -219,19 +219,6 @@ export class ServerLifecycle {
 
       log.info(`Configuration: Port=${deps.config.port}, Passcode=${deps.commissioningManager.passcode}, Discriminator=${deps.commissioningManager.discriminator}`)
 
-      // Configure network interfaces if specified
-      if (deps.config.networkInterfaces && deps.config.networkInterfaces.length > 0) {
-        const environment = Environment.default
-        const interfaceConfig: Record<string, { type: number }> = {}
-        for (const interfaceName of deps.config.networkInterfaces) {
-          interfaceConfig[interfaceName] = { type: 2 }
-        }
-        environment.vars.set('network.interface', interfaceConfig)
-        log.info(`Configured Matter server to use network interfaces: ${deps.config.networkInterfaces.join(', ')}`)
-      } else {
-        log.debug('No network interfaces specified, using all available interfaces')
-      }
-
       const commissioningOptions = {
         passcode: deps.commissioningManager.passcode,
         discriminator: deps.commissioningManager.discriminator,
@@ -273,8 +260,39 @@ export class ServerLifecycle {
         }
       }
 
+      // Clear any previously set network.interface from the global environment BEFORE
+      // creating the ServerNode. Environment.default is a singleton shared across all
+      // server instances in the process. If a previous server already set network.interface,
+      // the ValueCaster in Behaviors.defaultsFor() would reject the unknown 'interface'
+      // property when initializing NetworkBehavior on this new node.
+      // VariableService.get() returns a direct reference to the internal vars object,
+      // so deleting the key here mutates the stored value without needing a private API.
+      const networkVars = Environment.default.vars.get('network') as unknown as Record<string, unknown> | undefined
+      if (networkVars && 'interface' in networkVars) {
+        delete networkVars.interface
+        log.debug('Cleared network.interface from environment before ServerNode creation')
+      }
+
       const serverNode = await this.createServerNodeWithRecovery(nodeOptions, sanitizedId)
       deps.setServerNode(serverNode)
+
+      // Configure network interfaces if specified.
+      // This must happen after ServerNode creation because during creation,
+      // Behaviors.defaultsFor('network') picks up the entire 'network' env var
+      // subtree via EndpointVariableService.forBehaviorType() and the ValueCaster
+      // rejects the unknown 'interface' property. ServerNetworkRuntime reads
+      // 'network.interface' lazily (via a getter) so it only needs it at run() time.
+      if (deps.config.networkInterfaces && deps.config.networkInterfaces.length > 0) {
+        const environment = Environment.default
+        const interfaceConfig: Record<string, { type: number }> = {}
+        for (const interfaceName of deps.config.networkInterfaces) {
+          interfaceConfig[interfaceName] = { type: 2 }
+        }
+        environment.vars.set('network.interface', interfaceConfig)
+        log.info(`Configured Matter server to use network interfaces: ${deps.config.networkInterfaces.join(', ')}`)
+      } else {
+        log.debug('No network interfaces specified, using all available interfaces')
+      }
 
       // Set up commissioning event listeners
       deps.commissioningManager.setupCommissioningEventListeners(deps.getCommissioningDeps())


### PR DESCRIPTION
## Problem

When a Homebridge bridge has `"bind"` configured (e.g. `"bind": ["eno1"]`), the Matter server crashes during `ServerNode` initialization with:

```
[unsupported-cast] Property "interface" is unsupported
  Caused by: Error initializing <uuid>.commissioning
```

This affects all Matter-enabled plugins on any instance with network interface binding configured — including child bridges that inherit `bind` from the parent bridge config. A `RoboticVacuumCleaner` device type (which requires its own external `ServerNode`) reproduces both bugs in sequence.

## Root Cause

`Environment.default` is a **global singleton** shared across all `ServerNode` instances in the process. Two related bugs compound each other:

**Bug 1:** `environment.vars.set("network.interface", interfaceConfig)` was called **before** `MatterServerNode.create()`. During creation, `Behaviors.defaultsFor("network")` resolves environment variables via `EndpointVariableService.forBehaviorType("network")`, which falls back to `vars.get("network")` — returning the entire subtree including `{ interface: { eno1: { type: 2 } } }`. The `ValueCaster` rejects the unknown `interface` property (not in `NetworkBehavior.State`).

**Bug 2 (regression of fix 1):** Even after moving the `vars.set` call to after creation, a _second_ `ServerNode` (e.g. for an external accessory) still crashes because `network.interface` was already set in `Environment.default` by the first server's startup.

## Fix

Two-part fix in `ServerLifecycle.start()`:

1. **Before** `createServerNodeWithRecovery()`: clear any pre-existing `interface` key from the `network` vars object. `VariableService.get()` returns a direct reference to the internal vars object, so `delete networkVars["interface"]` safely removes it without needing private API access.

2. **After** `createServerNodeWithRecovery()`: set `network.interface` to the configured value. `ServerNetworkRuntime` reads it lazily via a getter at `run()` time, so it only needs the value after node creation.

This ensures each `ServerNode` creation sees a clean environment while still providing the interface config when the network runtime needs it.

## Verified

Tested on Homebridge v2.0.0-beta.89 with `@matter/main 0.17.0-alpha.0`, Docker image, with `"bind": ["eno1"]` in bridge config and a `RoboticVacuumCleaner` plugin (which creates two `ServerNode` instances). Both nodes now start successfully.

## Reproduction

1. Set `"bind": ["eno1"]` (or any interface) in bridge config
2. Configure a child bridge with any Matter-enabled plugin
   - Use a `RoboticVacuumCleaner` device type to trigger both bugs
3. Restart Homebridge → child bridge crashes
