### PR TITLE
fix: preserve concurrent accessory registration during cache restore (#3919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): make water valve open/close commands work
 - feat(matter): map valve commands for ui control
 - chore(ci): bump actions/setup-node to v7
+- fix: preserve concurrent accessory registration during cache restore (#3919) (@zerafachris)
 
 ### Homebridge Dependencies
 

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -255,8 +255,23 @@ describe('bridgeService', () => {
   describe('restoreCachedPlatformAccessories', () => {
     it('does not discard a registerPlatformAccessories() call made synchronously from configureAccessory()', () => {
       const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
-      vi.spyOn(service.bridge, 'addBridgedAccessory').mockImplementation(accessory => accessory)
-      vi.spyOn(service.bridge, 'addBridgedAccessories').mockImplementation(() => {})
+
+      // Mirror HAP-NodeJS: adding the same accessory (by UUID) to the bridge a
+      // second time throws. If the restore loop wrongly re-visits an accessory
+      // registered mid-restore, this mock surfaces it instead of hiding it.
+      const bridgedUuids = new Set<string>()
+      vi.spyOn(service.bridge, 'addBridgedAccessory').mockImplementation((accessory: any) => {
+        if (bridgedUuids.has(accessory.UUID)) {
+          throw new Error(`Cannot add a bridged Accessory with the same UUID as another bridged Accessory: ${accessory.UUID}`)
+        }
+        bridgedUuids.add(accessory.UUID)
+        return accessory
+      })
+      vi.spyOn(service.bridge, 'addBridgedAccessories').mockImplementation((accessories: any) => {
+        for (const accessory of accessories) {
+          service.bridge.addBridgedAccessory(accessory)
+        }
+      })
 
       const cachedA = makePlatformAccessory('A')
       const cachedB = makePlatformAccessory('B')
@@ -284,6 +299,47 @@ describe('bridgeService', () => {
       expect(cached).toContain(cachedA)
       expect(cached).toContain(cachedB)
       expect(cached).toContain(companion)
+
+      // configureAccessory is only for restoring cached accessories — the
+      // companion was registered by the plugin itself and must not be handed
+      // back through configureAccessory or bridged a second time.
+      expect(platform.configureAccessory).toHaveBeenCalledTimes(2)
+      expect(platform.configureAccessory).not.toHaveBeenCalledWith(companion)
+    })
+
+    it('does not restore an accessory unregistered synchronously from an earlier configureAccessory()', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
+      vi.spyOn(service.bridge, 'addBridgedAccessory').mockImplementation(accessory => accessory)
+      vi.spyOn(service.bridge, 'removeBridgedAccessories').mockImplementation(() => {})
+
+      const cachedA = makePlatformAccessory('A')
+      const cachedB = makePlatformAccessory('B')
+      const cachedC = makePlatformAccessory('C')
+      ;(service as any).cachedPlatformAccessories = [cachedA, cachedB, cachedC]
+
+      // A plugin may decide during restore that a cached accessory is stale and
+      // unregister it before the loop reaches it. The loop must neither
+      // configure/bridge the removed accessory nor skip over its neighbours.
+      const platform = {
+        configureAccessory: vi.fn((accessory: any) => {
+          if (accessory === cachedA) {
+            service.handleUnregisterPlatformAccessories([cachedB])
+          }
+        }),
+      }
+      pluginManager.getPlugin.mockReturnValue({
+        getActiveDynamicPlatform: () => platform,
+      })
+
+      service.restoreCachedPlatformAccessories()
+
+      const cached = (service as any).cachedPlatformAccessories
+      expect(cached).toContain(cachedA)
+      expect(cached).not.toContain(cachedB)
+      expect(cached).toContain(cachedC)
+      expect(platform.configureAccessory).toHaveBeenCalledWith(cachedA)
+      expect(platform.configureAccessory).toHaveBeenCalledWith(cachedC)
+      expect(platform.configureAccessory).not.toHaveBeenCalledWith(cachedB)
     })
 
     it('does not discard an updatePlatformAccessories() call made synchronously from configureAccessory()', () => {

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -252,6 +252,88 @@ describe('bridgeService', () => {
     })
   })
 
+  describe('restoreCachedPlatformAccessories', () => {
+    it('does not discard a registerPlatformAccessories() call made synchronously from configureAccessory()', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
+      vi.spyOn(service.bridge, 'addBridgedAccessory').mockImplementation(accessory => accessory)
+      vi.spyOn(service.bridge, 'addBridgedAccessories').mockImplementation(() => {})
+
+      const cachedA = makePlatformAccessory('A')
+      const cachedB = makePlatformAccessory('B')
+      ;(service as any).cachedPlatformAccessories = [cachedA, cachedB]
+
+      // A dynamic platform commonly registers a brand new companion accessory
+      // (e.g. a linked sensor) from within its configureAccessory() callback,
+      // which restoreCachedPlatformAccessories() invokes synchronously while
+      // it is still iterating the cached accessory list.
+      const companion = makePlatformAccessory('Companion')
+      const platform = {
+        configureAccessory: vi.fn((accessory: any) => {
+          if (accessory === cachedA) {
+            service.handleRegisterPlatformAccessories([companion])
+          }
+        }),
+      }
+      pluginManager.getPlugin.mockReturnValue({
+        getActiveDynamicPlatform: () => platform,
+      })
+
+      service.restoreCachedPlatformAccessories()
+
+      const cached = (service as any).cachedPlatformAccessories
+      expect(cached).toContain(cachedA)
+      expect(cached).toContain(cachedB)
+      expect(cached).toContain(companion)
+    })
+
+    it('does not discard an updatePlatformAccessories() call made synchronously from configureAccessory()', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
+      vi.spyOn(service.bridge, 'addBridgedAccessory').mockImplementation(accessory => accessory)
+
+      const cachedA = makePlatformAccessory('A')
+      const cachedB = makePlatformAccessory('B')
+      ;(service as any).cachedPlatformAccessories = [cachedA, cachedB]
+
+      // A dynamic platform may replace a cached accessory wholesale (e.g. to
+      // add/remove a service) by handing a new PlatformAccessory instance to
+      // api.updatePlatformAccessories() with the same UUID, from within
+      // configureAccessory().
+      const replacementA = makePlatformAccessory('A-updated')
+      ;(replacementA as any)._associatedHAPAccessory.UUID = cachedA._associatedHAPAccessory.UUID
+      ;(replacementA as any).UUID = cachedA._associatedHAPAccessory.UUID
+      const platform = {
+        configureAccessory: vi.fn((accessory: any) => {
+          if (accessory === cachedA) {
+            service.handleUpdatePlatformAccessories([replacementA])
+          }
+        }),
+      }
+      pluginManager.getPlugin.mockReturnValue({
+        getActiveDynamicPlatform: () => platform,
+      })
+
+      service.restoreCachedPlatformAccessories()
+
+      const cached = (service as any).cachedPlatformAccessories
+      expect(cached).toContain(replacementA)
+      expect(cached).not.toContain(cachedA)
+      expect(cached).toContain(cachedB)
+    })
+
+    it('still drops orphaned accessories when keepOrphanedCachedAccessories is false', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions({ keepOrphanedCachedAccessories: false }), makeBridgeConfig())
+      pluginManager.getPlugin.mockReturnValue(undefined)
+      pluginManager.getPluginByActiveDynamicPlatform.mockReturnValue(undefined)
+
+      const orphan = makePlatformAccessory('Orphan')
+      ;(service as any).cachedPlatformAccessories = [orphan]
+
+      service.restoreCachedPlatformAccessories()
+
+      expect((service as any).cachedPlatformAccessories).toHaveLength(0)
+    })
+  })
+
   describe('handlePublishExternalAccessories', () => {
     it('allocates a port for each external accessory', async () => {
       externalPortService.requestPort.mockResolvedValue(50000)

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -452,11 +452,20 @@ export class BridgeService {
     // reassigning `this.cachedPlatformAccessories` to the filtered result of the *original*
     // pre-iteration array, which silently discarded any such concurrent mutation. Instead,
     // we iterate a snapshot of the original list and only remove orphaned accessories from
-    // whatever `this.cachedPlatformAccessories` holds once iteration has finished.
-    const accessoriesToRestore = this.cachedPlatformAccessories
+    // whatever `this.cachedPlatformAccessories` holds once iteration has finished. The
+    // snapshot must be a copy — `handleRegisterPlatformAccessories()` pushes into the live
+    // array, and a `for...of` over the live array would visit those new accessories and
+    // configure/bridge them a second time.
+    const accessoriesToRestore = [...this.cachedPlatformAccessories]
     const orphanedAccessories = new Set<PlatformAccessory>()
 
     for (const accessory of accessoriesToRestore) {
+      // Skip accessories the plugin unregistered from an earlier configureAccessory()
+      // call in this same loop — they are already off the bridge and out of the cache.
+      if (!this.cachedPlatformAccessories.includes(accessory)) {
+        continue
+      }
+
       let plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!)
       if (!plugin) { // a little explainer here. This section is basically here to resolve plugin name changes of dynamic platform plugins
         try {

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -443,7 +443,20 @@ export class BridgeService {
   }
 
   public restoreCachedPlatformAccessories(): void {
-    this.cachedPlatformAccessories = this.cachedPlatformAccessories.filter((accessory) => {
+    // NOTE: `platformPlugins.configureAccessory(accessory)` below runs plugin code
+    // synchronously, and plugins commonly call `api.registerPlatformAccessories()`,
+    // `api.updatePlatformAccessories()` or `api.unregisterPlatformAccessories()` from
+    // within that very callback (e.g. to add/remove a companion accessory, or to swap
+    // in an updated accessory instance). Those calls mutate `this.cachedPlatformAccessories`
+    // while this method is still iterating over it. Previously this method finished by
+    // reassigning `this.cachedPlatformAccessories` to the filtered result of the *original*
+    // pre-iteration array, which silently discarded any such concurrent mutation. Instead,
+    // we iterate a snapshot of the original list and only remove orphaned accessories from
+    // whatever `this.cachedPlatformAccessories` holds once iteration has finished.
+    const accessoriesToRestore = this.cachedPlatformAccessories
+    const orphanedAccessories = new Set<PlatformAccessory>()
+
+    for (const accessory of accessoriesToRestore) {
       let plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!)
       if (!plugin) { // a little explainer here. This section is basically here to resolve plugin name changes of dynamic platform plugins
         try {
@@ -476,7 +489,8 @@ export class BridgeService {
         log.info(`Failed to find plugin to handle accessory ${accessory._associatedHAPAccessory.displayName}`)
         if (!this.bridgeOptions.keepOrphanedCachedAccessories) {
           log.info(`Removing orphaned accessory ${accessory._associatedHAPAccessory.displayName}`)
-          return false // filter it from the list
+          orphanedAccessories.add(accessory) // remove it from the list
+          continue
         }
       } else {
         // We set a placeholder for FirmwareRevision before configureAccessory is called so the plugin has the opportunity to override it.
@@ -488,10 +502,15 @@ export class BridgeService {
         this.bridge.addBridgedAccessory(accessory._associatedHAPAccessory)
       } catch (error: any) {
         log.warn(`${accessory._associatedPlugin ? getLogPrefix(accessory._associatedPlugin) : ''} Could not restore cached accessory '${accessory._associatedHAPAccessory.displayName}':`, error.message)
-        return false // filter it from the list
+        orphanedAccessories.add(accessory) // remove it from the list
       }
-      return true // keep it in the list
-    })
+    }
+
+    if (orphanedAccessories.size > 0) {
+      this.cachedPlatformAccessories = this.cachedPlatformAccessories.filter(
+        accessory => !orphanedAccessories.has(accessory),
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #3919

`restoreCachedPlatformAccessories()` iterated the cached accessory list with `Array.prototype.filter()` and reassigned the result back onto `this.cachedPlatformAccessories` at the end. Plugin `configureAccessory()` callbacks — invoked synchronously from within that same loop — commonly call `api.registerPlatformAccessories()`, `api.updatePlatformAccessories()` or `api.unregisterPlatformAccessories()` to add a companion accessory or swap in an updated accessory instance (exactly the pattern described in #3919, where a companion sensor service added/removed via `updatePlatformAccessories()` during restore never made it into the persisted cache). Those calls mutate `this.cachedPlatformAccessories` mid-iteration, but the final reassignment silently overwrote them with the filtered result of the *original* pre-iteration array, discarding the plugin's changes.

This PR changes the method to iterate a snapshot of the original list and only prune orphaned accessories from whatever `this.cachedPlatformAccessories` currently holds once iteration completes, so concurrent registrations/updates made during restore are preserved. Behavior for the non-reentrant path is unchanged.

**Test evidence:**
Added 3 tests to `src/bridgeService.spec.ts`. Before the fix, the two reentrancy tests fail:
```
AssertionError: expected [ …(2) ] to include PlatformAccessory{ ... }
```
After the fix: `npx vitest run src/bridgeService.spec.ts` → 63/63 passed. Full suite: `npm run test` → 1018/1018 passed. `npm run lint` and `tsc --noEmit -p tsconfig.typecheck.json` both clean.

Prepared with AI assistance (Claude, agent: claude-sonnet-5), reviewed for correctness before submission.