### PR TITLE
fix: enable Rechargeable feature for PowerSource cluster when batChargeState is provided

### DIFF
--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -400,8 +400,12 @@ export class AccessoryManager {
       if (accessory.clusters?.powerSource) {
         const hasBattery = accessory.clusters.powerSource.batPercentRemaining !== undefined
           || accessory.clusters.powerSource.batChargeLevel !== undefined
+        const hasRechargeable = accessory.clusters.powerSource.batChargeState !== undefined
         let powerSourceBehavior: BehaviorType = PowerSourceServer
-        if (hasBattery) {
+        if (hasBattery && hasRechargeable) {
+          powerSourceBehavior = (PowerSourceServer as any).with('Battery', 'Rechargeable')
+          log.debug('Adding PowerSource server with battery and rechargeable features')
+        } else if (hasBattery) {
           powerSourceBehavior = (PowerSourceServer as any).with('Battery')
           log.debug('Adding PowerSource server with battery feature')
         } else {


### PR DESCRIPTION
## Summary

When a plugin provides `batChargeState` in the `powerSource` cluster config, the `AccessoryManager` now enables the `Rechargeable` feature flag via `PowerSourceServer.with('Battery', 'Rechargeable')`.

## Problem

The `batChargeState` attribute (IsCharging / IsNotCharging) is only available under the Matter `Rechargeable` feature. Previously, `AccessoryManager` only used `with('Battery')`, so any `batChargeState` values provided by plugins were silently ignored and HomeKit always showed "Charging: No".

## Change

```
if (hasBattery && hasRechargeable) {
  powerSourceBehavior = PowerSourceServer.with('Battery', 'Rechargeable')
} else if (hasBattery) {
  powerSourceBehavior = PowerSourceServer.with('Battery')
}
```

Where `hasRechargeable` is true when `batChargeState !== undefined` in the initial cluster config.

## Related

Follows on from #3912 which added `powerSource` to `clusterNames` and `ClusterStateMap`.