### PR TITLE
fix(matter): compose PowerSource for all device types

### DIFF
--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -1,6 +1,7 @@
 import type { InternalMatterAccessory, MatterAccessory } from '../types.js'
 import type { AccessoryManagerDeps } from './AccessoryManager.js'
 
+import { PowerSourceServer } from '@matter/node/behaviors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -382,6 +383,62 @@ describe('accessoryManager', () => {
       expect(applyElectricalMeasurementClusters).not.toHaveBeenCalled()
       const internal = deps.accessories.get('test-uuid-001') as any
       expect(internal.endpoint.act).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('powerSource (battery) composition', () => {
+    // A battery cluster must compose for any device type, not just
+    // RoboticVacuumCleaner, and — since it is read-only — even for accessories
+    // that declare no handlers at all (sensors).
+
+    it('composes PowerSource for a non-RVC device type that has handlers (e.g. a lock)', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          powerSource: { batPercentRemaining: 200, batChargeLevel: 0 },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+    })
+
+    it('composes PowerSource for a non-RVC device with no handlers (e.g. a battery-powered sensor)', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x0015, name: 'ContactSensor', with: vi.fn(() => ({ deviceType: 0x0015, with: vi.fn() })) } as any,
+        clusters: {
+          // read-only sensor: a battery, and no handlers at all
+          powerSource: { batPercentRemaining: 200, batChargeLevel: 0 },
+        },
+      })
+      delete (accessory as any).handlers
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // Regression guard for the no-handlers early return: without the fix this
+      // accessory bails before the battery is ever composed.
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+    })
+
+    it('composes the Rechargeable feature when a charge state is declared', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          powerSource: { batPercentRemaining: 200, batChargeLevel: 0, batChargeState: 0 },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
     })
   })
 

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -403,6 +403,29 @@ export class AccessoryManager {
   ): Promise<BehaviorType[]> {
     const customBehaviors: BehaviorType[] = []
 
+    // PowerSource (battery) is a general utility cluster, not device-type
+    // specific — like the ElectricalPowerMeasurement/ElectricalEnergyMeasurement
+    // clusters, it should be composed for any device type. Compose it up front,
+    // before the no-handlers early return below: battery-powered sensors
+    // (contact/leak/occupancy, etc.) are read-only and declare no handlers at
+    // all, so gating this on handlers would silently drop their battery.
+    if (accessory.clusters?.powerSource) {
+      const hasBattery = accessory.clusters.powerSource.batPercentRemaining !== undefined
+        || accessory.clusters.powerSource.batChargeLevel !== undefined
+      const hasRechargeable = accessory.clusters.powerSource.batChargeState !== undefined
+      let powerSourceBehavior: BehaviorType = PowerSourceServer
+      if (hasBattery && hasRechargeable) {
+        powerSourceBehavior = (PowerSourceServer as any).with('Battery', 'Rechargeable')
+        log.debug('Adding PowerSource server with battery and rechargeable features')
+      } else if (hasBattery) {
+        powerSourceBehavior = (PowerSourceServer as any).with('Battery')
+        log.debug('Adding PowerSource server with battery feature')
+      } else {
+        log.debug('Adding base PowerSource server')
+      }
+      customBehaviors.push(powerSourceBehavior)
+    }
+
     if (!accessory.handlers) {
       return customBehaviors
     }
@@ -441,23 +464,6 @@ export class AccessoryManager {
           customBehaviors.push(behaviorClass)
           log.info('Adding base ServiceArea server')
         }
-      }
-
-      if (accessory.clusters?.powerSource) {
-        const hasBattery = accessory.clusters.powerSource.batPercentRemaining !== undefined
-          || accessory.clusters.powerSource.batChargeLevel !== undefined
-        const hasRechargeable = accessory.clusters.powerSource.batChargeState !== undefined
-        let powerSourceBehavior: BehaviorType = PowerSourceServer
-        if (hasBattery && hasRechargeable) {
-          powerSourceBehavior = (PowerSourceServer as any).with('Battery', 'Rechargeable')
-          log.debug('Adding PowerSource server with battery and rechargeable features')
-        } else if (hasBattery) {
-          powerSourceBehavior = (PowerSourceServer as any).with('Battery')
-          log.debug('Adding PowerSource server with battery feature')
-        } else {
-          log.debug('Adding base PowerSource server')
-        }
-        customBehaviors.push(powerSourceBehavior)
       }
     }
 


### PR DESCRIPTION
  ## :recycle: Current situation

  `AccessoryManager.buildCustomBehaviors()` composes the Matter `PowerSource`
  cluster **only inside the `RoboticVacuumCleanerDevice` branch**, alongside the
  genuinely vacuum-specific `rvcCleanMode` / `serviceArea` handling:

  ```ts
  if (deviceType.deviceType === devices.RoboticVacuumCleanerDevice.deviceType) {
    // ...rvcCleanMode / serviceArea...
    if (accessory.clusters?.powerSource) {
      // compose PowerSource
    }
  }
```

  So a plugin that declares clusters.powerSource (battery) on any other device
  type — DoorLock, ContactSensor, LeakSensor, OccupancySensor, Thermostat, … —
  silently gets no PowerSource cluster on its Matter endpoint, and controllers
  (e.g. Home Assistant) never expose a battery entity. powerSource is a
  recognized key that passes validateAccessory unchanged, so nothing warns that
  it was dropped — buildCustomBehaviors just never reaches it.

  There is also a second, subtler gap: even at the top level, a battery-only,
  read-only accessory (a sensor) declares no handlers, so it would be caught by
  the if (!accessory.handlers) return customBehaviors early return before any
  battery is composed.

  Reported and diagnosed in #3967, including before/after cluster reads
  from a real bridge.

## :bulb: Proposed solution

  Treat powerSource as the general utility cluster it is — the same way
  ElectricalPowerMeasurement / ElectricalEnergyMeasurement are applied at the
  top level for any device type.

  - Move the if (accessory.clusters?.powerSource) { … } block out of the
  RoboticVacuumCleanerDevice branch.
  - Place it at the top of buildCustomBehaviors, above the !accessory.handlers
  early return, so it also composes for read-only, handler-less accessories
  (battery sensors).

  This is a pure move — the feature selection
  (PowerSourceServer.with('Battery') / .with('Battery', 'Rechargeable') based
  on the declared attributes) is unchanged; only the scope and position of the
  block change. No new API surface.

## :gear: Release Notes

  Fixed: plugins declaring a powerSource (battery) cluster via api.matter now
  expose it over Matter for all device types, not just RoboticVacuumCleaner —
  including read-only sensors that declare no handlers. Battery-powered locks and
  contact/leak/occupancy sensors now surface a battery entity on Matter controllers
  (e.g. Home Assistant), matching what they already expose over HAP.

  No breaking changes: this only adds a cluster that was previously dropped;
  accessories that don't declare powerSource are unaffected, and RVC accessories
  behave exactly as before.
accessories that don't declare powerSource are unaffected, and RVC accessories
behave exactly as before.

## :heavy_plus_sign: Additional Information

Verified end-to-end against a real bridge (3× August locks via a fork of
homebridge-august declaring clusters.powerSource on the DoorLock
accessories): buildCustomBehaviors went from Applied 1 custom behavior(s) to
Applied 2, cluster 0x2F now appears on each lock endpoint with the Battery
feature (…/47/65532 = 2, …/47/12 = batPercentRemaining), and Home Assistant
created a working battery sensor.

## Testing

Added three cases to src/matter/server/AccessoryManager.spec.ts, all asserting
on the mocked PowerSourceServer.with:

- non-RVC device with handlers (a lock) → composes .with('Battery').
- non-RVC device without handlers (a read-only sensor) → still composes
.with('Battery'). This is the explicit regression guard for the
!accessory.handlers early return; without the fix it composes nothing.
- rechargeable variant (a batChargeState is declared) → composes
.with('Battery', 'Rechargeable').

Existing tests are unchanged and still pass (20/20). npm run typecheck and
eslint are clean. Not covered by unit tests: the live commissioning /
controller-side battery mapping, which was instead verified manually as described
above.

## Reviewer Nudging

Start in src/matter/server/AccessoryManager.ts, buildCustomBehaviors() — the
whole change is the relocated powerSource block (now at the top of the method,
above the !accessory.handlers early return) and its removal from the
RoboticVacuumCleanerDevice branch. The diff reads cleanly as a move. Then see
the new describe('powerSource (battery) composition', …) block in the spec,
where the no-handlers case is the one that pins the early-return behavior.