### PR TITLE
Add `GenericSwitch` to `api.matter.deviceTypes`

### DIFF
--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -129,6 +129,35 @@ describe('homebridgeAPI', () => {
         )
       })
 
+      it('should register stateless switch accessories using GenericSwitch device type', () => {
+        const matterAccessories: MatterAccessory[] = [
+          {
+            UUID: matter.uuid.generate('test-remote-1'),
+            displayName: 'Test Remote 1',
+            deviceType: matter.deviceTypes.GenericSwitch,
+            serialNumber: 'SN-REMOTE-001',
+            manufacturer: 'Test Manufacturer',
+            model: 'Test Remote',
+            clusters: {
+              switch: {
+                currentPosition: 0,
+                numberOfPositions: 3,
+              },
+            },
+            context: {},
+          },
+        ]
+
+        matter.registerPlatformAccessories(matterPluginName, matterPlatformName, matterAccessories)
+
+        expect(emitSpy).toHaveBeenLastCalledWith(
+          InternalAPIEvent.REGISTER_MATTER_PLATFORM_ACCESSORIES,
+          matterPluginName,
+          matterPlatformName,
+          matterAccessories,
+        )
+      })
+
       it('should register multiple Matter platform accessories', () => {
         const matterAccessories: MatterAccessory[] = [
           {
@@ -565,10 +594,17 @@ describe('homebridgeAPI', () => {
         expect(matter.deviceTypes.ExtendedColorLight).toBeDefined()
         expect(matter.deviceTypes.OnOffOutlet).toBeDefined()
         expect(matter.deviceTypes.OnOffSwitch).toBeDefined()
+        expect(matter.deviceTypes.GenericSwitch).toBeDefined()
         expect(matter.deviceTypes.DoorLock).toBeDefined()
         expect(matter.deviceTypes.Thermostat).toBeDefined()
         expect(matter.deviceTypes.WindowCovering).toBeDefined()
         expect(matter.deviceTypes.Fan).toBeDefined()
+      })
+
+      it('should expose GenericSwitch as a Matter EndpointType object', () => {
+        expect(typeof matter.deviceTypes.GenericSwitch).toBe('object')
+        expect(Array.isArray(matter.deviceTypes.GenericSwitch)).toBe(false)
+        expect(typeof matter.deviceTypes.GenericSwitch.deviceType).toBe('number')
       })
 
       it('should include specialized device types', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -248,8 +248,8 @@ export interface MatterAPI {
   readonly uuid: HAP['uuid']
 
   /**
-   * Matter device types for creating accessories
-   * Maps friendly names to Matter.js device types
+   * Matter device types for creating accessories.
+   * Maps friendly names to Matter.js device types, including stateless controller types like `GenericSwitch`.
    */
   readonly deviceTypes: typeof deviceTypes
 

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -64,7 +64,7 @@ export function validateAccessoryRequiredFields(accessory: MatterAccessory): voi
     throw new MatterDeviceError(
       `Matter accessory "${accessory.displayName || 'unknown'}" is missing required field 'deviceType'. `
       + 'Example: deviceType: api.matter!.deviceTypes.OnOffLight\n'
-      + 'Available device types: OnOffLight, DimmableLight, TemperatureSensor, etc.\n'
+      + 'Available device types: OnOffLight, DimmableLight, GenericSwitch, TemperatureSensor, etc.\n'
       + 'See the Matter types documentation for the full list.',
     )
   }


### PR DESCRIPTION
### Summary

Exposes the Matter Generic Switch device type (`0x000F`) through Homebridge's `api.matter.deviceTypes` so plugin developers can correctly model stateless button remotes (e.g. Pico remotes, scene controllers) without resorting to `OnOffSwitch` or other persistent-state device types.

`GenericSwitch` was already imported and wired internally in `src/matter/types.ts` but was not surfaced with tests, type documentation, or user-facing guidance. This PR completes first-class support.

---

### Changes

#### `src/api.ts`
Updated the `MatterAPI.deviceTypes` JSDoc to explicitly mention `GenericSwitch` as a supported stateless controller type.

#### `src/matter/serverHelpers.ts`
Updated the validation error hint message to include `GenericSwitch` in the available device types example string shown to plugin developers when `deviceType` is missing.

#### `src/api.spec.ts`
Added three new test assertions:

1. **Registration test** — registers a stateless remote accessory with `deviceType: matter.deviceTypes.GenericSwitch` and verifies it routes through the normal platform registration path (`REGISTER_MATTER_PLATFORM_ACCESSORIES`), not the external bridge path.
2. **Existence assertion** — `matter.deviceTypes.GenericSwitch` is defined in the `should include common device types` block alongside `OnOffSwitch`, `DoorLock`, etc.
3. **Shape assertion** — `GenericSwitch` is an object (not an array), and its `deviceType` property is a number, confirming it is a proper `EndpointType` and not a bare numeric ID.

---

### Plugin usage

```ts
const accessory: MatterAccessory = {
  UUID: api.matter.uuid.generate('pico-remote-1'),
  displayName: 'Pico Remote',
  deviceType: api.matter.deviceTypes.GenericSwitch,
  serialNumber: 'PICO-001',
  manufacturer: 'Lutron',
  model: 'PJ2-3BRL',
  clusters: {
    switch: {
      currentPosition: 0,
      numberOfPositions: 3,
    },
  },
  handlers: {
    switch: {
      initialPress: async (args) => {
        // args.newPosition indicates which button was pressed
        log.info(`Button ${args.newPosition} pressed`)
      },
    },
  },
  context: {},
}

await api.matter.registerPlatformAccessories('homebridge-my-plugin', 'MyPlatform', [accessory])
```

`GenericSwitch` routes through the normal shared bridge path — no dedicated external server setup is needed.

---

### Test results

```
Test Files  45 passed (45)
     Tests  734 passed (734)
  Duration  4.00s
```

Lint: ✅ passing
Build: ✅ passing
Homebridge startup: ✅ QR code and pairing info displayed

---

### Notes

- No existing device type exports were modified or removed — fully backward compatible.
- `GenericSwitch` maps to `@matter/main/devices/generic-switch` → `GenericSwitchDevice` (Matter spec device type ID `0x000F`).
- Does **not** require an external dedicated bridge (unlike `RoboticVacuumCleaner`). If future use cases require standalone exposure, `GenericSwitch` can be added to `EXTERNAL_DEVICE_TYPES` in `src/matter/MatterAPIImpl.ts`.
- Generated HTML docs in `docs/` will be regenerated from TypeDoc on the next documentation build and are not committed here.