### PR TITLE
fix: add powerSource to clusterNames and ClusterStateMap

### DIFF
--- a/src/matter/clusterStateMap.ts
+++ b/src/matter/clusterStateMap.ts
@@ -16,6 +16,7 @@ import type {
   FanControlState,
   LevelControlState,
   OnOffState,
+  PowerSourceState,
   RvcCleanModeState,
   RvcOperationalState,
   RvcRunModeState,
@@ -56,6 +57,9 @@ export interface ClusterStateMap {
   rvcRunMode: RvcRunModeState
   rvcCleanMode: RvcCleanModeState
   serviceArea: ServiceAreaState
+
+  // Power
+  powerSource: PowerSourceState
 
   // Sensor clusters
   temperatureMeasurement: { measuredValue: number | null, minMeasuredValue?: number | null, maxMeasuredValue?: number | null }

--- a/src/matter/clusterTypes.ts
+++ b/src/matter/clusterTypes.ts
@@ -329,3 +329,31 @@ export interface ServiceAreaState {
     totalOperationalTime?: number | null
   }>
 }
+
+/**
+ * Power Source state
+ * @see {@link https://matter-standard.github.io/matter/specification/latest/#ref-power-source-cluster}
+ *
+ * `batPercentRemaining` is encoded as double the percentage (0–200), so 100% = 200.
+ * `batChargeLevel`: 0 = Ok, 1 = Warning, 2 = Critical
+ */
+export interface PowerSourceState {
+  status?: number
+  order?: number
+  description?: string
+  batVoltage?: number | null
+  batPercentRemaining?: number | null
+  batTimeRemaining?: number | null
+  batChargeLevel?: number
+  batReplacementNeeded?: boolean
+  batReplaceability?: number
+  batPresent?: boolean
+  activeBatFaults?: number[]
+  batReplacementDescription?: string
+  batQuantity?: number
+  batChargeState?: number
+  batTimeToFullCharge?: number | null
+  batFunctionalWhileCharging?: boolean
+  batChargingCurrent?: number | null
+  activeBatChargeFaults?: number[]
+}

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -678,6 +678,9 @@ export const clusterNames = {
   RvcCleanMode: 'rvcCleanMode',
   ServiceArea: 'serviceArea',
 
+  // Power
+  PowerSource: 'powerSource',
+
   // Pump & Other
   PumpConfigurationAndControl: 'pumpConfigurationAndControl',
 


### PR DESCRIPTION
PowerSource cluster can be used by accessories to report battery level. Add it to `clusterNames` (eliminates spurious warning on `updateAccessoryState`), `ClusterStateMap` (type safety), and `clusterTypes.ts` (`PowerSourceState` interface).