### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - chore: dependency updates
 - fix: disable hap publishing on child bridges
 - fix: drop legacy request type aliases removed in matter v0.17.x
+- fix: keep accessory listeners attached during teardown
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to `homebridge` will be documented in this file. This projec
 ### Changes
 
 - docs: add `CLAUDE.md` to repo
+- feat: expose `hap` flag on child bridge metadata
+
+### Homebridge Dependencies
+
+- `@homebridge/hap-nodejs` @ `v2.1.4`
 
 ## v2.0.0 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 
 - docs: add `CLAUDE.md` to repo
 - feat: expose `hap` flag on child bridge metadata
+- chore: dependency updates
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat: expose `hap` flag on child bridge metadata
 - chore: dependency updates
 - fix: disable hap publishing on child bridges
+- fix: drop legacy request type aliases removed in matter v0.17.x
 
 ### Homebridge Dependencies
 
-- `@homebridge/hap-nodejs` @ `v2.1.4`
+- `@homebridge/hap-nodejs` @ `v2.1.5`
 
 ## v2.0.0 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - docs: add `CLAUDE.md` to repo
 - feat: expose `hap` flag on child bridge metadata
 - chore: dependency updates
+- fix: disable hap publishing on child bridges
 
 ### Homebridge Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/hap-nodejs": "2.1.4",
+        "@homebridge/hap-nodejs": "2.1.5-beta.0",
         "@matter/main": "0.17.0-alpha.0-20260504-3d4995178",
         "chalk": "5.6.2",
         "commander": "14.0.3",
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@homebridge/hap-nodejs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.4.tgz",
-      "integrity": "sha512-Ko04stZCEj0iEjFzB+fiotVkcofOKjmCfCIdqM/HVVK7uZzAam6aszLUn8CWCLSxUQ4V5s5gwR8e3bUH/UDSVQ==",
+      "version": "2.1.5-beta.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.5-beta.0.tgz",
+      "integrity": "sha512-8ehm0TtLlBN0wK+cBVeC4a56rI6pgrH79PtZlP/etVfmEFuVPLSHWN4IbNTBd+5ObshLmjca6jKUL5XfbaQOJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.3.8",
@@ -1825,17 +1825,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1848,22 +1848,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1879,14 +1879,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1901,16 +1901,16 @@
       }
     },
     "node_modules/@typescript-eslint/rule-tester": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.59.1.tgz",
-      "integrity": "sha512-VAlTRylRP+zh2jepYylwEllQSI8yP0QWQqUKc3xcPbuSlnDeC0CjbpWAOp5CrqfGl9ZMGw74BjZnutb7mILOzA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.59.2.tgz",
+      "integrity": "sha512-u6yY503P7E76xIzIQw2R6FCJwwifh0fOJsOWtkpEPeUUVmUApi1Hdnahz5mKSqRDi5wUN+iiUBedM0qZ41owYw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "ajv": "^6.12.6",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "4.6.2",
@@ -1924,18 +1924,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1946,9 +1947,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1963,15 +1964,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1988,9 +1989,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2002,16 +2003,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2030,16 +2031,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2054,13 +2055,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6475,9 +6476,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/hap-nodejs": "2.1.5-beta.0",
-        "@matter/main": "0.17.0-alpha.0-20260504-3d4995178",
+        "@homebridge/hap-nodejs": "2.1.5",
+        "@matter/main": "0.17.0-alpha.0-20260505-f95da55d0",
         "chalk": "5.6.2",
         "commander": "14.0.3",
         "fs-extra": "11.3.4",
@@ -29,14 +29,14 @@
         "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
         "@types/source-map-support": "^0.5.10",
-        "@vitest/coverage-v8": "^4.1.4",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint-plugin-format": "^2.0.1",
         "nodemon": "^3.1.14",
         "rimraf": "^6.1.3",
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.19",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": "^22 || ^24"
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@homebridge/hap-nodejs": {
-      "version": "2.1.5-beta.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.5-beta.0.tgz",
-      "integrity": "sha512-8ehm0TtLlBN0wK+cBVeC4a56rI6pgrH79PtZlP/etVfmEFuVPLSHWN4IbNTBd+5ObshLmjca6jKUL5XfbaQOJg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.5.tgz",
+      "integrity": "sha512-KdEgMbxGEMie3OdK4MrcdS27e6WpctIrnC8PbQVquaaEZdwRfDGKDeeGXw9yw8+5s3XHP4gD0BnAiBpIhYAumA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.3.8",
@@ -751,86 +751,86 @@
       "license": "MIT"
     },
     "node_modules/@matter/general": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-G/ZdVizLDjdxT9Ggtegn4OQNkabDfRKg99ZRk3Nxj0x8VoMmABI8SygE6AWhJKbwNr6lDCGawKsmfqc9sTXcmA==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-szSQvwWTuepb1QLO+S5DOwjKz6b+enN/v68l0IK2kfDfkl/cATBrK5ZvcPUhj7qGmVQx9os/fIprTC6nWsliDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-JypA9UPxXD2bKt5BDNz/iZfKqEymHzm+fy1IaZvERFRibzkuAykf+aadxTEHBzpBQylmeOGAHl9+MpXvwph/OQ==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-JMr7bqATJRxpx8DGgHU6uXLP05xVZb83bPaNjwygiVxtypwBVffRf2o3fFqlFvq9z41vJNajb4qhD8A3JcTovg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/model": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/node": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/protocol": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/types": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/model": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/node": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/protocol": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/types": "0.17.0-alpha.0-20260505-f95da55d0"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/nodejs": "0.17.0-alpha.0-20260505-f95da55d0"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-SRKlKVjNtjzIPPJAvb5C9ggQg2BaZmzG04APe3SMy+ddBeEIdAEgMK24rxYTaR4mkAKnP7/ME7i95WxvAdv8qw==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-l1o6YEnrVP+aVYhhgIohYfJrk6IR7+LRnWFWUNw1ISRPadAHtmOqKYBlwhObhxQ1yuiL4vOn0LSCgnNYaoryjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-pFl2P0xkT+bizLMerq5Q4r/FcdY+ujvS4buI3FKTGs6jYTgNYrhsnhjJ7MqNVi0/yHm8Z3Bw5JFymvJgs1tEdg==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-RsYZKExioPqtGspcvqBny8lEf4ZCTLg2r1dyBsGbw/qSx8xbZQXqdhviBWMBRzunkWGAJo5JVPfWl85fvspJsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/model": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/protocol": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/types": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/model": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/protocol": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/types": "0.17.0-alpha.0-20260505-f95da55d0"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-bPViU7fOgoMSWDzsUdDXjqmxOcS5oxb4RwO1vLHSUEWkFjYzwNV8XKJtyWw+QI7FxIeAFcUsxAFguU5by6AKcQ==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-wCtCXcHJzVPBJJqyCY9yA27mk27dsjsT7vqOizwKQ3mZbUbHQa297Fp4NiOkFg15arm9pIdGQmtuuCZ99KbsCA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/node": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/protocol": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/types": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/node": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/protocol": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/types": "0.17.0-alpha.0-20260505-f95da55d0"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-yvQfWcMDMMl0xf3GeRvNIM5A9nWLo42CbKLpGfIrQkgicmrGa78yy2orNBF1zRoKpVC6+psYPOnWo1UBgWShMw==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-bMMpcr5OK4JDGiyWfO/axn8fbOufspyVrwCjnYnZc21z2BKaYkhoiwE09JaUopm7f2CBkScrJyJDV+JDR6yGAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/model": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/types": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/model": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/types": "0.17.0-alpha.0-20260505-f95da55d0"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.0-alpha.0-20260504-3d4995178",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260504-3d4995178.tgz",
-      "integrity": "sha512-MHVlPjgjTOcuOay2PQmMDto7lnuRFG6nt94j9O73n8JiZcR+wa6tYYGk3hcjpYXk3Uw2lYgdzEpiKZi+ZUfqjA==",
+      "version": "0.17.0-alpha.0-20260505-f95da55d0",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260505-f95da55d0.tgz",
+      "integrity": "sha512-48sWCfTiaBor7k5B9AOwPbNV1vtVLibv5GBzxZqczoQnAZbu9sXlmcikq6oBB29+d3V5b0wnCOpQ2AtJVudt3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260504-3d4995178",
-        "@matter/model": "0.17.0-alpha.0-20260504-3d4995178"
+        "@matter/general": "0.17.0-alpha.0-20260505-f95da55d0",
+        "@matter/model": "0.17.0-alpha.0-20260505-f95da55d0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3657,9 +3657,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
-      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+      "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3677,7 +3677,7 @@
         "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "vue-eslint-parser": "^10.0.0"
+        "vue-eslint-parser": "^10.3.0"
       },
       "peerDependenciesMeta": {
         "@stylistic/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "watch": "nodemon"
   },
   "dependencies": {
-    "@homebridge/hap-nodejs": "2.1.4",
+    "@homebridge/hap-nodejs": "2.1.5-beta.0",
     "@matter/main": "0.17.0-alpha.0-20260504-3d4995178",
     "chalk": "5.6.2",
     "commander": "14.0.3",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "watch": "nodemon"
   },
   "dependencies": {
-    "@homebridge/hap-nodejs": "2.1.5-beta.0",
-    "@matter/main": "0.17.0-alpha.0-20260504-3d4995178",
+    "@homebridge/hap-nodejs": "2.1.5",
+    "@matter/main": "0.17.0-alpha.0-20260505-f95da55d0",
     "chalk": "5.6.2",
     "commander": "14.0.3",
     "fs-extra": "11.3.4",
@@ -65,13 +65,13 @@
     "@types/node": "^25.6.0",
     "@types/semver": "^7.7.1",
     "@types/source-map-support": "^0.5.10",
-    "@vitest/coverage-v8": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint-plugin-format": "^2.0.1",
     "nodemon": "^3.1.14",
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.5"
   }
 }

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -289,8 +289,8 @@ describe('bridgeService', () => {
     })
   })
 
-  describe('teardown — listener cleanup (M1 fix)', () => {
-    it('removes all four InternalAPIEvent listeners on teardown', () => {
+  describe('teardown', () => {
+    it('keeps the four InternalAPIEvent listeners attached so plugin shutdown handlers can still persist updates', () => {
       const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
       // Stub the network-touching parts of teardown.
       vi.spyOn(service.bridge, 'unpublish').mockResolvedValue(undefined)
@@ -305,10 +305,15 @@ describe('bridgeService', () => {
 
       service.teardown()
 
-      expect(api.listenerCount(InternalAPIEvent.REGISTER_PLATFORM_ACCESSORIES)).toBe(before.register - 1)
-      expect(api.listenerCount(InternalAPIEvent.UPDATE_PLATFORM_ACCESSORIES)).toBe(before.update - 1)
-      expect(api.listenerCount(InternalAPIEvent.UNREGISTER_PLATFORM_ACCESSORIES)).toBe(before.unregister - 1)
-      expect(api.listenerCount(InternalAPIEvent.PUBLISH_EXTERNAL_ACCESSORIES)).toBe(before.publishExt - 1)
+      // Listeners must remain attached: plugins commonly call
+      // api.updatePlatformAccessories() from inside their `shutdown`
+      // listener (often after async cleanup), and that call relies on
+      // handleUpdatePlatformAccessories firing to write context updates
+      // to disk.
+      expect(api.listenerCount(InternalAPIEvent.REGISTER_PLATFORM_ACCESSORIES)).toBe(before.register)
+      expect(api.listenerCount(InternalAPIEvent.UPDATE_PLATFORM_ACCESSORIES)).toBe(before.update)
+      expect(api.listenerCount(InternalAPIEvent.UNREGISTER_PLATFORM_ACCESSORIES)).toBe(before.unregister)
+      expect(api.listenerCount(InternalAPIEvent.PUBLISH_EXTERNAL_ACCESSORIES)).toBe(before.publishExt)
     })
 
     it('signals shutdown on the api', () => {
@@ -319,6 +324,24 @@ describe('bridgeService', () => {
       service.teardown()
 
       expect(signalSpy).toHaveBeenCalled()
+    })
+
+    it('signals shutdown after persisting cached accessories so plugin updatePlatformAccessories calls during shutdown can still write to disk', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
+      vi.spyOn(service.bridge, 'unpublish').mockResolvedValue(undefined)
+
+      const order: string[] = []
+      vi.spyOn(service, 'saveCachedPlatformAccessoriesOnDisk').mockImplementation(() => {
+        order.push('save')
+      })
+      vi.spyOn(api, 'signalShutdown').mockImplementation(() => {
+        order.push('signal')
+        return undefined as never
+      })
+
+      service.teardown()
+
+      expect(order).toEqual(['save', 'signal'])
     })
   })
 

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -245,6 +245,26 @@ describe('bridgeService', () => {
       // Re-publish the same accessory — same UUID → same advertise-address → collision
       await expect(service.handlePublishExternalAccessories([a])).rejects.toThrow(/address collision/)
     })
+
+    it('skips publishing external accessories when HAP is disabled', async () => {
+      const service = new BridgeService(
+        api,
+        pluginManager,
+        externalPortService,
+        makeBridgeOptions(),
+        makeBridgeConfig({ hap: false }),
+      )
+
+      const a = makePlatformAccessory('External-A')
+      const publishSpy = vi.spyOn(a._associatedHAPAccessory, 'publish').mockResolvedValue(undefined)
+
+      await service.handlePublishExternalAccessories([a])
+
+      // Should not attempt to publish when hap is false
+      expect(publishSpy).not.toHaveBeenCalled()
+      // Should not request a port either
+      expect(externalPortService.requestPort).not.toHaveBeenCalled()
+    })
   })
 
   describe('createHAPAccessory', () => {

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -461,6 +461,12 @@ export class BridgeService {
   }
 
   async handlePublishExternalAccessories(accessories: PlatformAccessory[]): Promise<void> {
+    // HAP must be enabled to publish external accessories
+    if (this.bridgeConfig.hap === false) {
+      log.debug('Skipping external accessory HAP publish: HAP is disabled for this bridge (bridgeConfig.hap=false).')
+      return
+    }
+
     const accessoryPin = this.bridgeConfig.pin
 
     for (const accessory of accessories) {

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -144,21 +144,6 @@ export class BridgeService {
   private cachedAccessoriesFileLoaded = false
   private readonly publishedExternalAccessories: Map<MacAddress, PlatformAccessory> = new Map()
 
-  // Stored listener references so they can be removed in teardown(),
-  // matching the pattern used by MatterBridgeManager (#3915).
-  private readonly _onRegisterPlatformAccessories = (accessories: PlatformAccessory[]): void =>
-    this.handleRegisterPlatformAccessories(accessories)
-
-  private readonly _onUpdatePlatformAccessories = (accessories: PlatformAccessory[]): void =>
-    this.handleUpdatePlatformAccessories(accessories)
-
-  private readonly _onUnregisterPlatformAccessories = (accessories: PlatformAccessory[]): void =>
-    this.handleUnregisterPlatformAccessories(accessories)
-
-  private readonly _onPublishExternalAccessories = (accessories: PlatformAccessory[]): void => {
-    void this.handlePublishExternalAccessories(accessories)
-  }
-
   constructor(
     private api: HomebridgeAPI,
     private pluginManager: PluginManager,
@@ -176,10 +161,10 @@ export class BridgeService {
     // bridged accessories, like changing characteristics (i.e. flipping your lights on and off).
     this.allowInsecureAccess = this.bridgeOptions.insecureAccess || false
 
-    this.api.on(InternalAPIEvent.REGISTER_PLATFORM_ACCESSORIES, this._onRegisterPlatformAccessories)
-    this.api.on(InternalAPIEvent.UPDATE_PLATFORM_ACCESSORIES, this._onUpdatePlatformAccessories)
-    this.api.on(InternalAPIEvent.UNREGISTER_PLATFORM_ACCESSORIES, this._onUnregisterPlatformAccessories)
-    this.api.on(InternalAPIEvent.PUBLISH_EXTERNAL_ACCESSORIES, this._onPublishExternalAccessories)
+    this.api.on(InternalAPIEvent.REGISTER_PLATFORM_ACCESSORIES, this.handleRegisterPlatformAccessories.bind(this))
+    this.api.on(InternalAPIEvent.UPDATE_PLATFORM_ACCESSORIES, this.handleUpdatePlatformAccessories.bind(this))
+    this.api.on(InternalAPIEvent.UNREGISTER_PLATFORM_ACCESSORIES, this.handleUnregisterPlatformAccessories.bind(this))
+    this.api.on(InternalAPIEvent.PUBLISH_EXTERNAL_ACCESSORIES, this.handlePublishExternalAccessories.bind(this))
 
     this.bridge = new Bridge(bridgeConfig.name, uuid.generate('HomeBridge'))
     this.bridge.on(AccessoryEventTypes.CHARACTERISTIC_WARNING, () => {
@@ -596,12 +581,6 @@ export class BridgeService {
   }
 
   teardown(): void {
-    // Remove API event listeners to prevent retention of this service after teardown.
-    this.api.removeListener(InternalAPIEvent.REGISTER_PLATFORM_ACCESSORIES, this._onRegisterPlatformAccessories)
-    this.api.removeListener(InternalAPIEvent.UPDATE_PLATFORM_ACCESSORIES, this._onUpdatePlatformAccessories)
-    this.api.removeListener(InternalAPIEvent.UNREGISTER_PLATFORM_ACCESSORIES, this._onUnregisterPlatformAccessories)
-    this.api.removeListener(InternalAPIEvent.PUBLISH_EXTERNAL_ACCESSORIES, this._onPublishExternalAccessories)
-
     void this.bridge.unpublish()
     for (const accessory of this.publishedExternalAccessories.values()) {
       void accessory._associatedHAPAccessory.unpublish()
@@ -609,6 +588,11 @@ export class BridgeService {
 
     this.saveCachedPlatformAccessoriesOnDisk()
 
+    // signalShutdown fires last so plugin shutdown listeners run with the
+    // UPDATE_PLATFORM_ACCESSORIES handler still attached. Plugins may do
+    // async cleanup (e.g. cancelling subscriptions on exposed devices) and
+    // call api.updatePlatformAccessories() afterwards; that call needs the
+    // handler in place to persist any context updates to disk.
     this.api.signalShutdown()
   }
 

--- a/src/childBridgeFork.spec.ts
+++ b/src/childBridgeFork.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PluginType } from './api.js'
 import { ChildBridgeFork } from './childBridgeFork.js'
+import { ChildProcessMessageEventType } from './childBridgeService.js'
 
 describe('childBridgeFork - Matter Accessory Guard', () => {
   it('should not have matterManager when type is ACCESSORY even with matter config', () => {
@@ -67,6 +68,7 @@ describe('childBridgeFork - Matter Handlers', () => {
       collectAllAccessories: vi.fn(),
       getAccessoryInfo: vi.fn(),
       handleTriggerCommand: vi.fn(),
+      getMatterStatusInfo: vi.fn(() => undefined),
     }
 
     // Set the matter manager on the instance
@@ -163,6 +165,85 @@ describe('childBridgeFork - Matter Handlers', () => {
       ;(childBridgeFork as any).matterMessageHandler = undefined
 
       expect(() => childBridgeFork.handleMatterAccessoryControl(mockControlData)).not.toThrow()
+    })
+  })
+
+  describe('sendPairedStatusEvent', () => {
+    it('does not call setupURI when bridge is not published', () => {
+      const sendMessageSpy = vi.fn()
+      const setupURISpy = vi.fn(() => {
+        throw new Error('should not be called')
+      })
+
+      ;(childBridgeFork as any).sendMessage = sendMessageSpy
+      ;(childBridgeFork as any).bridgeService = {
+        bridge: {
+          setupURI: setupURISpy,
+          _accessoryInfo: undefined,
+        },
+      }
+
+      childBridgeFork.sendPairedStatusEvent()
+
+      expect(setupURISpy).not.toHaveBeenCalled()
+      expect(sendMessageSpy).toHaveBeenCalledWith(ChildProcessMessageEventType.STATUS_UPDATE, {
+        paired: null,
+        setupUri: null,
+      })
+    })
+
+    it('includes paired and setupUri when bridge is published', () => {
+      const sendMessageSpy = vi.fn()
+
+      ;(childBridgeFork as any).sendMessage = sendMessageSpy
+      ;(childBridgeFork as any).bridgeService = {
+        bridge: {
+          setupURI: vi.fn(() => 'X-HM://abc'),
+          _accessoryInfo: {
+            paired: vi.fn(() => true),
+          },
+        },
+      }
+
+      childBridgeFork.sendPairedStatusEvent()
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(ChildProcessMessageEventType.STATUS_UPDATE, {
+        paired: true,
+        setupUri: 'X-HM://abc',
+      })
+    })
+
+    it('includes matter status even when HAP is unpublished', () => {
+      const sendMessageSpy = vi.fn()
+
+      ;(childBridgeFork as any).sendMessage = sendMessageSpy
+      ;(childBridgeFork as any).bridgeService = {
+        bridge: {
+          setupURI: vi.fn(() => 'X-HM://abc'),
+          _accessoryInfo: undefined,
+        },
+      }
+      ;(childBridgeFork as any).matterManager = {
+        getMatterStatusInfo: vi.fn(() => ({
+          qrCode: 'MT:ABCD',
+          manualPairingCode: '12345-67890',
+          serialNumber: 'SN-1',
+          commissioned: false,
+        })),
+      }
+
+      childBridgeFork.sendPairedStatusEvent()
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(ChildProcessMessageEventType.STATUS_UPDATE, {
+        paired: null,
+        setupUri: null,
+        matter: {
+          qrCode: 'MT:ABCD',
+          manualPairingCode: '12345-67890',
+          serialNumber: 'SN-1',
+          commissioned: false,
+        },
+      })
     })
   })
 })

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -259,13 +259,13 @@ export class ChildBridgeFork {
       this.matterManager.restoreCachedAccessories(this.bridgeOptions.keepOrphanedCachedAccessories ?? false)
     }
 
-    // Publish HAP only when not opted out via _bridge.hap=false. The
+    // Publish HAP only when not opted out via bridgeConfig.hap=false. The
     // protocol-enablement check in Server.validateChildBridgeConfig has
     // already guaranteed at least one of HAP or Matter is on for this bridge.
     if (this.bridgeConfig.hap !== false) {
       this.bridgeService.publishBridge()
     } else {
-      Logger.internal.info('HAP is disabled for this child bridge (_bridge.hap=false); skipping HAP publish.')
+      Logger.internal.info('HAP is disabled for this child bridge (bridgeConfig.hap=false); skipping HAP publish.')
     }
     this.api.signalFinished()
 
@@ -350,10 +350,11 @@ export class ChildBridgeFork {
   public sendPairedStatusEvent() {
     // Get Matter commissioning info if Matter is enabled
     const matterInfo = this.matterManager?.getMatterStatusInfo()
+    const isPublished = !!this.bridgeService?.bridge?._accessoryInfo
 
     this.sendMessage<ChildBridgePairedStatusEventData>(ChildProcessMessageEventType.STATUS_UPDATE, {
-      paired: this.bridgeService?.bridge?._accessoryInfo?.paired() ?? null,
-      setupUri: this.bridgeService?.bridge?.setupURI() ?? null,
+      paired: isPublished ? (this.bridgeService?.bridge?._accessoryInfo?.paired() ?? null) : null,
+      setupUri: isPublished ? (this.bridgeService?.bridge?.setupURI() ?? null) : null,
       // Include Matter commissioning info in unified message
       ...(matterInfo && { matter: matterInfo }),
     })

--- a/src/childBridgeService.spec.ts
+++ b/src/childBridgeService.spec.ts
@@ -674,5 +674,72 @@ describe('childBridgeService', () => {
       expect(metadata.matterConfig).toBeUndefined()
       expect(metadata.matterIdentifier).toBeUndefined()
     })
+
+    it('reflects hap:false in metadata when HAP is disabled', () => {
+      const { service } = buildService({
+        bridgeConfig: makeBridgeConfig({ hap: false, matter: { port: 5540 } }),
+      })
+      const metadata = service.getMetadata()
+      expect(metadata.hap).toBe(false)
+    })
+
+    it('reflects hap:true in metadata when HAP is explicitly enabled', () => {
+      const { service } = buildService({
+        bridgeConfig: makeBridgeConfig({ hap: true }),
+      })
+      const metadata = service.getMetadata()
+      expect(metadata.hap).toBe(true)
+    })
+
+    it('reflects hap as undefined in metadata when not set (defaults enabled)', () => {
+      const { service } = buildService()
+      const metadata = service.getMetadata()
+      expect(metadata.hap).toBeUndefined()
+    })
+  })
+
+  describe('loadPlugin — hap property forwarded in LOAD message', () => {
+    it('includes hap:false in LOAD bridgeConfig when HAP is disabled', () => {
+      const { service } = buildService({
+        bridgeConfig: makeBridgeConfig({ hap: false, matter: { port: 5540 } }),
+      })
+      service.addConfig({ platform: 'TestPlatform', name: 'X' } as any)
+      service.start()
+      const child = childProcesses.list[0]
+
+      child.emit('message', { id: ChildProcessMessageEventType.READY })
+
+      const loadMessage = child.sentMessages.find(m => m.id === ChildProcessMessageEventType.LOAD)
+      expect(loadMessage).toBeDefined()
+      expect(loadMessage.data.bridgeConfig.hap).toBe(false)
+    })
+
+    it('includes hap:false alongside matter config in LOAD bridgeConfig', () => {
+      const { service } = buildService({
+        bridgeConfig: makeBridgeConfig({ hap: false, matter: { port: 5540 } }),
+      })
+      service.addConfig({ platform: 'TestPlatform', name: 'X' } as any)
+      service.start()
+      const child = childProcesses.list[0]
+
+      child.emit('message', { id: ChildProcessMessageEventType.READY })
+
+      const loadMessage = child.sentMessages.find(m => m.id === ChildProcessMessageEventType.LOAD)
+      expect(loadMessage.data.bridgeConfig.hap).toBe(false)
+      expect(loadMessage.data.bridgeConfig.matter).toEqual({ port: 5540 })
+    })
+
+    it('does not set hap in LOAD bridgeConfig when not configured (default enabled)', () => {
+      const { service } = buildService()
+      service.addConfig({ platform: 'TestPlatform', name: 'X' } as any)
+      service.start()
+      const child = childProcesses.list[0]
+
+      child.emit('message', { id: ChildProcessMessageEventType.READY })
+
+      const loadMessage = child.sentMessages.find(m => m.id === ChildProcessMessageEventType.LOAD)
+      expect(loadMessage).toBeDefined()
+      expect(loadMessage.data.bridgeConfig.hap).toBeUndefined()
+    })
   })
 })

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -561,6 +561,7 @@ export class ChildBridgeService {
       model: this.bridgeConfig.model || this.homebridgeConfig.bridge.model,
       firmwareRevision: this.bridgeConfig.firmwareRevision || this.homebridgeConfig.bridge.firmwareRevision,
       serialNumber: this.bridgeConfig.serialNumber || this.bridgeConfig.username,
+      hap: this.bridgeConfig.hap,
       matter: this.bridgeConfig.matter,
     }
 

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -187,6 +187,7 @@ export interface ChildMetadata {
   identifier: string
   manuallyStopped: boolean
   pid?: number
+  hap?: boolean
   matterConfig?: MatterConfig
   matterIdentifier?: string
   matterSetupUri?: string
@@ -747,6 +748,7 @@ export class ChildBridgeService {
       identifier: this.identifier,
       pid: this.child?.pid,
       manuallyStopped: this.manuallyStopped,
+      hap: this.bridgeConfig.hap,
       matterConfig: this.bridgeConfig.matter,
       matterIdentifier: this.bridgeConfig.matter ? this.bridgeConfig.username : undefined,
       matterSetupUri: this.matterCommissioningInfo?.qrCode,

--- a/src/matter/index.ts
+++ b/src/matter/index.ts
@@ -145,19 +145,9 @@ export namespace MatterRequests {
   export type SetUser = DoorLock.SetUserRequest
   export type GetUser = DoorLock.GetUserRequest
   export type ClearUser = DoorLock.ClearUserRequest
-  export type SetUserStatus = DoorLock.SetUserStatusRequest
-  export type GetUserStatus = DoorLock.GetUserStatusRequest
-  export type SetUserType = DoorLock.SetUserTypeRequest
-  export type GetUserType = DoorLock.GetUserTypeRequest
   export type SetCredential = DoorLock.SetCredentialRequest
   export type GetCredentialStatus = DoorLock.GetCredentialStatusRequest
   export type ClearCredential = DoorLock.ClearCredentialRequest
-  export type SetPinCode = DoorLock.SetPinCodeRequest
-  export type GetPinCode = DoorLock.GetPinCodeRequest
-  export type ClearPinCode = DoorLock.ClearPinCodeRequest
-  export type SetRfidCode = DoorLock.SetRfidCodeRequest
-  export type GetRfidCode = DoorLock.GetRfidCodeRequest
-  export type ClearRfidCode = DoorLock.ClearRfidCodeRequest
   export type SetWeekDaySchedule = DoorLock.SetWeekDayScheduleRequest
   export type GetWeekDaySchedule = DoorLock.GetWeekDayScheduleRequest
   export type ClearWeekDaySchedule = DoorLock.ClearWeekDayScheduleRequest
@@ -174,8 +164,6 @@ export namespace MatterRequests {
   // ============================================================================
   export type GoToLiftPercentage = WindowCovering.GoToLiftPercentageRequest
   export type GoToTiltPercentage = WindowCovering.GoToTiltPercentageRequest
-  export type GoToLiftValue = WindowCovering.GoToLiftValueRequest
-  export type GoToTiltValue = WindowCovering.GoToTiltValueRequest
 
   // ============================================================================
   // Thermostat Cluster (§9.1)
@@ -183,8 +171,6 @@ export namespace MatterRequests {
   export type SetpointRaiseLower = Thermostat.SetpointRaiseLowerRequest
   export type SetActivePreset = Thermostat.SetActivePresetRequest
   export type SetActiveSchedule = Thermostat.SetActiveScheduleRequest
-  export type GetWeeklySchedule = Thermostat.GetWeeklyScheduleRequest
-  export type SetWeeklySchedule = Thermostat.SetWeeklyScheduleRequest
 
   // ============================================================================
   // Fan Control Cluster (§4.4)


### PR DESCRIPTION
### Changes

- docs: add `CLAUDE.md` to repo
- feat: expose `hap` flag on child bridge metadata
- chore: dependency updates
- fix: disable hap publishing on child bridges
- fix: drop legacy request type aliases removed in matter v0.17.x
- fix: keep accessory listeners attached during teardown

### Homebridge Dependencies

- `@homebridge/hap-nodejs` @ `v2.1.5`