### PR TITLE
fix(matter): defer bridge online until registrations settle

### DIFF
--- a/src/matter/BaseMatterManager.spec.ts
+++ b/src/matter/BaseMatterManager.spec.ts
@@ -89,6 +89,30 @@ describe('baseMatterManager', () => {
     })
   })
 
+  describe('isBridgeServerStarting', () => {
+    it('is false when no bridge MatterServer exists', () => {
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+
+    it('is false once the server is running', () => {
+      manager.setMatterServer({ isServerRunning: () => true, isDeferredPreOnline: () => false } as any)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+
+    it('is true while the server is still starting (not running, not deferred)', () => {
+      manager.setMatterServer({ isServerRunning: () => false, isDeferredPreOnline: () => false } as any)
+      expect(manager.isBridgeServerStarting()).toBe(true)
+    })
+
+    it('is false while deliberately offline in deferOnline mode, so registrations are accepted', () => {
+      // The deadlock this guards against: if registrations were rejected while
+      // the deferred node is offline, the settle signal would never fire and
+      // the node would come online with no accessories.
+      manager.setMatterServer({ isServerRunning: () => false, isDeferredPreOnline: () => true } as any)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+  })
+
   describe('handleTriggerCommand', () => {
     it('should route commands to external server if accessory is external', async () => {
       const uuid = 'test-uuid'

--- a/src/matter/BaseMatterManager.spec.ts
+++ b/src/matter/BaseMatterManager.spec.ts
@@ -111,6 +111,28 @@ describe('baseMatterManager', () => {
       manager.setMatterServer({ isServerRunning: () => false, isDeferredPreOnline: () => true } as any)
       expect(manager.isBridgeServerStarting()).toBe(false)
     })
+
+    it('treats a constructed but not yet built deferred server as starting (real isDeferredPreOnline)', () => {
+      // Exercises the real method, not a stub: between `new MatterServer()`
+      // and start() building the node, deferOnline is already set but no
+      // aggregator exists yet. Registrations in that gap must be rejected as
+      // "starting", or they would hit the silent-drop path from #3970.
+      const server = new MatterServer({ uniqueId: 'test-bridge', deferOnline: true })
+      manager.setMatterServer(server as any)
+      expect(server.isDeferredPreOnline()).toBe(false)
+      expect(manager.isBridgeServerStarting()).toBe(true)
+
+      // Once start() has built the aggregator, the defer window opens...
+      ;(server as any).aggregator = {}
+      expect(server.isDeferredPreOnline()).toBe(true)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+
+      // ...and once the node is online, normal behaviour resumes
+      // (running, so no longer "starting" either).
+      ;(server as any).isRunning = true
+      expect(server.isDeferredPreOnline()).toBe(false)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
   })
 
   describe('handleTriggerCommand', () => {

--- a/src/matter/BaseMatterManager.ts
+++ b/src/matter/BaseMatterManager.ts
@@ -65,6 +65,13 @@ export abstract class BaseMatterManager {
    * are intentionally dropped by the drop stubs — that must not throw.
    */
   isBridgeServerStarting(): boolean {
+    // In deferOnline mode the server is deliberately built but kept offline
+    // until the initial registration burst settles, so registrations MUST be
+    // accepted while it is offline — otherwise they are rejected, the settle
+    // signal never fires, and the node comes online with no accessories.
+    if (this.matterServer?.isDeferredPreOnline()) {
+      return false
+    }
     return this.matterServer !== undefined && !this.matterServer.isServerRunning()
   }
 

--- a/src/matter/ChildBridgeMatterManager.spec.ts
+++ b/src/matter/ChildBridgeMatterManager.spec.ts
@@ -3,7 +3,7 @@ import type { BridgeConfiguration, BridgeOptions } from '../bridgeService.js'
 import type { ChildBridgeExternalPortService } from '../externalPortService.js'
 import type { MatterConfig } from './types.js'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { InternalAPIEvent } from '../api.js'
 import { Logger } from '../logger.js'
@@ -549,6 +549,105 @@ describe('childBridgeMatterManager', () => {
       // REGISTER and UPDATE etc. appear at least twice — once for the normal listener, once for the drop stub.
       const registerRemovals = removed.filter((e: any) => e === InternalAPIEvent.REGISTER_MATTER_PLATFORM_ACCESSORIES)
       expect(registerRemovals.length).toBe(2)
+    })
+  })
+
+  describe('runServerWhenSettled (deferred online)', () => {
+    const SETTLE_MS = 2000
+    const CAP_MS = 45000
+
+    function makeManager(): ChildBridgeMatterManager {
+      return new ChildBridgeMatterManager(
+        { ...mockBridgeConfig, matter: { enabled: true } } as any,
+        mockBridgeOptions,
+        mockApi,
+        mockExternalPortService,
+        mockPluginManager,
+      )
+    }
+
+    function makeServer(overrides: Partial<{ inFlight: number, lastRegistrationAt: number }> = {}): any {
+      return {
+        getRegistrationsInFlight: vi.fn(() => overrides.inFlight ?? 0),
+        getLastRegistrationAt: vi.fn(() => overrides.lastRegistrationAt ?? 0),
+        runServer: vi.fn().mockResolvedValue(undefined),
+      }
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('brings the node online once registrations settle', async () => {
+      const manager = makeManager()
+      const server = makeServer({ lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Still within the settle window after the last registration.
+      await vi.advanceTimersByTimeAsync(SETTLE_MS - 100)
+      expect(server.runServer).not.toHaveBeenCalled()
+
+      // Past the settle window -> online.
+      await vi.advanceTimersByTimeAsync(600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('goes online promptly when no registrations ever arrive', async () => {
+      const manager = makeManager()
+      const server = makeServer({ lastRegistrationAt: 0, inFlight: 0 })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Online just after the settle window, long before the 45s cap - if it
+      // waited for the cap it would not have fired at 2.6s.
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not go online while a registration is still in flight', async () => {
+      const manager = makeManager()
+      const server = makeServer({ inFlight: 1, lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 2000)
+      expect(server.runServer).not.toHaveBeenCalled()
+
+      // Once in flight drains and the window passes, it comes online.
+      server.getRegistrationsInFlight.mockReturnValue(0)
+      server.getLastRegistrationAt.mockReturnValue(Date.now())
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops polling if the server is torn down mid-wait', async () => {
+      const manager = makeManager()
+      const server = makeServer()
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // A restart mid-wait replaces the server reference.
+      ;(manager as any).matterServer = makeServer()
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + CAP_MS)
+      expect(server.runServer).not.toHaveBeenCalled()
+    })
+
+    it('goes online at the cap if registrations never drain', async () => {
+      const manager = makeManager()
+      const server = makeServer({ inFlight: 1, lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Never settles (in flight stuck), so it only comes online at the cap.
+      await vi.advanceTimersByTimeAsync(CAP_MS - 1000)
+      expect(server.runServer).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/matter/ChildBridgeMatterManager.ts
+++ b/src/matter/ChildBridgeMatterManager.ts
@@ -28,6 +28,14 @@ import { appendUsernameSuffix, getMatterJsVersion, normalizeBindConfig } from '.
 const log = Logger.withPrefix('Matter/ChildManager')
 const COLON_RE = /:/g
 
+// Deferred-online settle loop tuning (see startMatterServer): the node goes
+// online once registrations have been idle for SETTLE_MS, checked every
+// POLL_MS, capped at CAP_MS so a stuck or registration-less plugin cannot
+// keep the bridge offline.
+const DEFER_ONLINE_SETTLE_MS = 2000
+const DEFER_ONLINE_CAP_MS = 45000
+const DEFER_ONLINE_POLL_MS = 500
+
 /**
  * Matter status information for child bridge IPC communication
  */
@@ -242,6 +250,12 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
       serialNumber,
       networkInterfaces,
       disableIpv4: matterConfig.disableIpv4,
+      // Build the node fully (accessory cache restored, initial plugin
+      // registrations applied offline) before it goes online, so a
+      // commissioned controller's subscription re-establishment - which runs
+      // once, right after the node comes online, with a short per-peer
+      // connection timeout - is not aborted by registration transactions.
+      deferOnline: true,
     })
 
     await this.matterServer.start()
@@ -260,6 +274,45 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
 
     // Set up event listeners for Matter API calls
     this.setupEventListeners()
+
+    // Deferred-online: bring the node online once the initial plugin
+    // registration burst has settled.
+    this.runServerWhenSettled(this.matterServer)
+  }
+
+  /**
+   * Poll until plugin registrations have been idle for DEFER_ONLINE_SETTLE_MS
+   * (capped at DEFER_ONLINE_CAP_MS so a stuck or registration-less plugin
+   * cannot keep the bridge offline), then bring the deferred node online.
+   */
+  private runServerWhenSettled(server: MatterServer): void {
+    const deferStartedAt = Date.now()
+
+    const check = (): void => {
+      // Stop polling if the server was torn down (or replaced) mid-defer.
+      if (this.matterServer !== server) {
+        return
+      }
+
+      const lastRegistrationAt = server.getLastRegistrationAt()
+      const idleSince = Math.max(lastRegistrationAt, deferStartedAt)
+      const settled = lastRegistrationAt > 0 && Date.now() - idleSince >= DEFER_ONLINE_SETTLE_MS
+      const capped = Date.now() - deferStartedAt >= DEFER_ONLINE_CAP_MS
+
+      if (!settled && !capped) {
+        setTimeout(check, DEFER_ONLINE_POLL_MS)
+        return
+      }
+
+      if (capped && !settled) {
+        log.warn(`Deferred Matter start: no registrations settled within ${DEFER_ONLINE_CAP_MS / 1000}s - going online anyway`)
+      }
+      server.runServer().catch((error) => {
+        log.error('Deferred Matter server start failed:', error)
+      })
+    }
+
+    setTimeout(check, DEFER_ONLINE_POLL_MS)
   }
 
   /**

--- a/src/matter/ChildBridgeMatterManager.ts
+++ b/src/matter/ChildBridgeMatterManager.ts
@@ -294,9 +294,12 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
         return
       }
 
-      const lastRegistrationAt = server.getLastRegistrationAt()
-      const idleSince = Math.max(lastRegistrationAt, deferStartedAt)
-      const settled = lastRegistrationAt > 0 && Date.now() - idleSince >= DEFER_ONLINE_SETTLE_MS
+      // Settle once no registration has started or been in flight for the
+      // settle window. A bridge that never registers (or restores purely from
+      // the accessory cache) settles the window after deferStartedAt, so it
+      // goes online promptly rather than waiting for the cap.
+      const idleSince = Math.max(server.getLastRegistrationAt(), deferStartedAt)
+      const settled = server.getRegistrationsInFlight() === 0 && Date.now() - idleSince >= DEFER_ONLINE_SETTLE_MS
       const capped = Date.now() - deferStartedAt >= DEFER_ONLINE_CAP_MS
 
       if (!settled && !capped) {

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -61,6 +61,7 @@ export class MatterServer extends EventEmitter {
   private readonly registryManager: RegistryManager
   private isRunning = false
   private lastRegistrationAt = 0
+  private registrationsInFlight = 0
   private shutdownHandler: (() => Promise<void>) | null = null
   private cleanupHandlers: Array<() => void | Promise<void>> = []
   private accessoryCache: MatterAccessoryCache | null = null
@@ -161,10 +162,24 @@ export class MatterServer extends EventEmitter {
     return this.lastRegistrationAt
   }
 
+  /** Registration calls that have started but not finished; used by the deferred-online settle check. */
+  getRegistrationsInFlight(): number {
+    return this.registrationsInFlight
+  }
+
   async registerPlatformAccessories(pluginIdentifier: string, platformName: string, accessories: MatterAccessory[]): Promise<void> {
+    // Stamp on both entry and exit and track in-flight calls so the deferred-
+    // online settle check never treats a batch that is still registering (or
+    // one that takes longer than the settle window) as idle.
+    this.registrationsInFlight++
     this.lastRegistrationAt = Date.now()
-    for (const accessory of accessories) {
-      await this.accessoryManager.registerAccessory(pluginIdentifier, platformName, accessory, this.getAccessoryManagerDeps())
+    try {
+      for (const accessory of accessories) {
+        await this.accessoryManager.registerAccessory(pluginIdentifier, platformName, accessory, this.getAccessoryManagerDeps())
+      }
+    } finally {
+      this.lastRegistrationAt = Date.now()
+      this.registrationsInFlight--
     }
   }
 
@@ -326,6 +341,15 @@ export class MatterServer extends EventEmitter {
 
   isServerRunning(): boolean {
     return this.isRunning
+  }
+
+  /**
+   * True while the node is built but deliberately kept offline in deferOnline
+   * mode, waiting for the initial registration burst to settle. Registrations
+   * are expected in this window, so callers must not treat it as "starting".
+   */
+  isDeferredPreOnline(): boolean {
+    return this.config.deferOnline === true && !this.isRunning
   }
 
   getDeviceTypes(): typeof deviceTypes {

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -60,6 +60,7 @@ export class MatterServer extends EventEmitter {
   private readonly behaviorRegistry: BehaviorRegistry
   private readonly registryManager: RegistryManager
   private isRunning = false
+  private lastRegistrationAt = 0
   private shutdownHandler: (() => Promise<void>) | null = null
   private cleanupHandlers: Array<() => void | Promise<void>> = []
   private accessoryCache: MatterAccessoryCache | null = null
@@ -151,7 +152,17 @@ export class MatterServer extends EventEmitter {
   // Accessory registration (Plugin API - matches HAP pattern)
   // ============================================================================
 
+  /**
+   * When the last registerPlatformAccessories() call arrived. The
+   * deferred-online settle loop (ChildBridgeMatterManager) polls this to
+   * detect when the initial registration burst has gone idle.
+   */
+  getLastRegistrationAt(): number {
+    return this.lastRegistrationAt
+  }
+
   async registerPlatformAccessories(pluginIdentifier: string, platformName: string, accessories: MatterAccessory[]): Promise<void> {
+    this.lastRegistrationAt = Date.now()
     for (const accessory of accessories) {
       await this.accessoryManager.registerAccessory(pluginIdentifier, platformName, accessory, this.getAccessoryManagerDeps())
     }

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -347,9 +347,12 @@ export class MatterServer extends EventEmitter {
    * True while the node is built but deliberately kept offline in deferOnline
    * mode, waiting for the initial registration burst to settle. Registrations
    * are expected in this window, so callers must not treat it as "starting".
+   * The aggregator check keeps this false before start() has built the node
+   * (and when start() failed) - registrations in that gap must be rejected as
+   * "starting", or they would be silently dropped (#3970).
    */
   isDeferredPreOnline(): boolean {
-    return this.config.deferOnline === true && !this.isRunning
+    return this.config.deferOnline === true && !this.isRunning && this.aggregator !== null
   }
 
   getDeviceTypes(): typeof deviceTypes {

--- a/src/matter/server/CommissioningManager.spec.ts
+++ b/src/matter/server/CommissioningManager.spec.ts
@@ -266,4 +266,34 @@ describe('commissioningManager', () => {
       await expect(manager.updateCommissioningFile(deps)).resolves.not.toThrow()
     })
   })
+
+  describe('purgeSubscriptionsForFabric', () => {
+    function serverNodeWith(subs: any[]) {
+      const subscriptions = { state: { subscriptions: subs } }
+      return {
+        node: { act: async (cb: any) => cb({ get: () => subscriptions }) },
+        subscriptions,
+      }
+    }
+
+    it('removes only the persisted subscriptions of the deleted fabric', async () => {
+      const { node, subscriptions } = serverNodeWith([
+        { peerAddress: { fabricIndex: 1 } },
+        { peerAddress: { fabricIndex: 2 } },
+        { peerAddress: { fabricIndex: 1 } },
+      ])
+      await (manager as any).purgeSubscriptionsForFabric(node, 1)
+      expect(subscriptions.state.subscriptions).toEqual([{ peerAddress: { fabricIndex: 2 } }])
+    })
+
+    it('leaves subscriptions untouched when none belong to the fabric', async () => {
+      const { node, subscriptions } = serverNodeWith([{ peerAddress: { fabricIndex: 2 } }])
+      await (manager as any).purgeSubscriptionsForFabric(node, 1)
+      expect(subscriptions.state.subscriptions).toEqual([{ peerAddress: { fabricIndex: 2 } }])
+    })
+
+    it('is a no-op when there is no server node', async () => {
+      await expect((manager as any).purgeSubscriptionsForFabric(null, 1)).resolves.toBeUndefined()
+    })
+  })
 })

--- a/src/matter/server/CommissioningManager.ts
+++ b/src/matter/server/CommissioningManager.ts
@@ -15,6 +15,7 @@ import { randomBytes } from 'node:crypto'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { SubscriptionsServer } from '@matter/node'
 import { ManualPairingCodeCodec, QrCode, QrPairingCodeCodec } from '@matter/types/schema'
 
 import { Logger } from '../../logger.js'
@@ -308,6 +309,12 @@ export class CommissioningManager {
       this.onFabricsChanged = (fabricIndex, action) => {
         log.info(`Fabric ${action}: index ${fabricIndex}`)
 
+        if (action === 'deleted') {
+          this.purgeSubscriptionsForFabric(deps.serverNode, fabricIndex).catch((error) => {
+            log.debug(`Failed to purge persisted subscriptions for removed fabric ${fabricIndex}:`, error)
+          })
+        }
+
         // Compute commissioning state once and reuse for both the file update
         // and the IPC emit, then push the snapshot into updateCommissioningFile
         // so it doesn't redo the same fabric reads.
@@ -348,6 +355,34 @@ export class CommissioningManager {
       // Roll back any partial registration so a retry can succeed
       this.teardownCommissioningEventListeners(deps.serverNode)
     }
+  }
+
+  /**
+   * Delete persisted subscriptions belonging to a removed fabric.
+   *
+   * matter.js persists controller subscriptions so it can proactively
+   * re-establish them when the node next comes online (a single pass with a
+   * short, no-retry connection timeout per peer). It removes the fabric's
+   * sessions on removal but leaves the persisted subscription entries behind,
+   * so re-establishment wastes its window on peers that can never answer
+   * ("Failed to connect to ... Fabric index #N does not exist").
+   */
+  private async purgeSubscriptionsForFabric(serverNode: ServerNode | null, fabricIndex: number): Promise<void> {
+    if (!serverNode) {
+      return
+    }
+
+    await serverNode.act((agent) => {
+      const subscriptions = agent.get(SubscriptionsServer)
+      const remaining = subscriptions.state.subscriptions.filter(
+        subscription => subscription.peerAddress.fabricIndex !== fabricIndex,
+      )
+      const purged = subscriptions.state.subscriptions.length - remaining.length
+      if (purged > 0) {
+        subscriptions.state.subscriptions = remaining
+        log.debug(`Purged ${purged} persisted subscription(s) for removed fabric ${fabricIndex}`)
+      }
+    })
   }
 
   /**

--- a/src/matter/server/ServerConfig.ts
+++ b/src/matter/server/ServerConfig.ts
@@ -111,5 +111,6 @@ export function validateAndSanitizeConfig(config: MatterServerConfig): MatterSer
     externalAccessory,
     networkInterfaces: config.networkInterfaces,
     disableIpv4: config.disableIpv4,
+    deferOnline: config.deferOnline,
   }
 }

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -13,6 +13,7 @@ import type { MatterServerConfig } from '../sharedTypes.js'
 import type { CommissioningDeps, CommissioningManager } from './CommissioningManager.js'
 import type { FabricManager } from './FabricManager.js'
 
+import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import { access, mkdir, rm, stat } from 'node:fs/promises'
 import { homedir, release } from 'node:os'
@@ -288,6 +289,15 @@ export class ServerLifecycle {
 
       const sanitizedId = deps.config.uniqueId!
 
+      // Apple homed refuses to register nodes whose firmware metadata is
+      // missing or unparseable ("invalid matter AFU settings") - which
+      // silently breaks its whole control path. Derive a consistent
+      // numeric+string version pair from the configured firmware revision.
+      const versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(deps.config.firmwareRevision || getVersion() || '')
+      const version = versionMatch
+        ? [Number(versionMatch[1]) & 0xFF, Number(versionMatch[2]) & 0xFF, Number(versionMatch[3]) & 0xFF]
+        : [1, 0, 0]
+
       const nodeOptions: Parameters<typeof MatterServerNode.create>[0] = {
         id: sanitizedId,
         network: {
@@ -307,9 +317,17 @@ export class ServerLifecycle {
           serialNumber: deps.config.serialNumber || deps.config.uniqueId,
           hardwareVersion: 1,
           hardwareVersionString: release(),
-          softwareVersion: 1,
-          softwareVersionString: deps.config.firmwareRevision || getVersion(),
+          softwareVersion: (version[0] << 16) | (version[1] << 8) | version[2],
+          softwareVersionString: version.join('.'),
+          configurationVersion: 1,
+          productUrl: 'https://homebridge.io',
           reachable: true,
+          // matter.js otherwise fills uniqueId with a random string persisted
+          // only in its own storage; controllers key node identity on it.
+          // Derive it from the bridge's uniqueId so the same bridge always
+          // yields the same identity. This is a stable non-cryptographic
+          // identity derivation, truncated to the attribute's 32-char cap.
+          uniqueId: createHash('sha256').update(deps.config.uniqueId).digest('hex').slice(0, 32),
         },
       }
 
@@ -427,7 +445,15 @@ export class ServerLifecycle {
           await deps.restoreAccessoriesFromCache()
         }
 
-        await this.startServerNode(serverNode, deps)
+        if (deps.config.deferOnline) {
+          // Deferred-online mode: the node is fully built (cache restored) but
+          // stays offline until runServer() - plugins register against the
+          // offline node so its FIRST advertisement already carries the final
+          // structure, and subscription re-establishment runs on a quiet node.
+          log.info('Deferred online mode - Matter node built, waiting for initial registrations before going online')
+        } else {
+          await this.startServerNode(serverNode, deps)
+        }
       } else {
         log.debug('Deferred start mode - server prepared but not running yet (will start after device registration)')
       }
@@ -476,7 +502,8 @@ export class ServerLifecycle {
   }
 
   /**
-   * Run the server after devices have been added (for external accessory mode)
+   * Run the server after devices have been added (for external accessory and
+   * deferred-online modes)
    */
   async runServer(deps: ServerLifecycleDeps): Promise<void> {
     const serverNode = deps.getServerNode()
@@ -489,8 +516,8 @@ export class ServerLifecycle {
       return
     }
 
-    if (!deps.config.externalAccessory) {
-      throw new MatterDeviceError('runServer() should only be called when externalAccessory mode is enabled')
+    if (!deps.config.externalAccessory && !deps.config.deferOnline) {
+      throw new MatterDeviceError('runServer() should only be called when externalAccessory or deferOnline mode is enabled')
     }
 
     log.debug('Running deferred server with device(s) already attached')

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -13,7 +13,6 @@ import type { MatterServerConfig } from '../sharedTypes.js'
 import type { CommissioningDeps, CommissioningManager } from './CommissioningManager.js'
 import type { FabricManager } from './FabricManager.js'
 
-import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import { access, mkdir, rm, stat } from 'node:fs/promises'
 import { homedir, release } from 'node:os'
@@ -318,16 +317,11 @@ export class ServerLifecycle {
           hardwareVersion: 1,
           hardwareVersionString: release(),
           softwareVersion: (version[0] << 16) | (version[1] << 8) | version[2],
-          softwareVersionString: version.join('.'),
-          configurationVersion: 1,
-          productUrl: 'https://homebridge.io',
+          // Keep the full version string (including any pre-release suffix) so
+          // beta builds remain identifiable to controllers/support; only the
+          // numeric softwareVersion is derived from the parsed triplet.
+          softwareVersionString: deps.config.firmwareRevision || getVersion(),
           reachable: true,
-          // matter.js otherwise fills uniqueId with a random string persisted
-          // only in its own storage; controllers key node identity on it.
-          // Derive it from the bridge's uniqueId so the same bridge always
-          // yields the same identity. This is a stable non-cryptographic
-          // identity derivation, truncated to the attribute's 32-char cap.
-          uniqueId: createHash('sha256').update(deps.config.uniqueId).digest('hex').slice(0, 32),
         },
       }
 

--- a/src/matter/sharedTypes.ts
+++ b/src/matter/sharedTypes.ts
@@ -192,6 +192,14 @@ export interface MatterServerConfig {
   /** External accessory mode - device is not bridged and so added before server starts */
   externalAccessory?: boolean
 
+  /**
+   * Deferred-online mode - the node is fully built by `start()` (aggregator
+   * created, accessory cache restored) but stays offline until `runServer()`,
+   * so initial plugin registrations apply to the offline node and its first
+   * advertisement already carries the final structure
+   */
+  deferOnline?: boolean
+
   /** Network interfaces to bind to (inherited from `bridge.bind` config) */
   networkInterfaces?: string[]
 


### PR DESCRIPTION
## Summary

When a commissioned matter.js node comes online,
`SubscriptionsServer.reestablishFormerSubscriptions()` proactively reconnects
every controller that had a persisted subscription (2-second connection
timeout per peer, no retry). When this succeeds, a bridge restart is
invisible: the hub is re-subscribed within seconds and bridged accessories
never drop out. When it fails, Apple hubs keep transmitting on their dead
CASE sessions ("Ignoring message for unknown session") for minutes — visible
to users as every bridged device going "No Response" after each Homebridge
restart, historically with room assignments being lost.

Today Homebridge undermines this mechanism in two ways:

1. **The node goes online ~200 ms after creation**, while plugin
   registrations stream in immediately afterwards. Their transactions
   (`aggregator.add`, handler attachment, `increaseConfigurationVersion()`)
   land inside the 2-second window and abort re-establishment
   ("Reestablished 0 of 2 former subscriptions", "Operation aborted").
   Standalone bridges (matterbridge) never hit this because they build the
   complete aggregator before starting the node.
2. **Persisted subscriptions for deleted fabrics are never purged**, so
   re-establishment wastes its window on peers that no longer exist
   ("Failed to connect to @N Fabric index #N does not exist").

This PR makes the child-bridge Matter server start in a deferred-online mode:
the node is fully built (accessory cache restored, initial plugin
registrations applied to the offline node) and only then brought online — so
its first advertisement carries the final structure and re-establishment runs
against a quiescent node. It also purges persisted subscriptions when their
fabric is removed.

## Changes (validated as dist patches in production)

1. **`ServerConfig` / `ServerLifecycle`: `deferOnline` mode.**
   `start()` builds the node, creates the aggregator, restores the accessory
   cache — and, with `deferOnline`, skips `startServerNode()`. The existing
   `runServer()` path ("deferred server with device(s) already attached",
   previously restricted to external-accessory mode) is opened up to
   `deferOnline` and brings the node online later.
2. **`MatterServer`: registration activity signal.**
   `registerPlatformAccessories()` stamps `lastRegistrationAt`, exposed via
   `getLastRegistrationAt()`.
3. **`ChildBridgeMatterManager`: settle loop.** `deferOnline` is enabled for
   the child-bridge server; after `start()`, `runServerWhenSettled()` polls
   (500 ms) until registrations have been idle for 2 s (capped at 45 s so a
   stuck or registration-less plugin cannot keep the bridge offline — the cap
   logs a warning and goes online anyway), then `runServer()`. The loop stops
   if the server is torn down mid-defer.
4. **`CommissioningManager`: purge persisted subscriptions on fabric
   removal.** The existing `fabricsChanged` handler now, on a `deleted`
   action, filters the removed fabric's entries out of the root endpoint's
   `SubscriptionsServer` state (each persisted entry carries
   `peerAddress.fabricIndex`), so re-establishment only spends its 2-second
   window on live peers. matter.js removes the fabric's sessions on removal
   but leaves the persisted subscription entries behind.
5. **Root node BasicInformation completeness** (same AFU-metadata class of
   fix as the per-accessory changes in the sibling PR #3972):
   `softwareVersion`/`softwareVersionString` parsed from the configured
   firmware revision (`x.y.z` triplet; Apple homed rejects nodes whose
   firmware metadata is missing or unparseable — "invalid matter AFU
   settings"), plus `configurationVersion`, `productUrl`, and a deterministic
   `uniqueId` derived from the bridge's `uniqueId` instead of the random
   matter.js-persisted string controllers would otherwise key node identity
   on.

## Evidence

- Before: every restart of a commissioned bridge logged
  `Reestablished 0 of 2 former subscriptions` / `Operation aborted`,
  followed by minutes of hub dead-session traffic and "No Response" tiles;
  with a stale fabric present, also `Fabric index #N does not exist`.
- After: restarts log `Deferred online mode - Matter node built, waiting for
  initial registrations` → online ~7-10 s later →
  `Reestablished 1 of 1 former subscriptions successfully` within the same
  second — verified repeatedly on an 11-device production bridge via both
  `systemctl restart` and stop/start. Room assignments survive; the hub's
  only trace is a few seconds of stale tiles while secondary peers (phone,
  standby hubs) re-establish their own sessions.
- Subscription persistence itself already works (written at graceful close);
  the failures were entirely the two issues above.

## Notes for reviewers

- Same lineage as #3969/#3970 and the composed-parent FixedLabel/PowerSource
  PR (#3972); validated together on the same deployment, but independent —
  this one is about restart behavior, that one about Apple's composed-device
  modeling.
- Interaction with the beta branch: the registration reject-guard on
  `beta-2.2.2` ("reject bridged registrations that arrive before the server
  is running", part of the #3970 work, not yet on `latest`) must be made
  defer-aware when these meet, or deferred mode deadlocks — the server waits
  for registrations, the guard rejects them for the server not running.
  Offline registration is exactly what deferred mode wants; the cache-restore
  path (#3969) already proves registration works on the offline node. Our
  production validation ran on the beta dist with that guard relaxed to
  treat "deferred, pre-online" as registrable; happy to include that here or
  in a follow-up on the beta branch, whichever the maintainers prefer.
- The 2 s / 45 s settle constants are pragmatic; an explicit "initial
  registrations complete" signal from plugins would be cleaner, but no such
  API contract exists today and the idle heuristic has been reliable.
- Plugins that register accessories long after launch (e.g. from network
  discovery) are unaffected: late registrations apply to the live node
  exactly as today; deferred mode only front-loads whatever arrives during
  the settle window.
- Main-bridge Matter and external accessories are unchanged; the mode is
  enabled for child bridges, where all plugin registrations are in-process.
