### PR TITLE
fix: remove process message listener on IpcService teardown

### DIFF
--- a/src/ipcService.ts
+++ b/src/ipcService.ts
@@ -32,21 +32,30 @@ export declare interface IpcService {
 
 // eslint-disable-next-line ts/no-unsafe-declaration-merging
 export class IpcService extends EventEmitter {
+  private readonly messageHandler = (message: { id: string, data: never }) => {
+    if (!message || typeof message !== 'object' || !message.id) {
+      return
+    }
+    this.emit(message.id, message.data)
+  }
+
   constructor() {
     super()
   }
 
   /**
-   * Start the IPC service listeners/
+   * Start the IPC service listeners.
    * Currently this will only listen for messages from a parent process.
    */
   public start(): void {
-    process.on('message', (message: { id: string, data: never }) => {
-      if (!message || typeof message !== 'object' || !message.id) {
-        return
-      }
-      this.emit(message.id, message.data)
-    })
+    process.on('message', this.messageHandler)
+  }
+
+  /**
+   * Stop the IPC service listeners.
+   */
+  public stop(): void {
+    process.removeListener('message', this.messageHandler)
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -256,6 +256,7 @@ export class Server {
     // Teardown Matter servers (main bridge and external accessories)
     await this.matterManager?.teardown()
 
+    this.ipcService.stop()
     this.setServerStatus(ServerStatus.DOWN)
   }
 


### PR DESCRIPTION
IpcService.start() registered an anonymous listener on the global process object with no way to remove it. Each call accumulated another listener. Extracts the handler to a class field so stop() can call removeListener(), and calls stop() from Server.teardown().