### PR TITLE
fix(matter): declare ac/dc feature on power measurement

### DIFF
--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -856,10 +856,24 @@ describe('serverHelpers', () => {
       expect(result.behaviors.powerTopology).toBeDefined()
       expect(result.behaviors.powerTopology.features.treeTopology).toBe(true)
       expect(result.behaviors.electricalPowerMeasurement).toBeDefined()
+      expect(result.behaviors.electricalPowerMeasurement.features.alternatingCurrent).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement).toBeDefined()
       expect(result.behaviors.electricalEnergyMeasurement.features.importedEnergy).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement.features.cumulativeEnergy).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement.features.exportedEnergy).toBe(false)
+    })
+
+    it('should declare DirectCurrent instead of AlternatingCurrent when the accessory declares DC powerMode', () => {
+      const accessory = {
+        displayName: 'USB Meter',
+        clusters: { electricalPowerMeasurement: { activePower: 0, powerMode: 1 } },
+      } as any
+      const detection = { hasPowerMeasurement: true, energyFeatures: [] }
+
+      const result = applyElectricalMeasurementClusters(devices.OnOffPlugInUnitDevice, accessory, detection) as any
+
+      expect(result.behaviors.electricalPowerMeasurement.features.directCurrent).toBe(true)
+      expect(result.behaviors.electricalPowerMeasurement.features.alternatingCurrent).toBe(false)
     })
 
     it('should return the device type unchanged when nothing was detected', () => {

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -763,7 +763,13 @@ export function applyElectricalMeasurementClusters(
     behaviors.push((requirements.PowerTopologyServer as any).with('TreeTopology'))
   }
   if (detection.hasPowerMeasurement && !existing.electricalPowerMeasurement) {
-    behaviors.push(requirements.ElectricalPowerMeasurementServer)
+    // The EPM cluster's feature conformance requires at least one of
+    // DirectCurrent/AlternatingCurrent. Follow the accessory's powerMode
+    // (already resolved by applyElectricalMeasurementDefaults: plugin value
+    // or the AC default): 1 = DC, everything else measures mains.
+    const powerMode = (accessory.clusters?.electricalPowerMeasurement as Record<string, unknown> | undefined)?.powerMode
+    const currentFeature = powerMode === 1 ? 'DirectCurrent' : 'AlternatingCurrent'
+    behaviors.push((requirements.ElectricalPowerMeasurementServer as any).with(currentFeature))
   }
   if (detection.energyFeatures.length > 0 && !existing.electricalEnergyMeasurement) {
     behaviors.push((requirements.ElectricalEnergyMeasurementServer as any).with(...detection.energyFeatures))


### PR DESCRIPTION
## Summary

The ElectricalPowerMeasurement cluster's feature conformance requires at least one of the current-type features (DirectCurrent/AlternatingCurrent). The auto-detected power measurement server in `applyElectricalMeasurementClusters()` composes the cluster with no features at all — a controller reading the featureMap sees `0`, which is non-conformant. Certified mains-measuring devices declare AlternatingCurrent (verified with a controller read against an Eve Energy).

The fix follows the accessory's `powerMode`, which `applyElectricalMeasurementDefaults()` has already resolved by the time the composition runs (plugin-declared value, AC default): DC (`powerMode: 1`) declares DirectCurrent, everything else declares AlternatingCurrent — mirroring how PowerTopology already gets TreeTopology in the same function.

## Validation

- The AlternatingCurrent path is running as a dist patch on a production bridge (12 bridged accessories, 7 metering): clean startup, no re-registration churn, Apple Home controls/tile wattage/energy totals unchanged.
- Tests: featureMap assertion added to the existing AC-default case, plus a new DC case asserting DirectCurrent/not-AlternatingCurrent; full suite passes.
