### PR TITLE
fix(matter): restore cached accessories into the bridge before going online

### DIFF
--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -5,7 +5,7 @@
  * All public method signatures are preserved for external callers.
  */
 
-import type { ServerNode } from '@matter/main'
+import type { EndpointType, ServerNode } from '@matter/main'
 
 import type { SerializedMatterAccessory } from './accessoryCache.js'
 import type { MatterServerConfig } from './sharedTypes.js'
@@ -367,6 +367,92 @@ export class MatterServer extends EventEmitter {
       getAccessoryCache: () => this.accessoryCache,
       setAccessoryCache: (cache: MatterAccessoryCache) => {
         this.accessoryCache = cache
+      },
+      restoreAccessoriesFromCache: async () => {
+        if (!this.accessoryCache) {
+          return
+        }
+        let cached: Map<string, SerializedMatterAccessory>
+        try {
+          cached = await this.accessoryCache.load()
+        } catch (error) {
+          log.warn('Failed to load Matter accessory cache for pre-online restore:', error)
+          return
+        }
+        if (cached.size === 0) {
+          return
+        }
+
+        // Device types are cached as name-only info; resolve them back through
+        // the public registry.
+        const typeByName = new Map<string, EndpointType>()
+        for (const [key, value] of Object.entries(deviceTypes)) {
+          typeByName.set(key, value as EndpointType)
+          const name = (value as { name?: string }).name
+          if (name) {
+            typeByName.set(name, value as EndpointType)
+          }
+        }
+
+        // Handlers are functions and cannot be cached, but custom behaviors
+        // (e.g. the OnOff server on switch device types) are only attached for
+        // clusters that have handlers. Synthesize empty stubs per cached
+        // cluster so the restored endpoint is structurally identical to the
+        // original; the plugin's re-registration supplies the real handlers.
+        const stubHandlers = (clusters?: Record<string, unknown>) => {
+          const handlers: Record<string, Record<string, never>> = {}
+          for (const clusterName of Object.keys(clusters ?? {})) {
+            handlers[clusterName] = {}
+          }
+          return Object.keys(handlers).length > 0 ? handlers : undefined
+        }
+
+        let restored = 0
+        for (const serialized of cached.values()) {
+          try {
+            const deviceType = typeByName.get(serialized.deviceType?.name ?? '')
+            if (!deviceType) {
+              log.warn(`Cannot restore cached Matter accessory ${serialized.displayName}: unknown device type "${serialized.deviceType?.name}"`)
+              continue
+            }
+            const parts = (serialized.parts ?? [])
+              .map(part => ({
+                id: part.id,
+                displayName: part.displayName,
+                deviceType: typeByName.get(part.deviceType?.name ?? ''),
+                clusters: part.clusters ?? {},
+                handlers: stubHandlers(part.clusters),
+              }))
+              .filter((part): part is typeof part & { deviceType: EndpointType } => part.deviceType !== undefined)
+
+            const accessory: InternalMatterAccessory = {
+              UUID: serialized.uuid,
+              displayName: serialized.displayName,
+              deviceType,
+              serialNumber: serialized.serialNumber,
+              manufacturer: serialized.manufacturer,
+              model: serialized.model,
+              firmwareRevision: serialized.firmwareRevision,
+              hardwareRevision: serialized.hardwareRevision,
+              softwareVersion: serialized.softwareVersion,
+              context: serialized.context ?? {},
+              clusters: serialized.clusters ?? {},
+              handlers: stubHandlers(serialized.clusters),
+              registered: false,
+              _restoredFromCache: true,
+            }
+            if (parts.length > 0) {
+              accessory.parts = parts
+            }
+            await this.accessoryManager.registerAccessory(serialized.plugin, serialized.platform, accessory, this.getAccessoryManagerDeps())
+            restored++
+          } catch (error) {
+            log.warn(`Failed to restore cached Matter accessory ${serialized.displayName}:`, error)
+          }
+        }
+        if (restored > 0) {
+          log.info(`Restored ${restored} cached Matter accessories into the bridge before going online`)
+        }
       },
       setServerNode: (node: ServerNode | null) => {
         this.serverNode = node

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -109,12 +109,51 @@ export class AccessoryManager {
 
     if (deps.accessories.has(accessory.UUID)) {
       const existing = deps.accessories.get(accessory.UUID)
-      throw new MatterDeviceError(
-        `Matter accessory with UUID "${accessory.UUID}" is already registered.\n`
-        + `Existing accessory: "${existing?.displayName}"\n`
-        + `New accessory: "${accessory.displayName}"\n`
-        + 'Each accessory must have a unique UUID. Use api.hap.uuid.generate() with a unique string.',
-      )
+      // A cache-restored accessory keeps its endpoint (so the parts list never
+      // churns); the plugin's registration attaches its handlers and metadata
+      // in place. Structural changes fall through to a fresh registration.
+      if (existing?._restoredFromCache) {
+        const partIds = (list?: { id: string }[]) => JSON.stringify((list ?? []).map(part => part.id).sort())
+        const sameShape = (existing.deviceType as { name?: string })?.name === (accessory.deviceType as { name?: string })?.name
+          && partIds(existing._parts ?? existing.parts) === partIds(accessory.parts)
+        if (sameShape) {
+          log.info(`Attached plugin registration to restored accessory ${accessory.displayName} (${accessory.UUID})`)
+          deps.accessories.set(accessory.UUID, {
+            ...existing,
+            ...accessory,
+            endpoint: existing.endpoint,
+            _parts: existing._parts,
+            registered: true,
+            _restoredFromCache: false,
+          })
+          this.registerAccessoryHandlers(accessory, deps)
+          for (const part of accessory.parts ?? []) {
+            if (!part.handlers) {
+              continue
+            }
+            const partEndpointId = `${accessory.UUID}-part-${part.id}`
+            deps.behaviorRegistry.registerPartEndpoint(partEndpointId, accessory.UUID, part.id)
+            for (const [clusterName, handlers] of Object.entries(part.handlers)) {
+              for (const [commandName, handler] of Object.entries(handlers)) {
+                deps.behaviorRegistry.registerHandler(partEndpointId, clusterName, commandName, handler)
+              }
+            }
+          }
+          if (deps.accessoryCache) {
+            deps.accessoryCache.requestSave(deps.accessories)
+          }
+          return
+        }
+        log.info(`Restored accessory ${accessory.displayName} changed structure - re-registering`)
+        await this.unregisterAccessory(accessory.UUID, deps)
+      } else {
+        throw new MatterDeviceError(
+          `Matter accessory with UUID "${accessory.UUID}" is already registered.\n`
+          + `Existing accessory: "${existing?.displayName}"\n`
+          + `New accessory: "${accessory.displayName}"\n`
+          + 'Each accessory must have a unique UUID. Use api.hap.uuid.generate() with a unique string.',
+        )
+      }
     }
 
     this.restoreCachedState(accessory, deps.accessoryCache)

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -50,6 +50,14 @@ export interface ServerLifecycleDeps {
   getCommissioningDeps: () => CommissioningDeps
   getAccessoryCache: () => MatterAccessoryCache | null
   setAccessoryCache: (cache: MatterAccessoryCache) => void
+  /**
+   * Rebuilds cached accessories into the aggregator. Called after the
+   * aggregator exists but BEFORE the server node goes online, so that a
+   * commissioned controller reconnecting during startup never observes a
+   * shrunken parts list (which makes controllers treat the missing endpoints
+   * as removed devices and e.g. discard their room assignments).
+   */
+  restoreAccessoriesFromCache?: () => Promise<void>
   setServerNode: (node: ServerNode | null) => void
   getServerNode: () => ServerNode | null
   setAggregator: (agg: Endpoint<typeof AggregatorEndpointType> | null) => void
@@ -368,6 +376,14 @@ export class ServerLifecycle {
       process.on('SIGTERM', shutdownHandler)
 
       if (!deps.config.externalAccessory) {
+        // Restore cached accessories into the aggregator before going online.
+        // Controllers (verified with an Apple Home hub) re-establish their
+        // subscription within the first second of the node coming online and
+        // prune any bridged device missing from the parts list at that moment.
+        if (deps.restoreAccessoriesFromCache) {
+          await deps.restoreAccessoriesFromCache()
+        }
+
         await this.startServerNode(serverNode, deps)
       } else {
         log.debug('Deferred start mode - server prepared but not running yet (will start after device registration)')

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -456,6 +456,13 @@ export interface InternalMatterAccessory extends MatterAccessory {
   /** Plugin identifier (set when registered) */
   _associatedPlugin?: string
 
+  /**
+   * True while this accessory was rebuilt from the accessory cache at startup
+   * and its plugin has not re-registered yet. The plugin's registration
+   * attaches handlers to the existing endpoint instead of erroring.
+   */
+  _restoredFromCache?: boolean
+
   /** Platform name (set when registered) */
   _associatedPlatform?: string
 


### PR DESCRIPTION
## Description

**The problem.** On every restart of a commissioned Matter bridge, the server
node comes online with an empty aggregator parts list — cached accessories are
only delivered to plugins via `configureMatterAccessory`, never rebuilt into
the bridge. A paired controller re-establishes its subscription within the
first second (log excerpt below, Apple TV hub), reads a parts list containing
0-2 of 11 devices, treats the missing endpoints as removed, and discards their
metadata: **room assignments and tile settings are lost on nearly every
restart**, with the devices re-added as "new" seconds later when plugin
registrations land. Endpoint identity is not the issue — endpoint numbers and
`BridgedDeviceBasicInformation.uniqueId` are byte-stable across restarts
(verified from matter.js storage); the transient parts-list shrink alone
triggers the controller-side deletion.

```
11:05:00 PM [Matter/Node] 0E8093EB8676 is online
11:05:01 PM [Matter/InteractionServer] Subscription successfully reestablished ...
11:05:01 PM [Matter/Server] Registered Matter accessory: (1 of 11)   <- too late
...
11:05:11 PM [Matter/Server] Registered Matter accessory: (11 of 11)
```

There is no race plugins can win: even batching all registrations into one
call loses to a same-second subscription. HAP solved the equivalent problem
years ago by restoring cached accessories into the bridge before publishing;
Matter needs the same.

**The fix.**

1. `ServerLifecycle.start()` invokes a new optional dep,
   `restoreAccessoriesFromCache()`, after the aggregator is created and
   **before** `startServerNode()`.
2. `MatterServer` implements it: load the accessory cache, rebuild each cached
   accessory (device types resolved back through the public `deviceTypes`
   registry from their cached names) and register it through the normal
   `AccessoryManager.registerAccessory` path, marked with an internal
   `_restoredFromCache` flag. Handlers cannot be cached, but custom behaviors
   (e.g. the OnOff server on switch device types) are only attached for
   clusters that have handlers — empty stubs are synthesized per cached
   cluster so the restored endpoint is structurally identical to the original.
3. `AccessoryManager.registerAccessory`: when a plugin re-registers a UUID
   whose accessory is `_restoredFromCache`, attach the plugin's handlers and
   metadata to the existing endpoint in place (no parts-list churn) instead of
   throwing the duplicate-UUID error. If the structure changed (device type or
   part ids), unregister the restored endpoint and register fresh.

**Also fixed as a side effect:** `restoreCachedAccessories()` currently logs
`Restoring 0 cached Matter accessories` even with a populated
`accessories.json`, because the cache is only loaded at the end of
`startServerNode()` — after the synchronous restore call sites in `server.ts`
/ `childBridgeFork.ts` have already read it. The pre-online hook loads the
cache first, so `configureMatterAccessory` now fires with the cached
accessories as designed.

**Testing.** Live bridge (child bridge, `hap.enabled: false`), 11 accessories
covering single-endpoint devices, a composed BridgedNode with typed parts, and
electrical measurement clusters, paired with an Apple Home hub (tvOS 27):

- restore completes before `going online`; the controller's first read sees all 11
- plugin re-registration attaches in place: no duplicate-UUID errors, no
  "Cluster 'onOff' not found", commands work end to end
- endpoint numbers and uniqueIds byte-identical across restarts
- room assignments survive repeated bridge restarts (previously lost)
- fresh-pair (empty cache) path unchanged; structural-change path re-registers

**Notes for reviewers.**

- Stub handlers are a workaround for handlers being non-serializable. A
  cleaner follow-up would be caching the handler *shape* (cluster/command
  names) in `SerializedMatterAccessory`, but the stubs keep the cache format
  unchanged and behave identically for behavior selection.
- Restored accessories could be marked `reachable: false` until the plugin
  attaches; left out to keep the diff minimal.
- Related but not fixed here (can file separately): registrations arriving
  while the Matter server is starting are logged
  (`MatterDeviceError: Matter server not started`) but the API call resolves,
  so plugins cannot detect the drop; storage-lock contention on a quick
  restart permanently disables Matter for the process lifetime with no retry;
  and `notifyPartsListChanged`'s `increaseConfigurationVersion` acquires locks
  synchronously and drops notifications under concurrent transactions.
