### PR TITLE
feat(matter): populate bridged accessory firmware version from firmwareRevision

### DIFF
--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -713,6 +713,53 @@ describe('accessoryManager', () => {
       expect(bdbi.softwareVersion).toBeUndefined()
     })
 
+    it('encodes a large major that still fits 16 bits as an unsigned value', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '40000.0.0' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('40000.0.0')
+      // 40000 sets the sign bit under a plain 32-bit shift; the value must stay unsigned
+      expect(bdbi.softwareVersion).toBe(40000 * 0x10000)
+    })
+
+    it('omits the numeric version when the major does not fit 16 bits', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '70000.0.0' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('70000.0.0')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('omits the numeric version when minor or patch exceeds 255', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '1.7.300' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('1.7.300')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('truncates softwareVersionString to the 64-character spec limit', async () => {
+      const deps = createMockDeps()
+      const longRevision = `1.2.3+${'a'.repeat(80)}`
+      const accessory = createMockAccessory({ firmwareRevision: longRevision } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe(longRevision.slice(0, 64))
+      expect(bdbi.softwareVersionString).toHaveLength(64)
+      expect(bdbi.softwareVersion).toBe((1 << 16) | (2 << 8) | 3)
+    })
+
     it('sets neither field when the accessory has no firmwareRevision', async () => {
       const deps = createMockDeps()
       const accessory = createMockAccessory()

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -685,6 +685,46 @@ describe('accessoryManager', () => {
     })
   })
 
+  describe('bridged firmware version (BDBI software version)', () => {
+    // The firmwareRevision every plugin already provides is surfaced to
+    // controllers via BridgedDeviceBasicInformation, so e.g. Apple Home can
+    // show the bridged device's firmware in the accessory details.
+
+    it('maps firmwareRevision to softwareVersionString with a derived numeric softwareVersion', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '1.7.5-g9979d16' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('1.7.5-g9979d16')
+      // (1 << 16) | (7 << 8) | 5
+      expect(bdbi.softwareVersion).toBe(67333)
+    })
+
+    it('keeps the string but omits the numeric version when no semver triplet leads the string', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: 'build-2026' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('build-2026')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('sets neither field when the accessory has no firmwareRevision', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory()
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBeUndefined()
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+  })
+
   describe('unregisterAccessory', () => {
     it('should remove an accessory from the map', async () => {
       const deps = createMockDeps()

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -646,6 +646,17 @@ export class AccessoryManager {
         serialNumber: accessory.serialNumber,
         reachable: true,
       }
+      // Surface the device's firmware version to controllers (shown in the
+      // accessory details of e.g. Apple Home). The numeric companion is
+      // derived from a leading semver triplet when the string has one.
+      if (typeof accessory.firmwareRevision === 'string' && accessory.firmwareRevision.length > 0) {
+        endpointOptions.bridgedDeviceBasicInformation.softwareVersionString = accessory.firmwareRevision
+        const semver = accessory.firmwareRevision.match(/^(\d+)\.(\d+)\.(\d+)/)
+        if (semver) {
+          endpointOptions.bridgedDeviceBasicInformation.softwareVersion
+            = (Number(semver[1]) << 16) | (Number(semver[2]) << 8) | Number(semver[3])
+        }
+      }
     }
 
     return endpointOptions

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -648,13 +648,21 @@ export class AccessoryManager {
       }
       // Surface the device's firmware version to controllers (shown in the
       // accessory details of e.g. Apple Home). The numeric companion is
-      // derived from a leading semver triplet when the string has one.
+      // derived from a leading semver triplet when the string has one and
+      // the parts fit the 16/8/8-bit encoding - otherwise only the string
+      // is set (both attributes are independently optional per spec, and a
+      // failed uint32 validation would block the accessory registering).
+      // The spec caps SoftwareVersionString at 64 characters.
       if (typeof accessory.firmwareRevision === 'string' && accessory.firmwareRevision.length > 0) {
-        endpointOptions.bridgedDeviceBasicInformation.softwareVersionString = accessory.firmwareRevision
+        endpointOptions.bridgedDeviceBasicInformation.softwareVersionString = accessory.firmwareRevision.slice(0, 64)
         const semver = accessory.firmwareRevision.match(/^(\d+)\.(\d+)\.(\d+)/)
         if (semver) {
-          endpointOptions.bridgedDeviceBasicInformation.softwareVersion
-            = (Number(semver[1]) << 16) | (Number(semver[2]) << 8) | Number(semver[3])
+          const [major, minor, patch] = [Number(semver[1]), Number(semver[2]), Number(semver[3])]
+          if (major <= 0xFFFF && minor <= 0xFF && patch <= 0xFF) {
+            // >>> 0 keeps the value unsigned - a signed << would go negative
+            // for majors >= 0x8000 and fail matter.js's uint32 validation.
+            endpointOptions.bridgedDeviceBasicInformation.softwareVersion = ((major << 16) | (minor << 8) | patch) >>> 0
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

HAP-bridged accessories surface their firmware through the AccessoryInformation service's `FirmwareRevision` characteristic. Matter-bridged accessories currently expose nothing: the BridgedDeviceBasicInformation cluster's `SoftwareVersionString`/`SoftwareVersion` attributes are never set, even though every `PlatformAccessory` already carries `firmwareRevision`.

This PR maps it across when registering a Matter accessory:

- `softwareVersionString` ← `accessory.firmwareRevision` whenever it is a non-empty string (the attribute is free-form per spec).
- `softwareVersion` (numeric) ← additionally encoded as `major<<16 | minor<<8 | patch` when the string starts with a `x.y.z` semver core, so version comparisons work for controllers that use the numeric attribute. Non-semver strings set only the string attribute.

## Validation

- Verified on the wire (controller read from a second fabric): each bridged endpoint reports its own device's version — e.g. `swString=1.7.5 sw=67333` on most devices and a distinct `2.0.0-g87fbfa4` (string only) on another — running as a dist patch on a production bridge with 12 bridged accessories.
- One honest caveat: Apple Home currently renders per-accessory firmware for HAP-bridged accessories but not (yet) for Matter-bridged ones, even with these attributes present — we tested both raw vendor strings and clean numeric strings across hub reboots. The mapping is spec-correct and consumable by other controllers/ecosystems (and by Apple whenever they wire it up); we're filing the rendering gap with Apple separately.
- 3 new unit tests (semver → string+numeric, non-semver → string only, absent → neither); full suite passes.
