### PR TITLE
fix: remove MatterServer stateChange/commissioning listeners on teardown

### DIFF
--- a/src/matter/ChildBridgeMatterManager.ts
+++ b/src/matter/ChildBridgeMatterManager.ts
@@ -97,6 +97,21 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
     })
   }
 
+  // Stored references so listeners can be removed in teardown()
+  private readonly _onMatterServerStateChange = ({ uuid, cluster, state, partId }: { uuid: string, cluster: string, state: Record<string, unknown>, partId?: string }): void => {
+    if (process.send) {
+      process.send({
+        id: 'matterEvent',
+        data: {
+          type: 'accessoryUpdate',
+          data: { uuid, cluster, state, partId },
+        },
+      })
+    }
+  }
+
+  private _onCommissioningStatusChanged?: (commissioned: boolean, fabricCount: number) => void
+
   /**
    * Initialize Matter server for child bridge if enabled
    * @param onCommissioningChanged Optional callback when commissioning status changes
@@ -131,30 +146,16 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
 
     // Listen for commissioning status changes to update parent process
     if (onCommissioningChanged && this.matterServer) {
-      this.matterServer.on('commissioning-status-changed', (commissioned, fabricCount) => {
+      this._onCommissioningStatusChanged = (commissioned, fabricCount) => {
         log.info(`Matter commissioning status changed for child bridge ${this.bridgeConfig.username}: commissioned=${commissioned}, fabricCount=${fabricCount}`)
         onCommissioningChanged()
-      })
+      }
+      this.matterServer.on('commissioning-status-changed', this._onCommissioningStatusChanged)
     }
 
     // Listen for state changes and forward to parent process
     if (this.matterServer) {
-      this.matterServer.on('stateChange', ({ uuid, cluster, state, partId }) => {
-        if (process.send) {
-          process.send({
-            id: 'matterEvent',
-            data: {
-              type: 'accessoryUpdate',
-              data: {
-                uuid,
-                cluster,
-                state,
-                partId,
-              },
-            },
-          })
-        }
-      })
+      this.matterServer.on('stateChange', this._onMatterServerStateChange)
     }
   }
 
@@ -250,22 +251,7 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
 
           // Listen for state changes and forward to parent process
           // (same pattern as the child bridge server listener in initialize())
-          result.server.on('stateChange', ({ uuid, cluster, state, partId }) => {
-            if (process.send) {
-              process.send({
-                id: 'matterEvent',
-                data: {
-                  type: 'accessoryUpdate',
-                  data: {
-                    uuid,
-                    cluster,
-                    state,
-                    partId,
-                  },
-                },
-              })
-            }
-          })
+          result.server.on('stateChange', this._onMatterServerStateChange)
 
           // Register the external bridge username with parent process for routing
           // Send via IPC to parent - parent will register in externalMatterBridgeRegistry
@@ -412,6 +398,10 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
     if (this.matterServer) {
       log.debug(`Stopping Matter server for child bridge ${this.bridgeConfig.username}`)
       try {
+        this.matterServer.removeListener('stateChange', this._onMatterServerStateChange)
+        if (this._onCommissioningStatusChanged) {
+          this.matterServer.removeListener('commissioning-status-changed', this._onCommissioningStatusChanged)
+        }
         await this.matterServer.stop()
       } catch (error: unknown) {
         log.error('Error stopping Matter server:', error)
@@ -422,6 +412,7 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
     for (const [uuid, matterServer] of this.externalMatterServers) {
       log.debug(`Stopping external Matter server for ${uuid}`)
       try {
+        matterServer.removeListener('stateChange', this._onMatterServerStateChange)
         await matterServer.stop()
       } catch (error: unknown) {
         log.error(`Error stopping external Matter server for ${uuid}:`, error)

--- a/src/matter/MatterBridgeManager.ts
+++ b/src/matter/MatterBridgeManager.ts
@@ -89,6 +89,15 @@ export class MatterBridgeManager extends BaseMatterManager {
     })
   }
 
+  // Stored reference so the stateChange listener can be removed in teardown()
+  private readonly _onMatterServerStateChange = ({ uuid, cluster, state, partId }: { uuid: string, cluster: string, state: Record<string, unknown>, partId?: string }): void => {
+    const event: MatterEvent = {
+      type: 'accessoryUpdate',
+      data: { uuid, cluster, state, partId },
+    }
+    this.server.ipcService.sendMessage(IpcOutgoingEvent.MATTER_EVENT, event)
+  }
+
   /**
    * Set up event listeners for Matter accessory operations
    * Subscribes directly to API events instead of requiring server.ts to delegate
@@ -160,18 +169,7 @@ export class MatterBridgeManager extends BaseMatterManager {
       this.api._setMatterServer(this.matterServer)
 
       // Listen for state changes and forward to UI via IPC
-      this.matterServer.on('stateChange', ({ uuid, cluster, state, partId }) => {
-        const event: MatterEvent = {
-          type: 'accessoryUpdate',
-          data: {
-            uuid,
-            cluster,
-            state,
-            partId,
-          },
-        }
-        this.server.ipcService.sendMessage(IpcOutgoingEvent.MATTER_EVENT, event)
-      })
+      this.matterServer.on('stateChange', this._onMatterServerStateChange)
     } catch (error: unknown) {
       log.error('Failed to initialize Matter server for main bridge:', error)
 
@@ -253,18 +251,7 @@ export class MatterBridgeManager extends BaseMatterManager {
 
           // Listen for state changes and forward to UI via IPC
           // (same pattern as the main bridge server listener in initialize())
-          result.server.on('stateChange', ({ uuid, cluster, state, partId }) => {
-            const event: MatterEvent = {
-              type: 'accessoryUpdate',
-              data: {
-                uuid,
-                cluster,
-                state,
-                partId,
-              },
-            }
-            this.server.ipcService.sendMessage(IpcOutgoingEvent.MATTER_EVENT, event)
-          })
+          result.server.on('stateChange', this._onMatterServerStateChange)
 
           // Register the external bridge username for direct routing
           // Use main bridge's username for consistent lookups
@@ -585,6 +572,7 @@ export class MatterBridgeManager extends BaseMatterManager {
     // Stop main Matter server if running
     if (this.matterServer) {
       try {
+        this.matterServer.removeListener('stateChange', this._onMatterServerStateChange)
         await this.matterServer.stop()
       } catch (error) {
         log.error('Failed to stop Matter server:', error)
@@ -594,6 +582,7 @@ export class MatterBridgeManager extends BaseMatterManager {
     // Stop all external Matter servers
     for (const [uuid, matterServer] of this.externalMatterServers) {
       try {
+        matterServer.removeListener('stateChange', this._onMatterServerStateChange)
         await matterServer.stop()
         log.debug(`Stopped external Matter server for ${uuid}`)
       } catch (error) {


### PR DESCRIPTION
MatterBridgeManager and ChildBridgeMatterManager registered inline arrow-function listeners for `stateChange` (and `commissioning-status-changed` in the child bridge case) on MatterServer instances but never removed them before calling `stop()`. The closures retained references to `ipcService`/`process.send`, preventing the EventEmitter from being fully released on restart.

Store each listener as a private arrow-property (`_onMatterServerStateChange`) or optional field (`_onCommissioningStatusChanged`) and call `removeListener()` before `stop()` in `teardown()`, covering both the main server and each entry in `externalMatterServers`.