### PR TITLE
feat: make identifying material in bonjour configurable

### DIFF
--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -895,9 +895,9 @@ describe('bridgeService', () => {
 
       validateHapConfig(cfg, { bridgeLabel: 'main bridge' })
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(
-        /main bridge.*identifying material is disabled.*bridge names.*unique.*mDNS name collisions.*pairing instability/i,
-      ))
+      expect(warnSpy).toHaveBeenCalledOnce()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/^main bridge:/))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/identifying material is disabled/i))
     })
 
     it('does not warn when hap.disableIdentifyingMaterial is omitted or false', () => {

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -6,7 +6,13 @@ import { Accessory, Categories, CharacteristicWarningType, uuid } from '@homebri
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { HomebridgeAPI, InternalAPIEvent } from './api.js'
-import { BridgeService, isHapConfigEnabled, isHapExternalsOnly, validateHapConfig } from './bridgeService.js'
+import {
+  BridgeService,
+  isHapConfigEnabled,
+  isHapExternalsOnly,
+  shouldAddIdentifyingMaterial,
+  validateHapConfig,
+} from './bridgeService.js'
 import { Logger } from './logger.js'
 import { PlatformAccessory } from './platformAccessory.js'
 
@@ -404,6 +410,25 @@ describe('bridgeService', () => {
       expect(externalPortService.requestPort).toHaveBeenCalledTimes(1)
     })
 
+    it('forwards hap.addIdentifyingMaterial to external accessories', async () => {
+      externalPortService.requestPort.mockResolvedValue(50002)
+      const service = new BridgeService(
+        api,
+        pluginManager,
+        externalPortService,
+        makeBridgeOptions(),
+        makeBridgeConfig({ hap: { addIdentifyingMaterial: false } }),
+      )
+
+      const accessory = makePlatformAccessory('External-Exact-Name')
+      const publishSpy = vi.spyOn(accessory._associatedHAPAccessory, 'publish').mockResolvedValue(undefined)
+
+      await service.handlePublishExternalAccessories([accessory])
+
+      const publishInfo = publishSpy.mock.calls[0][0] as any
+      expect(publishInfo.addIdentifyingMaterial).toBe(false)
+    })
+
     it('throws when an accessory address collides with an existing one', async () => {
       externalPortService.requestPort.mockResolvedValue(50000)
       const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
@@ -729,6 +754,17 @@ describe('bridgeService', () => {
       expect(publishInfo.addIdentifyingMaterial).toBe(true)
     })
 
+    it('disables identifying material when configured in the HAP block', () => {
+      const config = makeBridgeConfig({ hap: { addIdentifyingMaterial: false } })
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), config)
+      const publishSpy = vi.spyOn(service.bridge, 'publish').mockResolvedValue(undefined)
+
+      service.publishBridge()
+
+      const publishInfo = publishSpy.mock.calls[0][0] as any
+      expect(publishInfo.addIdentifyingMaterial).toBe(false)
+    })
+
     it('includes setupID when it is exactly 4 characters', () => {
       const config = makeBridgeConfig({ setupID: 'AB12' })
       const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), config)
@@ -822,6 +858,19 @@ describe('bridgeService', () => {
     })
   })
 
+  describe('shouldAddIdentifyingMaterial', () => {
+    it('defaults to true when the HAP block or option is omitted', () => {
+      expect(shouldAddIdentifyingMaterial(undefined)).toBe(true)
+      expect(shouldAddIdentifyingMaterial({})).toBe(true)
+      expect(shouldAddIdentifyingMaterial(false)).toBe(true)
+      expect(shouldAddIdentifyingMaterial(true)).toBe(true)
+    })
+
+    it('honours an explicit false value', () => {
+      expect(shouldAddIdentifyingMaterial({ addIdentifyingMaterial: false })).toBe(false)
+    })
+  })
+
   describe('validateHapConfig', () => {
     it('is a no-op when hap is undefined', () => {
       const cfg = makeBridgeConfig()
@@ -831,6 +880,11 @@ describe('bridgeService', () => {
     it('accepts an empty hap object', () => {
       const cfg = makeBridgeConfig({ hap: {} })
       expect(() => validateHapConfig(cfg, { bridgeLabel: 'main' })).not.toThrow()
+    })
+
+    it('rejects a non-boolean hap.addIdentifyingMaterial value', () => {
+      const cfg = makeBridgeConfig({ hap: { addIdentifyingMaterial: 'false' } })
+      expect(() => validateHapConfig(cfg, { bridgeLabel: 'main' })).toThrow(/addIdentifyingMaterial.*boolean/)
     })
 
     it('accepts hap.enabled: false on its own', () => {

--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -410,14 +410,14 @@ describe('bridgeService', () => {
       expect(externalPortService.requestPort).toHaveBeenCalledTimes(1)
     })
 
-    it('forwards hap.addIdentifyingMaterial to external accessories', async () => {
+    it('forwards hap.disableIdentifyingMaterial to external accessories', async () => {
       externalPortService.requestPort.mockResolvedValue(50002)
       const service = new BridgeService(
         api,
         pluginManager,
         externalPortService,
         makeBridgeOptions(),
-        makeBridgeConfig({ hap: { addIdentifyingMaterial: false } }),
+        makeBridgeConfig({ hap: { disableIdentifyingMaterial: true } }),
       )
 
       const accessory = makePlatformAccessory('External-Exact-Name')
@@ -755,7 +755,7 @@ describe('bridgeService', () => {
     })
 
     it('disables identifying material when configured in the HAP block', () => {
-      const config = makeBridgeConfig({ hap: { addIdentifyingMaterial: false } })
+      const config = makeBridgeConfig({ hap: { disableIdentifyingMaterial: true } })
       const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), config)
       const publishSpy = vi.spyOn(service.bridge, 'publish').mockResolvedValue(undefined)
 
@@ -859,15 +859,17 @@ describe('bridgeService', () => {
   })
 
   describe('shouldAddIdentifyingMaterial', () => {
-    it('defaults to true when the HAP block or option is omitted', () => {
+    it('defaults to true when disabling identifying material is omitted or false', () => {
       expect(shouldAddIdentifyingMaterial(undefined)).toBe(true)
       expect(shouldAddIdentifyingMaterial({})).toBe(true)
       expect(shouldAddIdentifyingMaterial(false)).toBe(true)
       expect(shouldAddIdentifyingMaterial(true)).toBe(true)
+      expect(shouldAddIdentifyingMaterial(null as any)).toBe(true)
+      expect(shouldAddIdentifyingMaterial({ disableIdentifyingMaterial: false })).toBe(true)
     })
 
-    it('honours an explicit false value', () => {
-      expect(shouldAddIdentifyingMaterial({ addIdentifyingMaterial: false })).toBe(false)
+    it('honours an explicit true value', () => {
+      expect(shouldAddIdentifyingMaterial({ disableIdentifyingMaterial: true })).toBe(false)
     })
   })
 
@@ -882,9 +884,32 @@ describe('bridgeService', () => {
       expect(() => validateHapConfig(cfg, { bridgeLabel: 'main' })).not.toThrow()
     })
 
-    it('rejects a non-boolean hap.addIdentifyingMaterial value', () => {
-      const cfg = makeBridgeConfig({ hap: { addIdentifyingMaterial: 'false' } })
-      expect(() => validateHapConfig(cfg, { bridgeLabel: 'main' })).toThrow(/addIdentifyingMaterial.*boolean/)
+    it('rejects a non-boolean hap.disableIdentifyingMaterial value', () => {
+      const cfg = makeBridgeConfig({ hap: { disableIdentifyingMaterial: 'true' } })
+      expect(() => validateHapConfig(cfg, { bridgeLabel: 'main' })).toThrow(/disableIdentifyingMaterial.*boolean/)
+    })
+
+    it('warns about mDNS collisions when hap.disableIdentifyingMaterial is true', () => {
+      const warnSpy = vi.spyOn(Logger.internal, 'warn').mockImplementation(() => {})
+      const cfg = makeBridgeConfig({ hap: { disableIdentifyingMaterial: true } })
+
+      validateHapConfig(cfg, { bridgeLabel: 'main bridge' })
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(
+        /main bridge.*identifying material is disabled.*bridge names.*unique.*mDNS name collisions.*pairing instability/i,
+      ))
+    })
+
+    it('does not warn when hap.disableIdentifyingMaterial is omitted or false', () => {
+      const warnSpy = vi.spyOn(Logger.internal, 'warn').mockImplementation(() => {})
+
+      validateHapConfig(makeBridgeConfig({ hap: {} }), { bridgeLabel: 'main bridge' })
+      validateHapConfig(
+        makeBridgeConfig({ hap: { disableIdentifyingMaterial: false } }),
+        { bridgeLabel: 'main bridge' },
+      )
+
+      expect(warnSpy).not.toHaveBeenCalled()
     })
 
     it('accepts hap.enabled: false on its own', () => {

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -78,6 +78,13 @@ export interface BridgeHapConfig {
    * warns and normalises `enabled` to `false` rather than rejecting the config.
    */
   externalsOnly?: boolean
+
+  /**
+   * Whether HAP-NodeJS appends identifying material derived from the bridge
+   * username to the bridge display name and mDNS service instance name.
+   * Defaults to `true` for backwards compatibility.
+   */
+  addIdentifyingMaterial?: boolean
 }
 
 export interface BridgeConfiguration {
@@ -143,6 +150,15 @@ export function isHapExternalsOnly(hap: BridgeHapConfig | boolean | undefined): 
 }
 
 /**
+ * Whether HAP-NodeJS should append identifying material to the published
+ * bridge and mDNS service instance names. Missing config and the deprecated
+ * boolean `hap` form preserve the historical default (`true`).
+ */
+export function shouldAddIdentifyingMaterial(hap: BridgeHapConfig | boolean | undefined): boolean {
+  return typeof hap !== 'object' || hap.addIdentifyingMaterial !== false
+}
+
+/**
  * Validate a `hap` config block. Throws on hard errors (wrong type, conflict
  * between `externalsOnly` and `enabled`). For accessory child bridges, strips
  * `externalsOnly` with a warn-level log because externals are not supported
@@ -171,11 +187,15 @@ export function validateHapConfig(
 
   if (typeof hap !== 'object' || hap === null || Array.isArray(hap)) {
     throw new Error(
-      `${opts.bridgeLabel}: 'hap' must be a boolean or an object with optional 'enabled' and 'externalsOnly' fields, not a ${Array.isArray(hap) ? 'array' : typeof hap}.`,
+      `${opts.bridgeLabel}: 'hap' must be a boolean or an object with optional 'enabled', 'externalsOnly', and 'addIdentifyingMaterial' fields, not a ${Array.isArray(hap) ? 'array' : typeof hap}.`,
     )
   }
 
   const hapBlock = hap as BridgeHapConfig
+
+  if (hapBlock.addIdentifyingMaterial !== undefined && typeof hapBlock.addIdentifyingMaterial !== 'boolean') {
+    throw new Error(`${opts.bridgeLabel}: 'hap.addIdentifyingMaterial' must be a boolean.`)
+  }
 
   if (hapBlock.externalsOnly === true) {
     if (opts.isAccessoryPlugin) {
@@ -354,7 +374,7 @@ export class BridgeService {
       pincode: bridgeConfig.pin,
       category: Categories.BRIDGE,
       bind: bridgeConfig.bind,
-      addIdentifyingMaterial: true,
+      addIdentifyingMaterial: shouldAddIdentifyingMaterial(bridgeConfig.hap),
       advertiser: bridgeConfig.advertiser,
     }
 
@@ -707,7 +727,7 @@ export class BridgeService {
         category: accessory.category,
         port: accessoryPort,
         bind: this.bridgeConfig.bind,
-        addIdentifyingMaterial: true,
+        addIdentifyingMaterial: shouldAddIdentifyingMaterial(this.bridgeConfig.hap),
         advertiser: this.bridgeConfig.advertiser,
       }
 

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -81,7 +81,7 @@ export interface BridgeHapConfig {
 
   /**
    * Whether to disable HAP-NodeJS's `addIdentifyingMaterial` publish option,
-   * which appends identifying material derived from the bridge name to the
+   * which appends identifying material derived from the username to the
    * bridge display name and mDNS service instance name. Defaults to `false`.
    */
   disableIdentifyingMaterial?: boolean

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -80,11 +80,11 @@ export interface BridgeHapConfig {
   externalsOnly?: boolean
 
   /**
-   * Whether HAP-NodeJS appends identifying material derived from the bridge
-   * username to the bridge display name and mDNS service instance name.
-   * Defaults to `true` for backwards compatibility.
+   * Whether to disable HAP-NodeJS's `addIdentifyingMaterial` publish option,
+   * which appends identifying material derived from the bridge name to the
+   * bridge display name and mDNS service instance name. Defaults to `false`.
    */
-  addIdentifyingMaterial?: boolean
+  disableIdentifyingMaterial?: boolean
 }
 
 export interface BridgeConfiguration {
@@ -150,19 +150,20 @@ export function isHapExternalsOnly(hap: BridgeHapConfig | boolean | undefined): 
 }
 
 /**
- * Whether HAP-NodeJS should append identifying material to the published
- * bridge and mDNS service instance names. Missing config and the deprecated
- * boolean `hap` form preserve the historical default (`true`).
+ * Whether HAP-NodeJS should enable its `addIdentifyingMaterial` publish option.
+ * Missing config, an explicit `disableIdentifyingMaterial: false`, and the
+ * deprecated boolean `hap` form preserve the historical behavior (`true`).
  */
 export function shouldAddIdentifyingMaterial(hap: BridgeHapConfig | boolean | undefined): boolean {
-  return typeof hap !== 'object' || hap.addIdentifyingMaterial !== false
+  return typeof hap !== 'object' || !hap?.disableIdentifyingMaterial
 }
 
 /**
  * Validate a `hap` config block. Throws on hard errors (wrong type, conflict
- * between `externalsOnly` and `enabled`). For accessory child bridges, strips
- * `externalsOnly` with a warn-level log because externals are not supported
- * via the accessory plugin API.
+ * between `externalsOnly` and `enabled`) and warns when identifying material is
+ * disabled because advertised mDNS service names must remain unique. For
+ * accessory child bridges, strips `externalsOnly` with a warn-level log because
+ * externals are not supported via the accessory plugin API.
  *
  * Mutates the passed block in place when stripping fields.
  */
@@ -187,14 +188,18 @@ export function validateHapConfig(
 
   if (typeof hap !== 'object' || hap === null || Array.isArray(hap)) {
     throw new Error(
-      `${opts.bridgeLabel}: 'hap' must be a boolean or an object with optional 'enabled', 'externalsOnly', and 'addIdentifyingMaterial' fields, not a ${Array.isArray(hap) ? 'array' : typeof hap}.`,
+      `${opts.bridgeLabel}: 'hap' must be a boolean or an object with optional 'enabled', 'externalsOnly', and 'disableIdentifyingMaterial' fields, not a ${Array.isArray(hap) ? 'array' : typeof hap}.`,
     )
   }
 
   const hapBlock = hap as BridgeHapConfig
 
-  if (hapBlock.addIdentifyingMaterial !== undefined && typeof hapBlock.addIdentifyingMaterial !== 'boolean') {
-    throw new Error(`${opts.bridgeLabel}: 'hap.addIdentifyingMaterial' must be a boolean.`)
+  if (hapBlock.disableIdentifyingMaterial !== undefined && typeof hapBlock.disableIdentifyingMaterial !== 'boolean') {
+    throw new Error(`${opts.bridgeLabel}: 'hap.disableIdentifyingMaterial' must be a boolean.`)
+  }
+
+  if (hapBlock.disableIdentifyingMaterial === true) {
+    log.warn(`${opts.bridgeLabel}: HAP identifying material is disabled. Ensure bridge names are unique on your network to avoid mDNS name collisions and pairing instability.`)
   }
 
   if (hapBlock.externalsOnly === true) {

--- a/src/childBridgeService.spec.ts
+++ b/src/childBridgeService.spec.ts
@@ -957,6 +957,20 @@ describe('childBridgeService', () => {
       expect(loadMessage.data.bridgeConfig.hap).toEqual({ enabled: false })
     })
 
+    it('includes hap.addIdentifyingMaterial in LOAD bridgeConfig', () => {
+      const { service } = buildService({
+        bridgeConfig: makeBridgeConfig({ hap: { addIdentifyingMaterial: false } }),
+      })
+      service.addConfig({ platform: 'TestPlatform', name: 'X' } as any)
+      service.start()
+      const child = childProcesses.list[0]
+
+      child.emit('message', { id: ChildProcessMessageEventType.READY })
+
+      const loadMessage = child.sentMessages.find(m => m.id === ChildProcessMessageEventType.LOAD)
+      expect(loadMessage.data.bridgeConfig.hap).toEqual({ addIdentifyingMaterial: false })
+    })
+
     it('includes hap.enabled:false alongside matter config in LOAD bridgeConfig', () => {
       const { service } = buildService({
         bridgeConfig: makeBridgeConfig({ hap: { enabled: false }, matter: { port: 5540 } }),

--- a/src/childBridgeService.spec.ts
+++ b/src/childBridgeService.spec.ts
@@ -957,9 +957,9 @@ describe('childBridgeService', () => {
       expect(loadMessage.data.bridgeConfig.hap).toEqual({ enabled: false })
     })
 
-    it('includes hap.addIdentifyingMaterial in LOAD bridgeConfig', () => {
+    it('includes hap.disableIdentifyingMaterial in LOAD bridgeConfig', () => {
       const { service } = buildService({
-        bridgeConfig: makeBridgeConfig({ hap: { addIdentifyingMaterial: false } }),
+        bridgeConfig: makeBridgeConfig({ hap: { disableIdentifyingMaterial: true } }),
       })
       service.addConfig({ platform: 'TestPlatform', name: 'X' } as any)
       service.start()
@@ -968,7 +968,7 @@ describe('childBridgeService', () => {
       child.emit('message', { id: ChildProcessMessageEventType.READY })
 
       const loadMessage = child.sentMessages.find(m => m.id === ChildProcessMessageEventType.LOAD)
-      expect(loadMessage.data.bridgeConfig.hap).toEqual({ addIdentifyingMaterial: false })
+      expect(loadMessage.data.bridgeConfig.hap).toEqual({ disableIdentifyingMaterial: true })
     })
 
     it('includes hap.enabled:false alongside matter config in LOAD bridgeConfig', () => {


### PR DESCRIPTION
_Note: This PR addresses the same goal as #3899. This implementation uses the current `bridge.hap` configuration block, applies the setting to both the main bridge and external accessories, validates the configured value, covers child bridge forwarding, and includes regression tests._

## :recycle: Current situation

Homebridge currently hard-codes HAP-NodeJS `addIdentifyingMaterial: true`. This appends additional identifying characters to (potentially) the bridge display name and Bonjour service instance name. The resulting service name might be confusing to end users due to its inconsistency with the bridge display name or what the end user might expect to see.

## :bulb: Proposed solution

HAP-NodeJS already supports disabling this behavior (ie, setting it to `false`), but Homebridge does not expose the option in `config.json`. This change makes the behavior configurable without changing the default for existing users.

## :gear: Release Notes

Update `config.json` to disable appending the extra four identifying characters like this:

```json
"bridge": {
  "name": "Homebridge",
  "hap": {
    "addIdentifyingMaterial": false
  }
}
```


## :test_tube: Testing

Six test cases were added. Here is a brief description of each:

### `src/bridgeService.spec.ts`

- **Forwards `hap.addIdentifyingMaterial` to external accessories**  
  Verifies that external HAP accessories receive the configured value in their publish options.

- **Disables identifying material when configured in the HAP block**  
  Verifies that the main bridge passes `addIdentifyingMaterial: false` to HAP-NodeJS.

- **Defaults to `true` when the HAP block or option is omitted**  
  Confirms backward-compatible behavior, including legacy boolean HAP configurations.

- **Honors an explicit `false` value**  
  Verifies that the new configuration helper recognizes the opt-out.

- **Rejects a non-boolean `hap.addIdentifyingMaterial` value**  
  Ensures invalid values, such as the string `"false"`, fail configuration validation.

### `src/childBridgeService.spec.ts`

- **Includes `hap.addIdentifyingMaterial` in the child bridge `LOAD` configuration**  
  Confirms that the setting is forwarded to child bridge processes.

### Validation

- `npm test` - 54 test files and 1,107 tests passed
- `npx vitest run src/bridgeService.spec.ts src/childBridgeService.spec.ts` - 2 test files and 121 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run lint-docs`
- `npm run build`

_EDIT: added validation info_