### PR TITLE
fix(matter): add FixedLabel and PowerSource to composed parents

### DIFF
--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -26,12 +26,19 @@ vi.mock('@matter/main', () => {
       this.id = options?.id
     }
   }
-  return { Endpoint: MockEndpoint }
+  return { Endpoint: MockEndpoint, VendorId: vi.fn((id: number) => id) }
 })
 vi.mock('@matter/main/behaviors', () => ({
   BasicInformationServer: { name: 'BasicInformationServer' },
-  BridgedDeviceBasicInformationServer: { name: 'BridgedDeviceBasicInformationServer' },
-  DescriptorServer: { name: 'DescriptorServer' },
+  BridgedDeviceBasicInformationServer: {
+    name: 'BridgedDeviceBasicInformationServer',
+    enable: vi.fn(() => ({ name: 'BridgedDeviceBasicInformationServer.enable' })),
+  },
+  DescriptorServer: {
+    name: 'DescriptorServer',
+    with: vi.fn((...args: any[]) => ({ name: `DescriptorServer.with(${args.join(',')})` })),
+  },
+  FixedLabelServer: { name: 'FixedLabelServer' },
 }))
 vi.mock('@matter/node/behaviors', () => ({
   PowerSourceServer: { name: 'PowerSourceServer', with: vi.fn((...args: any[]) => ({ name: `PowerSourceServer.with(${args.join(',')})` })) },
@@ -171,11 +178,18 @@ function createMockDeps(overrides: Partial<AccessoryManagerDeps> = {}): Accessor
   }
 }
 
+// Composed (parts-bearing) accessories chain several `.with()` calls on the
+// parent device type (BridgedDeviceBasicInformation, FixedLabel, PowerSource),
+// so the mock must stay chainable at any depth.
+function createChainableDeviceType(props: Record<string, unknown>): any {
+  return { ...props, with: vi.fn(() => createChainableDeviceType(props)) }
+}
+
 function createMockAccessory(overrides: Partial<MatterAccessory> = {}): MatterAccessory {
   return {
     UUID: 'test-uuid-001',
     displayName: 'Test Light',
-    deviceType: { deviceType: 0x0100, name: 'OnOffLight', with: vi.fn(() => ({ deviceType: 0x0100, with: vi.fn() })) } as any,
+    deviceType: createChainableDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
     serialNumber: 'SN-001',
     manufacturer: 'Test Mfg',
     model: 'Test Model',

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -1,6 +1,7 @@
 import type { InternalMatterAccessory, MatterAccessory } from '../types.js'
 import type { AccessoryManagerDeps } from './AccessoryManager.js'
 
+import { DescriptorServer, FixedLabelServer } from '@matter/main/behaviors'
 import { PowerSourceServer } from '@matter/node/behaviors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -183,6 +184,26 @@ function createMockDeps(overrides: Partial<AccessoryManagerDeps> = {}): Accessor
 // so the mock must stay chainable at any depth.
 function createChainableDeviceType(props: Record<string, unknown>): any {
   return { ...props, with: vi.fn(() => createChainableDeviceType(props)) }
+}
+
+// A parent device type whose `.with()` is a single self-returning spy, so a
+// test can assert exactly which behaviors (FixedLabel, wired PowerSource) were
+// composed onto it across the several chained `.with()` calls registerAccessory
+// makes on the parent.
+function createSpyDeviceType(props: Record<string, unknown>): any {
+  const deviceType: any = { ...props }
+  deviceType.with = vi.fn(() => deviceType)
+  return deviceType
+}
+
+// A composed-device part: a plain device type plus a cluster, no handlers.
+function createComposedPart(id = 'part-1'): any {
+  return {
+    id,
+    displayName: `Part ${id}`,
+    deviceType: createChainableDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+    clusters: { onOff: { onOff: false } },
+  }
 }
 
 function createMockAccessory(overrides: Partial<MatterAccessory> = {}): MatterAccessory {
@@ -573,6 +594,94 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
+    })
+  })
+
+  describe('composed parent (FixedLabel + wired PowerSource + tag list)', () => {
+    // A parts-bearing (composed/BridgedNode) parent must carry a FixedLabel and,
+    // unless the accessory declared its own PowerSource, a wired (AC) PowerSource
+    // — Apple's controller needs both to finish per-accessory session setup.
+    // Flat accessories get neither, and part endpoints carry a semantic tag list.
+
+    it('a composed accessory gets a FixedLabel and a wired PowerSource on the parent', async () => {
+      const deps = createMockDeps()
+      const deviceType = createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' })
+      const accessory = createMockAccessory({
+        deviceType,
+        parts: [createComposedPart()],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // FixedLabelServer is composed onto the parent device type...
+      expect(deviceType.with).toHaveBeenCalledWith(FixedLabelServer)
+      // ...and a wired PowerSource is synthesized.
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Wired')
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.fixedLabel).toEqual({
+        labelList: [{ label: 'composed', value: 'true' }],
+      })
+      // wiredCurrentType 0 = AC.
+      expect(internal.endpoint.options.powerSource.wiredCurrentType).toBe(0)
+    })
+
+    it('a composed accessory that declares its own PowerSource (battery) keeps it and gets no wired PowerSource', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+        clusters: {
+          onOff: { onOff: false },
+          powerSource: { batPercentRemaining: 200, batChargeLevel: 0 },
+        },
+        parts: [createComposedPart()],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // The plugin's battery PowerSource is composed...
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+      // ...and our wired PowerSource must never overwrite it.
+      expect(PowerSourceServer.with).not.toHaveBeenCalledWith('Wired')
+      const internal = deps.accessories.get('test-uuid-001') as any
+      // The plugin's battery cluster state survives, untouched by a wired override.
+      expect(internal.endpoint.options.powerSource.batPercentRemaining).toBe(200)
+      expect(internal.endpoint.options.powerSource.wiredCurrentType).toBeUndefined()
+    })
+
+    it('a flat accessory (no parts) gets no FixedLabel or synthesized PowerSource', async () => {
+      const deps = createMockDeps()
+      const deviceType = createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' })
+      const accessory = createMockAccessory({ deviceType })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(deviceType.with).not.toHaveBeenCalledWith(FixedLabelServer)
+      expect(PowerSourceServer.with).not.toHaveBeenCalledWith('Wired')
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.fixedLabel).toBeUndefined()
+      expect(internal.endpoint.options.powerSource).toBeUndefined()
+    })
+
+    it('part endpoints carry a tag list', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+        parts: [createComposedPart('outlet-1')],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // The part's Descriptor gains the TagList feature...
+      expect(DescriptorServer.with).toHaveBeenCalledWith('TagList')
+      // ...and the part endpoint carries a Number-namespace (7) tag per part index.
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal._parts[0].endpoint.options.descriptor.tagList).toEqual([{
+        mfgCode: null,
+        namespaceId: 7,
+        tag: 0,
+        label: 'Part outlet-1',
+      }])
     })
   })
 

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -237,8 +237,6 @@ export class AccessoryManager {
         // (e.g., BridgedNodeEndpoint used as a composed device container)
         const hasBridgedInfo = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.bridgedDeviceBasicInformation !== undefined
         if (!hasBridgedInfo) {
-          // Enable the Leave and ReachableChanged events - controllers use them
-          // to track bridged device lifecycle, and known-good bridges expose both.
           deviceType = (deviceType as any).with(BridgedDeviceBasicInformationServer)
           log.debug(`Added BridgedDeviceBasicInformationServer to ${accessory.displayName}`)
         }

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -21,11 +21,10 @@ import type {
   MatterAccessoryPart,
 } from '../types.js'
 
-import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import process from 'node:process'
 
-import { Endpoint, VendorId } from '@matter/main'
+import { Endpoint } from '@matter/main'
 import { BasicInformationServer, BridgedDeviceBasicInformationServer, DescriptorServer, FixedLabelServer } from '@matter/main/behaviors'
 import { PowerSourceServer } from '@matter/node/behaviors'
 
@@ -58,7 +57,6 @@ import {
 } from '../types.js'
 import { stripVendorFromLabel } from '../utils.js'
 import { CORE_CLUSTER_BEHAVIOR_MAP } from './BehaviorMap.js'
-import { DEFAULT_VENDOR_ID } from './ServerConfig.js'
 
 // The parts-list update and ConfigurationVersion bump run inside matter.js
 // transactions that acquire their resource lock synchronously. A controller
@@ -88,25 +86,6 @@ interface DetectedClusterFeatures {
 }
 
 const log = Logger.withPrefix('Matter/Server')
-
-/**
- * Human-readable kind for the FixedLabel "composed" value on a parts-bearing
- * parent, derived from the first part's device type name (matterbridge uses
- * the device class here; controllers accept any string).
- */
-function composedKindLabel(part: MatterAccessoryPart): string {
-  const name = (part.deviceType as { name?: string })?.name ?? ''
-  if (name.includes('Light')) {
-    return 'Light'
-  }
-  if (name.includes('Outlet') || name.includes('PlugIn')) {
-    return 'Outlet'
-  }
-  if (name.includes('Switch')) {
-    return 'Switch'
-  }
-  return 'Device'
-}
 
 export interface AccessoryManagerDeps {
   config: MatterServerConfig
@@ -261,7 +240,7 @@ export class AccessoryManager {
         if (!hasBridgedInfo) {
           // Enable the Leave and ReachableChanged events - controllers use them
           // to track bridged device lifecycle, and known-good bridges expose both.
-          deviceType = (deviceType as any).with(BridgedDeviceBasicInformationServer.enable({ events: { leave: true, reachableChanged: true } }))
+          deviceType = (deviceType as any).with(BridgedDeviceBasicInformationServer)
           log.debug(`Added BridgedDeviceBasicInformationServer to ${accessory.displayName}`)
         }
       }
@@ -273,21 +252,27 @@ export class AccessoryManager {
       // to the composed accessory. Without it (plus the PowerSource below),
       // homed never finishes its per-accessory session setup: commands fail
       // silently ("No Response") from ~30s after pairing while reads keep working.
-      if (accessory.parts && accessory.parts.length > 0 && (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.fixedLabel === undefined) {
-        deviceType = (deviceType as any).with(FixedLabelServer)
-        endpointOptions.fixedLabel = {
-          labelList: [{ label: 'composed', value: composedKindLabel(accessory.parts[0]) }],
+      if (accessory.parts && accessory.parts.length > 0) {
+        if ((deviceType as { behaviors?: Record<string, unknown> }).behaviors?.fixedLabel === undefined) {
+          deviceType = (deviceType as any).with(FixedLabelServer)
+          endpointOptions.fixedLabel = {
+            labelList: [{ label: 'composed', value: 'true' }],
+          }
         }
 
         // Known-good bridges also expose a wired PowerSource on composed
-        // parents; Apple's controller appears to expect it.
-        deviceType = (deviceType as any).with((PowerSourceServer as any).with('Wired'))
-        endpointOptions.powerSource = {
-          status: 1, // Active
-          order: 0,
-          description: 'AC Power',
-          endpointList: [],
-          wiredCurrentType: 1, // AC
+        // parents; Apple's controller appears to expect it. Only synthesize it
+        // when the accessory has not declared its own PowerSource — otherwise a
+        // plugin-provided battery PowerSource (added below) would be overwritten.
+        if (!accessory.clusters?.powerSource) {
+          deviceType = (deviceType as any).with((PowerSourceServer as any).with('Wired'))
+          endpointOptions.powerSource = {
+            status: 1, // Active
+            order: 0,
+            description: 'AC Power',
+            endpointList: [],
+            wiredCurrentType: 0, // AC (PowerSource.WiredCurrentType.Ac)
+          }
         }
       }
 
@@ -653,17 +638,7 @@ export class AccessoryManager {
     }
 
     if (!config.externalAccessory) {
-      // Apple homed refuses to register accessories whose firmware metadata is
-      // missing or unparseable ("invalid matter AFU settings") - which silently
-      // breaks its whole control path. Derive a consistent numeric+string
-      // version pair from the accessory's firmware revision.
-      const versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(accessory.firmwareRevision || '')
-      const version = versionMatch
-        ? [Number(versionMatch[1]) & 0xFF, Number(versionMatch[2]) & 0xFF, Number(versionMatch[3]) & 0xFF]
-        : [1, 0, 0]
-
       endpointOptions.bridgedDeviceBasicInformation = {
-        vendorId: VendorId(DEFAULT_VENDOR_ID),
         vendorName: accessory.manufacturer,
         nodeLabel: accessory.displayName,
         productName: accessory.model,
@@ -672,19 +647,7 @@ export class AccessoryManager {
         productLabel: stripVendorFromLabel(accessory.displayName, accessory.manufacturer)
           || accessory.model || 'Device',
         serialNumber: accessory.serialNumber,
-        softwareVersion: (version[0] << 16) | (version[1] << 8) | version[2],
-        softwareVersionString: version.join('.'),
-        hardwareVersion: 1,
-        hardwareVersionString: '1.0.0',
-        configurationVersion: 1,
-        productUrl: 'https://homebridge.io',
         reachable: true,
-        // matter.js otherwise fills uniqueId with a random string persisted
-        // only in its own storage; controllers key bridged accessory identity
-        // on it. Derive it from the accessory UUID so the same registration
-        // always yields the same identity. This is a stable non-cryptographic
-        // identity derivation, truncated to the attribute's 32-char cap.
-        uniqueId: createHash('sha256').update(accessory.UUID).digest('hex').slice(0, 32),
       }
     }
 

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -18,13 +18,15 @@ import type {
   InternalMatterAccessoryPart,
   MatterAccessory,
   MatterAccessoryEventEmitter,
+  MatterAccessoryPart,
 } from '../types.js'
 
+import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import process from 'node:process'
 
-import { Endpoint } from '@matter/main'
-import { BasicInformationServer, BridgedDeviceBasicInformationServer, DescriptorServer } from '@matter/main/behaviors'
+import { Endpoint, VendorId } from '@matter/main'
+import { BasicInformationServer, BridgedDeviceBasicInformationServer, DescriptorServer, FixedLabelServer } from '@matter/main/behaviors'
 import { PowerSourceServer } from '@matter/node/behaviors'
 
 import { IpcOutgoingEvent } from '../../ipcService.js'
@@ -56,6 +58,7 @@ import {
 } from '../types.js'
 import { stripVendorFromLabel } from '../utils.js'
 import { CORE_CLUSTER_BEHAVIOR_MAP } from './BehaviorMap.js'
+import { DEFAULT_VENDOR_ID } from './ServerConfig.js'
 
 // The parts-list update and ConfigurationVersion bump run inside matter.js
 // transactions that acquire their resource lock synchronously. A controller
@@ -85,6 +88,25 @@ interface DetectedClusterFeatures {
 }
 
 const log = Logger.withPrefix('Matter/Server')
+
+/**
+ * Human-readable kind for the FixedLabel "composed" value on a parts-bearing
+ * parent, derived from the first part's device type name (matterbridge uses
+ * the device class here; controllers accept any string).
+ */
+function composedKindLabel(part: MatterAccessoryPart): string {
+  const name = (part.deviceType as { name?: string })?.name ?? ''
+  if (name.includes('Light')) {
+    return 'Light'
+  }
+  if (name.includes('Outlet') || name.includes('PlugIn')) {
+    return 'Outlet'
+  }
+  if (name.includes('Switch')) {
+    return 'Switch'
+  }
+  return 'Device'
+}
 
 export interface AccessoryManagerDeps {
   config: MatterServerConfig
@@ -237,12 +259,38 @@ export class AccessoryManager {
         // (e.g., BridgedNodeEndpoint used as a composed device container)
         const hasBridgedInfo = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.bridgedDeviceBasicInformation !== undefined
         if (!hasBridgedInfo) {
-          deviceType = (deviceType as any).with(BridgedDeviceBasicInformationServer)
+          // Enable the Leave and ReachableChanged events - controllers use them
+          // to track bridged device lifecycle, and known-good bridges expose both.
+          deviceType = (deviceType as any).with(BridgedDeviceBasicInformationServer.enable({ events: { leave: true, reachableChanged: true } }))
           log.debug(`Added BridgedDeviceBasicInformationServer to ${accessory.displayName}`)
         }
       }
 
       const endpointOptions = this.createEndpointOptions(accessory, deps.config)
+
+      // Composed parents carry a FixedLabel marking the composition, matching
+      // known-good bridges - Apple's controller needs it to bind child endpoints
+      // to the composed accessory. Without it (plus the PowerSource below),
+      // homed never finishes its per-accessory session setup: commands fail
+      // silently ("No Response") from ~30s after pairing while reads keep working.
+      if (accessory.parts && accessory.parts.length > 0 && (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.fixedLabel === undefined) {
+        deviceType = (deviceType as any).with(FixedLabelServer)
+        endpointOptions.fixedLabel = {
+          labelList: [{ label: 'composed', value: composedKindLabel(accessory.parts[0]) }],
+        }
+
+        // Known-good bridges also expose a wired PowerSource on composed
+        // parents; Apple's controller appears to expect it.
+        deviceType = (deviceType as any).with((PowerSourceServer as any).with('Wired'))
+        endpointOptions.powerSource = {
+          status: 1, // Active
+          order: 0,
+          description: 'AC Power',
+          endpointList: [],
+          wiredCurrentType: 1, // AC
+        }
+      }
+
       const endpoint = new Endpoint(deviceType, endpointOptions)
 
       setRegistryManager(endpoint, deps.registryManager)
@@ -605,7 +653,17 @@ export class AccessoryManager {
     }
 
     if (!config.externalAccessory) {
+      // Apple homed refuses to register accessories whose firmware metadata is
+      // missing or unparseable ("invalid matter AFU settings") - which silently
+      // breaks its whole control path. Derive a consistent numeric+string
+      // version pair from the accessory's firmware revision.
+      const versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(accessory.firmwareRevision || '')
+      const version = versionMatch
+        ? [Number(versionMatch[1]) & 0xFF, Number(versionMatch[2]) & 0xFF, Number(versionMatch[3]) & 0xFF]
+        : [1, 0, 0]
+
       endpointOptions.bridgedDeviceBasicInformation = {
+        vendorId: VendorId(DEFAULT_VENDOR_ID),
         vendorName: accessory.manufacturer,
         nodeLabel: accessory.displayName,
         productName: accessory.model,
@@ -614,7 +672,19 @@ export class AccessoryManager {
         productLabel: stripVendorFromLabel(accessory.displayName, accessory.manufacturer)
           || accessory.model || 'Device',
         serialNumber: accessory.serialNumber,
+        softwareVersion: (version[0] << 16) | (version[1] << 8) | version[2],
+        softwareVersionString: version.join('.'),
+        hardwareVersion: 1,
+        hardwareVersionString: '1.0.0',
+        configurationVersion: 1,
+        productUrl: 'https://homebridge.io',
         reachable: true,
+        // matter.js otherwise fills uniqueId with a random string persisted
+        // only in its own storage; controllers key bridged accessory identity
+        // on it. Derive it from the accessory UUID so the same registration
+        // always yields the same identity. This is a stable non-cryptographic
+        // identity derivation, truncated to the attribute's 32-char cap.
+        uniqueId: createHash('sha256').update(accessory.UUID).digest('hex').slice(0, 32),
       }
     }
 
@@ -663,7 +733,7 @@ export class AccessoryManager {
 
     log.info(`Creating ${accessory.parts.length} child endpoint(s) for ${accessory.displayName}`)
 
-    for (const part of accessory.parts) {
+    for (const [partIndex, part] of accessory.parts.entries()) {
       const partEndpointId = `${accessory.UUID}-part-${part.id}`
 
       deps.behaviorRegistry.registerPartEndpoint(partEndpointId, accessory.UUID, part.id)
@@ -698,8 +768,22 @@ export class AccessoryManager {
         partDeviceType = applyElectricalMeasurementClusters(partDeviceType, part, partElectrical)
       }
 
+      // Tag each child with a semantic Number tag so controllers can stably
+      // re-map otherwise-identical children of a composed device; without it
+      // they are distinguishable only by transient endpoint number, which
+      // Apple Home mishandles across hub changes.
+      partDeviceType = (partDeviceType as any).with(DescriptorServer.with('TagList'))
+
       const partEndpointOptions: any = {
         id: partEndpointId,
+        descriptor: {
+          tagList: [{
+            mfgCode: null,
+            namespaceId: 7, // Number namespace
+            tag: partIndex,
+            label: (part.displayName || part.id).slice(0, 64),
+          }],
+        },
         ...part.clusters,
       }
 

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -18,7 +18,6 @@ import type {
   InternalMatterAccessoryPart,
   MatterAccessory,
   MatterAccessoryEventEmitter,
-  MatterAccessoryPart,
 } from '../types.js'
 
 import { EventEmitter } from 'node:events'


### PR DESCRIPTION
## Summary

Any Matter accessory registered with `parts` (a BridgedNode parent with child
endpoints) is uncontrollable from Apple Home beyond the first ~30 seconds
after pairing. Reads keep working indefinitely; every command fails silently
("No Response") with no error on either side. Flat accessories are unaffected.

Root cause (established by log-streaming the Apple TV home hub's `homed`
daemon and byte-diffing Matter descriptor dumps against a working reference
bridge): Apple's controller cannot build its internal model for a composed
bridged device unless the parent endpoint also exposes a **FixedLabel**
cluster and a **PowerSource** cluster. Without them, homed's per-accessory
session setup silently stalls:

- the child endpoints never bind to the composed accessory,
- homed's Matter-report→characteristic translation produces zero updates for
  the whole node (its `MTRDevice` layer receives our reports fine),
- the accessory-info model never populates, the accessory is never
  "configured", and homed's *Add accessory pairing operation* times out after
  ~30 s with `HMErrorDomain Code=4 (accessoryNotReachable)`.

The ~30 s of working control after pairing is the commissioning iPhone
controlling the accessory directly while that operation is still pending —
which makes the failure look like a mysterious timeout rather than a
modeling error. Nothing is logged at any level a bridge operator can see.

The fix is two clusters on the parent endpoint of parts-bearing accessories:

- `FixedLabel` with `labelList: [{ label: "composed", value: <kind> }]`
- `PowerSource` (Wired feature) with static wired-AC state

This matches what the matterbridge project has always exposed on composed
parents (`addFixedLabel('composed', …)` and
`createDefaultPowerSourceWiredClusterServer()`), which is why bridges built
on it never exhibited the failure.

## Evidence

- Descriptor diff of a WORKING composed parent (matterbridge, same Apple
  hub/LAN) vs a Homebridge composed parent:
  ServerList `[Descriptor, BridgedDeviceBasicInformation, PowerSource,
  FixedLabel]` vs `[BridgedDeviceBasicInformation, Descriptor]`. Child
  endpoints are equivalent.
- Bisect on a 40-line test plugin (included as the reproducer below): flat
  OnOffLight works; the same accessory as BridgedNode+part fails; adding
  FixedLabel alone → accessory no longer surfaces in Home; adding
  FixedLabel + PowerSource → works indefinitely (verified >2 min of
  continuous toggling, including hub-routed commands with the phone on
  cellular).
- Hub-side marker: `homed`'s `HMDMatterAttributeChangedNotification` count
  for the node goes from 0 (broken, all captures) to hundreds (fixed),
  with `Configuring with HAPAccessory` appearing only once the clusters are
  present.
- With the fix, an 11-device production bridge (mixed flat/composed, mixed
  light/outlet/switch types) survives everything that previously failed:
  control past the timeout, Homebridge restarts with room assignments
  intact, and home-hub elections (which previously re-adopted composed
  accessories as new, resetting rooms, every time).

Environment: Homebridge v2.2.2-beta.5, @matter 0.17.5, Apple Home on
iOS/tvOS 27 beta (multiple hubs). The same failure signature was present on
earlier tvOS-26.x observations of composed accessories.

## Implementation

All changes are in `AccessoryManager` (validated as a dist patch running in
production; this PR ports it to the TypeScript sources):

- **FixedLabel + PowerSource on parts-bearing parents.** After
  `createEndpointOptions()`, a parts-bearing accessory whose device type does
  not already carry `fixedLabel` gets
  `FixedLabelServer` (with `labelList: [{ label: 'composed', value: <kind> }]`)
  and `PowerSourceServer.with('Wired')` (static wired-AC state) composed onto
  the parent device type. The `<kind>` value is derived from the first part's
  device type name mapped to a human word (Light/Outlet/Switch, else Device) —
  the validated dist patch hardcoded one value and Apple did not appear to care
  about the string, but the derived label matches what matterbridge exposes.
- **BridgedDeviceBasicInformation completeness**, bundled here because it is
  the same "Apple builds its accessory model from this metadata" class of fix,
  discovered in the same investigation:
  - `softwareVersion`/`softwareVersionString` parsed from the accessory's
    `firmwareRevision` (`x.y.z` triplet, bytes packed into the numeric
    version; `1.0.0` fallback). Apple homed refuses to register accessories
    whose firmware metadata is missing or unparseable ("invalid matter AFU
    settings") — which silently breaks its whole control path.
  - `vendorId` (test vendor ID, matching the bridge's own), `hardwareVersion`,
    `configurationVersion`, `productUrl`.
  - deterministic `uniqueId` derived by hashing the accessory UUID (truncated sha256). matter.js otherwise fills
    it with a random string persisted only in its own storage; controllers key
    bridged accessory identity on it, so deriving it from the accessory UUID
    makes the same registration always yield the same identity.
  - `leave` and `reachableChanged` events enabled on the
    BridgedDeviceBasicInformationServer.
- **Descriptor TagList on part endpoints**: each child gets a semantic Number
  tag (`namespaceId: 7`, `tag` = part index, `label` = part display name) so
  controllers can stably re-map otherwise-identical children of a composed
  device; without it they are distinguishable only by transient endpoint
  number, which Apple Home mishandles across hub changes.

Both parent clusters are cheap static state; no runtime maintenance needed.
PowerSource here describes the bridge device's mains supply; if the API later
grows battery-state support, the plugin should be able to override.

## Reproducer

Minimal plugin (~40 lines, one virtual OnOffLight, no hardware needed) that
registers the accessory as BridgedNode+part (fails without this fix; register
the part's device type flat instead and it works). Pair the child bridge with
Apple Home, toggle for 60 s. Failure mode: toggles work ~30 s, then permanent
"No Response" while the tile still shows live state.

`index.js`:

```js
module.exports = (api) => {
  api.registerPlatform("homebridge-matter-minimal", "MatterMinimal", class {
    constructor(log, config, api) {
      this.log = log;
      this.api = api;
      this.state = false;
      api.on("didFinishLaunching", () => { this.register().catch((e) => log.error(String(e))); });
    }
    configureMatterAccessory() {}
    async register() {
      const uuid = this.api.hap.uuid.generate("matter-minimal-light-1");
      const accessory = {
        UUID: uuid,
        displayName: "Minimal Light",
        serialNumber: "MIN-0001",
        manufacturer: "Minimal",
        model: "MinimalLight",
        firmwareRevision: "1.0.0",
        context: {},
        deviceType: this.api.matter.deviceTypes.BridgedNode,
        parts: [{
          id: "switch-0-light",
          displayName: "Minimal Light",
          deviceType: this.api.matter.deviceTypes.OnOffLight,
          clusters: { onOff: { onOff: this.state } },
          handlers: {
            onOff: {
              on: () => { this.state = true; this.log.info("Minimal Light ON"); },
              off: () => { this.state = false; this.log.info("Minimal Light OFF"); },
            },
          },
        }],
      };
      for (let i = 0; i < 24; i++) {
        try {
          await this.api.matter.registerPlatformAccessories("homebridge-matter-minimal", "MatterMinimal", [accessory]);
          const ok = await this.api.matter.getAccessoryState(uuid, "onOff", "switch-0-light");
          if (ok !== undefined) { this.log.info("Minimal Light registered."); return; }
        } catch (e) { this.log.debug("retrying registration: " + e.message); }
        await new Promise((r) => setTimeout(r, 5000));
      }
      this.log.error("Minimal Light never registered");
    }
  });
};
```

`package.json`:

```json
{
  "name": "homebridge-matter-minimal",
  "version": "0.0.1",
  "description": "Minimal Matter test plugin - one static OnOffLight",
  "main": "index.js",
  "engines": { "homebridge": ">=2.2.0" },
  "keywords": ["homebridge-plugin"]
}
```

## Notes for reviewers

- Same investigation lineage as #3969/#3970; we can run any scenario on our
  deployment (11 Shelly devices, Apple Home, multiple tvOS 27 hubs).
- This is Apple-behavior-driven, not spec-mandated — the spec does not
  require these clusters on composed parents. We plan to file the silent
  30-second-timeout failure mode with Apple separately; but exposing the
  clusters is the pragmatic fix and matches the only bridge stack Apple
  demonstrably works with.
- Related cosmetic fix worth bundling separately: the "No custom behavior
  class available for cluster 'electricalPowerMeasurement'" warning fires for
  attribute-only clusters that have no commands; it should be suppressed
  for clusters without accepted commands.
