### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat(matter): expose the closure, media player and speaker device types to plugins
 - fix(matter): expose the clusters and enums the new device types need, so plugins are not left with magic numbers
 - fix(matter): route closure, media playback and keypad commands to plugin handlers
+- fix(matter): give composed parts the same preparation as their parent accessory
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat: make identifying material in bonjour configurable (#3965) (@naterator)
 - fix(matter): compose PowerSource for all device types (#3968) (@zbuc)
 - feat(matter): expose matter status errors on `api.matter.status`
+- fix(matter): retry Matter server start on transient storage-lock contention
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - chore(deps): bump `@matter/main` to the released v0.17.7
 - feat: Support for NodeJS 26 
 - feat(matter): warn when a thermostat's setpoint limits cannot satisfy its auto-mode deadband
+- fix(matter): advertise the power source device type on endpoints with a battery, per the Matter spec
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `homebridge` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
-## v2.2.2 (Pending Release)
+## v2.3.0 (2026-08-08)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): compose PowerSource for all device types (#3968) (@zbuc)
 - feat(matter): expose matter status errors on `api.matter.status`
 - fix(matter): retry Matter server start on transient storage-lock contention
+- fix(matter): retry parts-list notification on synchronous lock contention
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to `homebridge` will be documented in this file. This projec
 
 - feat: make identifying material in bonjour configurable (#3965) (@naterator)
 - fix(matter): compose PowerSource for all device types (#3968) (@zbuc)
+- fix(matter): restore cached accessories into the bridge before going online (#3969) (@keremerkan)
 - feat(matter): expose matter status errors on `api.matter.status`
+- feat(matter): detect thermostat features from the declared setpoints
+- fix(matter): read cluster features from the behavior, not the cluster
 - fix(matter): retry Matter server start on transient storage-lock contention
 - fix(matter): retry parts-list notification on synchronous lock contention
 - fix(matter): reject bridged registrations that arrive before the server is running
@@ -17,7 +20,10 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): add FixedLabel and PowerSource to composed parents (#3972) (@keremerkan)
 - feat(matter): expose commissioned fabrics in the child bridge status (#3974)
 - fix(matter): read the fabric vendor id from cluster-shaped fabric entries (#3974)
+- fix(matter): declare ac/dc feature on power measurement (#3977) (@keremerkan)
+- feat(matter): populate bridged accessory firmware version from firmwareRevision (#3976) (@keremerkan)
 - chore(deps): dependency updates
+- chore(deps): bump `@matter/main` to the released v0.17.7
 
 ### Homebridge Dependencies
 
@@ -25,7 +31,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 
 ### Matter Dependencies
 
-- `@matter/main` @ `v0.17.7-alpha`
+- `@matter/main` @ `v0.17.7`
 
 ## v2.2.1 (2026-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): retry parts-list notification on synchronous lock contention
 - fix(matter): reject bridged registrations that arrive before the server is running
 - test(matter): cover cache-restore attach-in-place and pre-online ordering
+- fix(matter): defer bridge online until registrations settle (#3973) (@keremerkan)
+- fix(matter): add FixedLabel and PowerSource to composed parents (#3972) (@keremerkan)
+- feat(matter): expose commissioned fabrics in the child bridge status (#3974)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat: Support for NodeJS 26 
 - feat(matter): warn when a thermostat's setpoint limits cannot satisfy its auto-mode deadband
 - fix(matter): advertise the power source device type on endpoints with a battery, per the Matter spec
+- fix(matter): seed a battery's unknown charge state, so a late first report is not rejected (#3982)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): defer bridge online until registrations settle (#3973) (@keremerkan)
 - fix(matter): add FixedLabel and PowerSource to composed parents (#3972) (@keremerkan)
 - feat(matter): expose commissioned fabrics in the child bridge status (#3974)
+- fix(matter): read the fabric vendor id from cluster-shaped fabric entries (#3974)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - chore(deps): updated `@matter/main` from `v0.17.6` to `v0.17.9`
   - [see changelog &rarr;](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md)
 - feat(matter): expose the closure, media player and speaker device types to plugins
+- fix(matter): expose the clusters and enums the new device types need, so plugins are not left with magic numbers
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): seed a battery's unknown charge state, so a late first report is not rejected (#3982)
 - chore(deps): updated `@matter/main` from `v0.17.6` to `v0.17.9`
   - [see changelog &rarr;](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md)
+- feat(matter): expose the closure, media player and speaker device types to plugins
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,16 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat(matter): warn when a thermostat's setpoint limits cannot satisfy its auto-mode deadband
 - fix(matter): advertise the power source device type on endpoints with a battery, per the Matter spec
 - fix(matter): seed a battery's unknown charge state, so a late first report is not rejected (#3982)
+- chore(deps): updated `@matter/main` from `v0.17.6` to `v0.17.9`
+  - [see changelog &rarr;](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md)
 
 ### Homebridge Dependencies
 
-- `@homebridge/hap-nodejs` @ `v2.1.10`
+- `@homebridge/hap-nodejs` @ `v2.2.0`
 
 ### Matter Dependencies
 
-- `@matter/main` @ `v0.17.7`
+- `@matter/main` @ `v0.17.9`
 
 ## v2.2.1 (2026-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `homebridge` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v2.2.2 (Pending Release)
+
+### Changes
+
+- feat: make identifying material in bonjour configurable (#3965) (@naterator)
+- fix(matter): compose PowerSource for all device types (#3968) (@zbuc)
+- feat(matter): expose matter status errors on `api.matter.status`
+
+### Homebridge Dependencies
+
+- `@homebridge/hap-nodejs` @ `v2.1.9`
+
+### Matter Dependencies
+
+- `@matter/main` @ `v0.17.6`
+
 ## v2.2.1 (2026-07-19)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat(matter): populate bridged accessory firmware version from firmwareRevision (#3976) (@keremerkan)
 - chore(deps): dependency updates
 - chore(deps): bump `@matter/main` to the released v0.17.7
+- feat: Support for NodeJS 26 
 
 ### Homebridge Dependencies
 
-- `@homebridge/hap-nodejs` @ `v2.1.9`
+- `@homebridge/hap-nodejs` @ `v2.1.10`
 
 ### Matter Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - chore(deps): dependency updates
 - chore(deps): bump `@matter/main` to the released v0.17.7
 - feat: Support for NodeJS 26 
+- feat(matter): warn when a thermostat's setpoint limits cannot satisfy its auto-mode deadband
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): expose the clusters and enums the new device types need, so plugins are not left with magic numbers
 - fix(matter): route closure, media playback and keypad commands to plugin handlers
 - fix(matter): give composed parts the same preparation as their parent accessory
+- fix(matter): measure thermostat setpoint limits against the declared absolute limits
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): retry Matter server start on transient storage-lock contention
 - fix(matter): retry parts-list notification on synchronous lock contention
 - fix(matter): reject bridged registrations that arrive before the server is running
+- test(matter): cover cache-restore attach-in-place and pre-online ordering
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
   - [see changelog &rarr;](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md)
 - feat(matter): expose the closure, media player and speaker device types to plugins
 - fix(matter): expose the clusters and enums the new device types need, so plugins are not left with magic numbers
+- fix(matter): route closure, media playback and keypad commands to plugin handlers
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): add FixedLabel and PowerSource to composed parents (#3972) (@keremerkan)
 - feat(matter): expose commissioned fabrics in the child bridge status (#3974)
 - fix(matter): read the fabric vendor id from cluster-shaped fabric entries (#3974)
+- chore(deps): dependency updates
 
 ### Homebridge Dependencies
 
@@ -24,7 +25,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 
 ### Matter Dependencies
 
-- `@matter/main` @ `v0.17.6`
+- `@matter/main` @ `v0.17.7-alpha`
 
 ## v2.2.1 (2026-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - feat(matter): expose matter status errors on `api.matter.status`
 - fix(matter): retry Matter server start on transient storage-lock contention
 - fix(matter): retry parts-list notification on synchronous lock contention
+- fix(matter): reject bridged registrations that arrive before the server is running
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to `homebridge` will be documented in this file. This projec
 - fix(matter): route closure, media playback and keypad commands to plugin handlers
 - fix(matter): give composed parts the same preparation as their parent accessory
 - fix(matter): measure thermostat setpoint limits against the declared absolute limits
+- fix(matter): report zero commissioned fabrics as not commissioned (#3974)
 
 ### Homebridge Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/hap-nodejs": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/hap-nodejs": "2.1.9",
+        "@homebridge/hap-nodejs": "2.1.10-beta.0",
         "@matter/main": "0.17.7",
         "chalk": "5.6.2",
         "commander": "15.0.0",
@@ -39,7 +39,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": "^22 || ^24"
+        "node": "^22 || ^24 || ^26"
       }
     },
     "node_modules/@antfu/eslint-config": {
@@ -642,9 +642,9 @@
       }
     },
     "node_modules/@homebridge/hap-nodejs": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.9.tgz",
-      "integrity": "sha512-+VBg84jVVM9sm4s4u5l64qLl07Skuei9Z7bF13J1T5zWOb3Fq6hzZMUJfLK6zUk6EAuY/3bf9TgV+eLT7YE5Mw==",
+      "version": "2.1.10-beta.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.10-beta.0.tgz",
+      "integrity": "sha512-PRL2caxv3mz1bym1DV50VM4r2uZh+MhqJyJv/zl3beQ5TeHTyKD5SUGatDiAkMumgIq6tqT3qd29qRnwq+conw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.3.10",
@@ -659,7 +659,7 @@
         "tweetnacl": "^1.0.3"
       },
       "engines": {
-        "node": "^22 || ^24"
+        "node": "^22 || ^24 || ^26"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/hap-nodejs": "2.1.10-beta.0",
-        "@matter/main": "0.17.7",
-        "chalk": "5.6.2",
+        "@homebridge/hap-nodejs": "2.2.0",
+        "@matter/main": "0.17.9",
+        "chalk": "6.0.0",
         "commander": "15.0.0",
-        "fs-extra": "^11.4.0",
+        "fs-extra": "11.4.0",
         "qrcode-terminal": "0.12.0",
         "semver": "7.8.5",
         "source-map-support": "0.5.21"
@@ -22,12 +22,12 @@
         "homebridge": "bin/homebridge.js"
       },
       "devDependencies": {
-        "@antfu/eslint-config": "^9.2.0",
+        "@antfu/eslint-config": "^9.3.0",
         "@prettier/plugin-xml": "^3.4.2",
         "@types/debug": "^4.1.13",
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^26.1.1",
-        "@types/semver": "^7.7.1",
+        "@types/node": "^26.2.0",
+        "@types/semver": "^7.8.0",
         "@types/source-map-support": "^0.5.10",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint-plugin-format": "^2.0.1",
@@ -43,43 +43,43 @@
       }
     },
     "node_modules/@antfu/eslint-config": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-9.2.0.tgz",
-      "integrity": "sha512-v/j0Pjn6Sj9CxHT8n4nIKI8lg4O/+P4G+Zdbg7u/3J6JaLayxRXsX2Twx0fjpUtoyxW5mdYd67QycVfr1ahirA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-9.3.0.tgz",
+      "integrity": "sha512-+CIC4G6MowUl1RHiT01Ah9Obo/wwVynw7uNlN8ODwEn2opo9W1KzaatCrmu4WhGGJjOkOkyT5w7kKfQ//agHrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
+        "@antfu/install-pkg": "^2.0.1",
         "@clack/prompts": "^1.7.0",
-        "@e18e/eslint-plugin": "^0.5.1",
+        "@e18e/eslint-plugin": "^0.6.0",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/markdown": "^8.0.3",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
-        "@vitest/eslint-plugin": "^1.6.23",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
+        "@vitest/eslint-plugin": "^1.6.26",
         "ansis": "^4.3.1",
         "cac": "^7.0.0",
         "eslint-config-flat-gitignore": "^2.3.0",
         "eslint-flat-config-utils": "^3.2.0",
         "eslint-merge-processors": "^2.0.0",
         "eslint-plugin-antfu": "^3.2.3",
-        "eslint-plugin-command": "^3.5.3",
+        "eslint-plugin-command": "^4.0.0",
         "eslint-plugin-import-lite": "^0.6.0",
-        "eslint-plugin-jsdoc": "^63.2.0",
-        "eslint-plugin-jsonc": "^3.3.0",
+        "eslint-plugin-jsdoc": "^63.3.3",
+        "eslint-plugin-jsonc": "^3.4.1",
         "eslint-plugin-n": "^18.2.2",
         "eslint-plugin-no-only-tests": "^3.4.0",
-        "eslint-plugin-perfectionist": "^5.10.0",
-        "eslint-plugin-pnpm": "^1.6.1",
+        "eslint-plugin-perfectionist": "^5.10.1",
+        "eslint-plugin-pnpm": "^1.7.0",
         "eslint-plugin-regexp": "^3.1.1",
-        "eslint-plugin-toml": "^1.4.0",
-        "eslint-plugin-unicorn": "^72.0.0",
+        "eslint-plugin-toml": "^1.5.0",
+        "eslint-plugin-unicorn": "^73.0.0",
         "eslint-plugin-unused-imports": "^4.4.1",
         "eslint-plugin-vue": "^10.10.0",
-        "eslint-plugin-yml": "^3.6.0",
+        "eslint-plugin-yml": "^3.8.1",
         "eslint-processor-vue-blocks": "^2.0.0",
-        "globals": "^17.7.0",
+        "globals": "^17.9.0",
         "local-pkg": "^1.2.1",
         "parse-gitignore": "^2.0.0",
         "toml-eslint-parser": "^1.0.3",
@@ -103,6 +103,7 @@
         "astro-eslint-parser": ">=1.0.2",
         "eslint": "^9.10.0 || ^10.0.0",
         "eslint-plugin-astro": ">=1.2.0",
+        "eslint-plugin-erasable-syntax-only": "^0.4.2",
         "eslint-plugin-format": ">=0.1.0",
         "eslint-plugin-jsx-a11y": ">=6.10.2",
         "eslint-plugin-react-refresh": "^0.5.0",
@@ -141,6 +142,9 @@
         "eslint-plugin-astro": {
           "optional": true
         },
+        "eslint-plugin-erasable-syntax-only": {
+          "optional": true
+        },
         "eslint-plugin-format": {
           "optional": true
         },
@@ -171,14 +175,14 @@
       }
     },
     "node_modules/@antfu/install-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-2.0.1.tgz",
+      "integrity": "sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
+        "package-manager-detector": "^1.7.0",
+        "tinyexec": "^1.2.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -205,13 +209,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -221,9 +225,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -320,19 +324,19 @@
       "license": "MIT"
     },
     "node_modules/@e18e/eslint-plugin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@e18e/eslint-plugin/-/eslint-plugin-0.5.1.tgz",
-      "integrity": "sha512-mqUozeyNI9xvJbjrOO7y765dT7Kud3bwCm/DHwctxdEngPdJWQaS9BNGgpM1wCCzZfOtlKQh4ZRhm3VRomT9KA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@e18e/eslint-plugin/-/eslint-plugin-0.6.0.tgz",
+      "integrity": "sha512-JQkeXoZA12f9WM2H4t4IobIRqlPvYLeNAjZF6raFu2vmD5YoyuzKmwsLZNJ4g/39c3v1Se2ad3o+oq4y2et/RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "empathic": "^2.0.1",
-        "module-replacements": "^3.0.0-beta.8",
-        "semver": "^7.8.2"
+        "module-replacements": "^3.0.0",
+        "semver": "^7.8.5"
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0",
-        "oxlint": "^1.68.0"
+        "oxlint": "^1.72.0"
       },
       "peerDependenciesMeta": {
         "eslint": {
@@ -343,55 +347,21 @@
         }
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
-      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.92.0.tgz",
+      "integrity": "sha512-WivZqV5jPTYDQJgIMp0hTsyQESKYNY6yCJr4b0l84tYtQntkAMkc6zARh2vlRQyeg4aYHPUkCUDpvr2IWAiGpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.59.4",
+        "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
+        "jsdoc-type-pratt-parser": "~9.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -642,9 +612,9 @@
       }
     },
     "node_modules/@homebridge/hap-nodejs": {
-      "version": "2.1.10-beta.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.10-beta.0.tgz",
-      "integrity": "sha512-PRL2caxv3mz1bym1DV50VM4r2uZh+MhqJyJv/zl3beQ5TeHTyKD5SUGatDiAkMumgIq6tqT3qd29qRnwq+conw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.2.0.tgz",
+      "integrity": "sha512-AOx7zlGDI2xIihXjTMf5DqkbIaN8/njAVWhN9GSy0tjUvUYtkq1L3sdTOxzAVIg/XKVFSWDp82UZ6e8IEBr9Rw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.3.10",
@@ -653,7 +623,6 @@
         "debug": "^4.4.3",
         "fast-srp-hap": "^2.0.4",
         "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
         "source-map-support": "^0.5.21",
         "tslib": "^2.8.1",
         "tweetnacl": "^1.0.3"
@@ -768,114 +737,95 @@
       "license": "MIT"
     },
     "node_modules/@matter/general": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7.tgz",
-      "integrity": "sha512-1k1px59FraPyge6wuK+1Wf/RyK/FpKoyOL6F8JpNRaMKh0CsIBkqcj6R46no2vkcqe7yzUBIo50x9dKklDJzJQ==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.9.tgz",
+      "integrity": "sha512-NMAhD/EKpfTb1e0UllUJLdWgViw+Jp41PoY6s4yVGAiuo0sot6CYSdQauXelQPldhonrn2bLSKAa2mQUKWdhLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7.tgz",
-      "integrity": "sha512-3D/n9Q6JiqWdkPI49CRDY76GUHJ1GqlKIZ1YEeQp93khf+MAtzS9ttT98ifuVQUMpK/l5i/xcJRWJtHU28fKBw==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.9.tgz",
+      "integrity": "sha512-YFBpU1AquN6sLC466xcOslAaERtlBnofHfuvDyY9B8UHZZJwFUfsDT7gMWVYkU5J/S9vc7lslL9TMvvns8Biaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7",
-        "@matter/model": "0.17.7",
-        "@matter/node": "0.17.7",
-        "@matter/protocol": "0.17.7",
-        "@matter/types": "0.17.7"
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.7"
+        "@matter/nodejs": "0.17.9"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7.tgz",
-      "integrity": "sha512-e8L/JVt3pG97aYZ/JU5R3dRSv664qR7/3y+B0ySXRbbdOwirL7u4CCPRURDFG+u2yvsGSIh+18uABj6yIcP3CA==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.9.tgz",
+      "integrity": "sha512-NICGlK8ubD2an1eKIhEX2osZRl5JjnZE3Z8CJGnWItyVU5MbX1ta/EdCx/eBGy8WQPTxpYu93keW3L6qTUMOlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7"
+        "@matter/general": "0.17.9"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7.tgz",
-      "integrity": "sha512-vqAorFQPQ7aa5Qhpu7iRUALKwuDUazuAiotyUyhjpR7GF6zFCZ90xJwfCWKYhTsTao6Ylr2nGFtEPsbjBXpqzQ==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.9.tgz",
+      "integrity": "sha512-5AT6NYfIlLaILHAgVQoNZkuobff+CR7Ewkdj14YkENx77rRlujgDlDpXRiJkAHc+EUvRkwr5zA9ZL70XkwHkEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7",
-        "@matter/model": "0.17.7",
-        "@matter/protocol": "0.17.7",
-        "@matter/types": "0.17.7"
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7.tgz",
-      "integrity": "sha512-9ZByr+p/Bf3ezip6IZ/4DdMLUo3xDdBO82IbTmqsga4aym5NyCdDH6FSGZfWi+sN85+ZmQdxGTJ8h5kr1FKLhQ==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.9.tgz",
+      "integrity": "sha512-2C3J89qeLyknLtbe/ls46dmjs/eN8LmMSKpGl90mC2ut8471z4rkpFYNE+MTJLFg8yzC+R86yi35Y3lBzioEwA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.7",
-        "@matter/node": "0.17.7",
-        "@matter/protocol": "0.17.7",
-        "@matter/types": "0.17.7"
+        "@matter/general": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7.tgz",
-      "integrity": "sha512-q9e96VBrrMJFS0PYlTAW2YD7qVzhnqI3U/AvqFAhgd/Czo60DuAsPjttmI+VYijuK1oyho1Bi7BCJGgMjbtPhg==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.9.tgz",
+      "integrity": "sha512-BZg1BWwm3rHsFxyQm17VjpTNO3kwd+AIjI9dtfnPFkH5CeS7r6Ebd/9j8L0zxeVPotciMcSW8H5W+3kCcuB2HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7",
-        "@matter/model": "0.17.7",
-        "@matter/types": "0.17.7"
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/types": "0.17.9"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7.tgz",
-      "integrity": "sha512-NSFAlSyMUkCuYSzwtlOGb1gkmH8uFaZwpTelZY6EdTjhVMDu+meOE/CEHVzQmcAK+x8Mv2hjKlv1qCzUOqj7zQ==",
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.9.tgz",
+      "integrity": "sha512-Tdb08WzfM2Ma962NTtNrHTA3S26eBGCj5/kpnpl9LS5Twpw78Rgk/jogOIM/HDVCbu/M/ZSQPmdBN/q3vWEXAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7",
-        "@matter/model": "0.17.7"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
+      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.3.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -885,9 +835,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -910,9 +860,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1293,9 +1243,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -1310,9 +1260,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -1327,9 +1277,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -1344,9 +1294,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -1361,9 +1311,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -1378,9 +1328,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -1398,9 +1348,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1418,9 +1368,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -1438,9 +1388,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -1458,9 +1408,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -1478,9 +1428,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -1498,9 +1448,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -1514,29 +1464,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -1551,9 +1482,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -1692,17 +1623,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1808,9 +1728,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1818,9 +1738,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1842,17 +1762,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1865,22 +1785,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1896,14 +1816,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1918,14 +1838,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1936,9 +1856,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1953,15 +1873,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1978,9 +1898,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1992,16 +1912,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2020,16 +1940,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2044,13 +1964,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2106,9 +2026,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.24",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.24.tgz",
-      "integrity": "sha512-U5isuChJ58H1M6oRGaIotYbH2gM1rhzKUjtiarqpLNG/3+fzXIXs5RyTLrYQJmQPnXbvIMPFvI9z8ufpFZc8lg==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.26.tgz",
+      "integrity": "sha512-2eawZk4MZvkEtMZFdScmCE0R1Rti85uRZpmbe9eAv5Q3blDZ5OxlrC9IHlSnxhDCqOO2xKNaD3oufl9BUlI0yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2260,45 +2180,45 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
-      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.40",
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
-      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-core": "3.5.40",
-        "@vue/shared": "3.5.40"
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
-      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.40",
-        "@vue/compiler-dom": "3.5.40",
-        "@vue/compiler-ssr": "3.5.40",
-        "@vue/shared": "3.5.40",
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.19",
@@ -2306,21 +2226,21 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
-      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.5.40",
-        "@vue/shared": "3.5.40"
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.40",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
-      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2336,9 +2256,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2493,9 +2413,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
-      "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2537,9 +2457,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2626,9 +2546,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -2668,12 +2588,12 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
       "license": "MIT",
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -2808,13 +2728,16 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2982,9 +2905,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2999,9 +2922,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3057,9 +2980,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3247,13 +3170,16 @@
       }
     },
     "node_modules/eslint-plugin-command": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-command/-/eslint-plugin-command-3.5.3.tgz",
-      "integrity": "sha512-JIhmUOW2K2Dw1K+p4mtj5potkqTZ4ZaicrTkgCygPZCWErP2+O2F46n7ZwGKapeEjiwcVqoY8u01SxNUUXWPeQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-command/-/eslint-plugin-command-4.0.0.tgz",
+      "integrity": "sha512-mM1UdKu39YF5nUBVbA+PaVvpB3R3Niwjes8CQ8rJTTbgIThgrfQILgDqmtpAAQL1xGaolCoES1SfiwzwPVGkXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@es-joy/jsdoccomment": "^0.88.0"
+        "@es-joy/jsdoccomment": "^0.92.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || >=24.15.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3324,13 +3250,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.1.tgz",
-      "integrity": "sha512-yVyTPtOY2tA8EjTwUtaM3pFxj9i/3m4/FSPMv5gMnDHSSleCpzIYQLyV8KnVmEIkkPpNhDlkDQ99mTfjxgqLxA==",
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.90.0",
+        "@es-joy/jsdoccomment": "~0.91.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -3353,9 +3279,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/@es-joy/jsdoccomment": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
-      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3363,7 +3289,7 @@
         "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.3.0"
+        "jsdoc-type-pratt-parser": "~8.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -3401,9 +3327,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
-      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3411,9 +3337,9 @@
       }
     },
     "node_modules/eslint-plugin-jsonc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-3.3.0.tgz",
-      "integrity": "sha512-CsTR8aDcShDg6A71ZppLaWiPoSo2J1Ivjm5/c4Mnb9sxgwWq+WG2PgeoAnj7SwzDPJB75tlHvLrGy6ntooIitg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-3.4.1.tgz",
+      "integrity": "sha512-HHWkjAmVJ3QAffCkfo0XKl3CstLtgbIu5EGfFfVDLQT6vqPrxl4pFbUwFwY03nOlvyuDiiBixhHFrlbzn9u09Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3507,13 +3433,13 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.0.tgz",
-      "integrity": "sha512-HiqpDrUDbGrMC6iHQbemgDyHJ0366Vyz/qRWmxQcSAkmG25cXr8BdRgx8yAhOKhEfBXn8Rnf/mTCsV4EqUJSxg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.1.tgz",
+      "integrity": "sha512-Kprsp9Us0GqAesYaAIzUViw57xYp5WBqzXrcE0Mtww++E5fexWXYBipMuuD7yvyH4vvpBH0+oJ+OMAmZ0oYXkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.62.1",
+        "@typescript-eslint/utils": "^8.65.0",
         "natural-orderby": "^5.0.0"
       },
       "engines": {
@@ -3574,6 +3500,16 @@
         "eslint": ">=9.38.0"
       }
     },
+    "node_modules/eslint-plugin-regexp/node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
+      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/eslint-plugin-toml": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-1.5.0.tgz",
@@ -3598,9 +3534,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "72.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
-      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+      "version": "73.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
+      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3697,9 +3633,9 @@
       }
     },
     "node_modules/eslint-plugin-yml": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-3.6.0.tgz",
-      "integrity": "sha512-8lSqBIiOJO8ms1gktdlNaVGm3zXQJiYeKhQmtIG66XzU58kFDOjQae4sufQEMGHC4bP8VxiaH3tjU5PpDB6euw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-3.8.1.tgz",
+      "integrity": "sha512-E/70psRwxz5EJ8dBtzrFfqSiiInuSytbdtFCjueb/GcKjsWzPBfxfhtQePImMAPjHwMA/VDurO7DJwStDJ4wWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4100,9 +4036,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -4174,9 +4110,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4226,9 +4162,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4488,13 +4424,16 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.0.0.tgz",
+      "integrity": "sha512-gZvnVGWqgA9L/L2NLdcff6Rezp6ymKBqJDqfg+qWL9QyZA5prn5irUCkSGDEvuse1SjiFhlV2WQsgGBaIlPLWg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9"
+      },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/jsesc": {
@@ -4535,15 +4474,15 @@
       "peer": true
     },
     "node_modules/jsonc-eslint-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-3.1.0.tgz",
-      "integrity": "sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-3.2.0.tgz",
+      "integrity": "sha512-fjACeZ2chy9tiBakt5nU5SZhzk385pkSSfmhVvS13o4gqGiHVCNJXTNve8kqMeKv7A0L50mdaNUb7T8s+Egrnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^5.0.0",
-        "semver": "^7.3.5"
+        "verkit": "^0.3.2"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -5002,14 +4941,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
       }
     },
@@ -6054,18 +5993,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -6131,9 +6058,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6166,20 +6093,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/node-persist": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-      "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "q": "~1.1.1"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6573,9 +6490,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -6593,7 +6510,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6602,9 +6519,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6680,17 +6597,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qrcode-terminal": {
@@ -6848,13 +6754,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -6864,21 +6770,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -7189,9 +7094,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7226,9 +7131,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7549,9 +7454,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {
@@ -7604,17 +7509,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/verkit": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.3.2.tgz",
+      "integrity": "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -7631,7 +7549,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/hap-nodejs": "2.1.9",
-        "@matter/main": "0.17.6",
+        "@matter/main": "0.17.7-alpha.0-20260724-baac832f7",
         "chalk": "5.6.2",
         "commander": "15.0.0",
-        "fs-extra": "11.3.6",
+        "fs-extra": "^11.4.0",
         "qrcode-terminal": "0.12.0",
         "semver": "7.8.5",
         "source-map-support": "0.5.21"
@@ -22,7 +22,7 @@
         "homebridge": "bin/homebridge.js"
       },
       "devDependencies": {
-        "@antfu/eslint-config": "^9.1.0",
+        "@antfu/eslint-config": "^9.2.0",
         "@prettier/plugin-xml": "^3.4.2",
         "@types/debug": "^4.1.13",
         "@types/fs-extra": "^11.0.4",
@@ -43,48 +43,48 @@
       }
     },
     "node_modules/@antfu/eslint-config": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-9.1.0.tgz",
-      "integrity": "sha512-Vtjt+W/6/bV9hgQG8AiWG66OpAeLKmpo5bZaAmUdRvZsMyirVvIJeHnbM4XUJf4urIuLvK0gGSvXD74PI3ZnGQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-9.2.0.tgz",
+      "integrity": "sha512-v/j0Pjn6Sj9CxHT8n4nIKI8lg4O/+P4G+Zdbg7u/3J6JaLayxRXsX2Twx0fjpUtoyxW5mdYd67QycVfr1ahirA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
-        "@clack/prompts": "^1.6.0",
+        "@clack/prompts": "^1.7.0",
         "@e18e/eslint-plugin": "^0.5.1",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
-        "@eslint/markdown": "^8.0.2",
+        "@eslint/markdown": "^8.0.3",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/eslint-plugin": "^8.62.0",
-        "@typescript-eslint/parser": "^8.62.0",
-        "@vitest/eslint-plugin": "^1.6.20",
+        "@typescript-eslint/eslint-plugin": "^8.65.0",
+        "@typescript-eslint/parser": "^8.65.0",
+        "@vitest/eslint-plugin": "^1.6.23",
         "ansis": "^4.3.1",
         "cac": "^7.0.0",
         "eslint-config-flat-gitignore": "^2.3.0",
         "eslint-flat-config-utils": "^3.2.0",
         "eslint-merge-processors": "^2.0.0",
         "eslint-plugin-antfu": "^3.2.3",
-        "eslint-plugin-command": "^3.5.2",
+        "eslint-plugin-command": "^3.5.3",
         "eslint-plugin-import-lite": "^0.6.0",
-        "eslint-plugin-jsdoc": "^63.0.7",
-        "eslint-plugin-jsonc": "^3.2.0",
-        "eslint-plugin-n": "^18.1.0",
+        "eslint-plugin-jsdoc": "^63.2.0",
+        "eslint-plugin-jsonc": "^3.3.0",
+        "eslint-plugin-n": "^18.2.2",
         "eslint-plugin-no-only-tests": "^3.4.0",
-        "eslint-plugin-perfectionist": "^5.9.1",
+        "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-pnpm": "^1.6.1",
-        "eslint-plugin-regexp": "^3.1.0",
+        "eslint-plugin-regexp": "^3.1.1",
         "eslint-plugin-toml": "^1.4.0",
-        "eslint-plugin-unicorn": "^68.0.0",
+        "eslint-plugin-unicorn": "^72.0.0",
         "eslint-plugin-unused-imports": "^4.4.1",
-        "eslint-plugin-vue": "^10.9.2",
-        "eslint-plugin-yml": "^3.5.0",
+        "eslint-plugin-vue": "^10.10.0",
+        "eslint-plugin-yml": "^3.6.0",
         "eslint-processor-vue-blocks": "^2.0.0",
         "globals": "^17.7.0",
         "local-pkg": "^1.2.1",
         "parse-gitignore": "^2.0.0",
         "toml-eslint-parser": "^1.0.3",
         "vue-eslint-parser": "^10.4.1",
-        "yaml-eslint-parser": "^2.0.0"
+        "yaml-eslint-parser": "^2.1.0"
       },
       "bin": {
         "eslint-config": "bin/index.mjs"
@@ -100,9 +100,9 @@
         "@next/eslint-plugin-next": ">=15.0.0",
         "@prettier/plugin-xml": "^3.4.1",
         "@unocss/eslint-plugin": ">=0.50.0",
-        "astro-eslint-parser": "^1.0.2",
+        "astro-eslint-parser": ">=1.0.2",
         "eslint": "^9.10.0 || ^10.0.0",
-        "eslint-plugin-astro": "^1.2.0",
+        "eslint-plugin-astro": ">=1.2.0",
         "eslint-plugin-format": ">=0.1.0",
         "eslint-plugin-jsx-a11y": ">=6.10.2",
         "eslint-plugin-react-refresh": "^0.5.0",
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -525,6 +525,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
+      "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.29.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -611,9 +625,9 @@
       }
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.7.tgz",
-      "integrity": "sha512-VwTSCy1qofS0QLHtOiSVVmtR49xr/DR17D+5VeJm+xw1rGaluv++MF/atF1Jomxsf4WduVed63ouX2s6SH17Qw==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.8.tgz",
+      "integrity": "sha512-ZXcJzhA2Z3pYsSdQKcDZqELaJHzb5CXALlVHQRg+PHcXqx5xvL83ZPq8HdHCeavxS3pph6d85+zamCb1UFQa5A==",
       "license": "MIT",
       "dependencies": {
         "event-stream": "^4.0.1",
@@ -754,86 +768,86 @@
       "license": "MIT"
     },
     "node_modules/@matter/general": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6.tgz",
-      "integrity": "sha512-PiSly47lwR+31sMWZTxT9eVgibfC2PB3FflTwxhVDzektrNNYT4wh9+5abTNhQmszs/VnXixbyo64HSz+LQS8g==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-c9D2bDP/DAa7godehOxlIt9t9/y29+lu1O1w9nuQZrBRzmZQ1XZtQLask+aQzQtGJB4Zz4aYcH9lqVgDPX+u0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6.tgz",
-      "integrity": "sha512-RBXVLxJGEd3IUZ63QrHPUpb7o1amErvs2MoK3bJpnUXYNqXAuN2IHLTYZ04j4yrdMHJlyGSDxdIYr5rN6zXqSA==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-ZdhYfLVAtV+8ZAq3LyfGjAY6ffhBcfuiOBKSaeISLYBtjC10VX2jKDfzdlrbSFkSuA2VFPk4YvGtiOF6BtDCfA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.6",
-        "@matter/model": "0.17.6",
-        "@matter/node": "0.17.6",
-        "@matter/protocol": "0.17.6",
-        "@matter/types": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/node": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.6"
+        "@matter/nodejs": "0.17.7-alpha.0-20260724-baac832f7"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6.tgz",
-      "integrity": "sha512-ECf6r0zTq6FS6IA4ov8qtSu36iyO1oxEJT06RFYX/SVDOyfhgzRjQDSIsVtW4UwTMht8kSVnDJE9EAO0qY37YA==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-N/x4dgH6RmP0m7LgVB9swyoHJZx/P5Loml/NJbFQLYpozbCHzS0Z2b4Mg3UUnr5a7R9vrOZXBLwjxayc77xZyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6.tgz",
-      "integrity": "sha512-qtkh3/hz+73Wh7kY+Jz9HogrnpqjIMreYaY//VEMb9Jl/tY1A+3RFa7PDIY51LK2m+gWy3boXu/3kdYEvn00ig==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-dqPVzKJC8WgtLfTpfmILIVe8tCm1Dv+v+WF5PUzHpcXAw/DL/Gm1EXBGOAbB/F3W7c5cJhgMfYpFgrQZpno0jg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.6",
-        "@matter/model": "0.17.6",
-        "@matter/protocol": "0.17.6",
-        "@matter/types": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6.tgz",
-      "integrity": "sha512-tvn2wLMgjd1YVKr/kAkKq50WU+8mUeoDVCPIyO6aXJMsy0GTOc8/vC3Lu3ZIUD1IwMiOgn67xnqBVozpp+ZjTw==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-rqm6zD0YEFtM7nP39aS0dGdd1mR8jmS0IHpa+4wGoJORp0OXDzQUBTZfceaQQeANRSDqzuJNnPY4Y+IjYgiCCQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.6",
-        "@matter/node": "0.17.6",
-        "@matter/protocol": "0.17.6",
-        "@matter/types": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/node": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6.tgz",
-      "integrity": "sha512-p3oc8v2RKKbV4RkkjKemDpzheNHFMQJnbxpij2yKpxsXYIXpYnwtexnvLxDpZCJPsd9Jv3igSxxURBEUexHmBA==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-WZPqd5eR0LKSAhgRnjFCR3GZTXBNAWvbs1DuaJpdRJt3sNcWaHm9YM1bvkFkS1qJJNHOK1jvV9bsk6B/DpY6CA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.6",
-        "@matter/model": "0.17.6",
-        "@matter/types": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6.tgz",
-      "integrity": "sha512-zYCWx+om6hQR6s6CHniWJMaOsqzTNDKcxUoU0QI8ZgF39SCtIeIb+qOzNigoAtKKZzhVdo9B5IsbEbYY4PhO3g==",
+      "version": "0.17.7-alpha.0-20260724-baac832f7",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7-alpha.0-20260724-baac832f7.tgz",
+      "integrity": "sha512-r7QG9GRkUt63x6dG6fz4LZ6rL+hCJMhWDb4RHmkYwQOJ/MFieWt1OyquFsmjGaWs/4M8JfREreCZj/OtFwemvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.6",
-        "@matter/model": "0.17.6"
+        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1828,17 +1842,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1851,22 +1865,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1882,14 +1896,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1904,14 +1918,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1922,9 +1936,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1939,15 +1953,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1964,9 +1978,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1978,16 +1992,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2006,16 +2020,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2030,13 +2044,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2092,9 +2106,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.23.tgz",
-      "integrity": "sha512-CbrXxQpIUMbeyylGlxaxTgnWYM44et4Nx58swl7+vrTyC9Ttx+hQoy8BGCregbbZ08K5qFhRHeoad1VvERUbkg==",
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.24.tgz",
+      "integrity": "sha512-U5isuChJ58H1M6oRGaIotYbH2gM1rhzKUjtiarqpLNG/3+fzXIXs5RyTLrYQJmQPnXbvIMPFvI9z8ufpFZc8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2479,9 +2493,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2523,16 +2537,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2549,9 +2563,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2569,9 +2583,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
         "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
@@ -2773,6 +2787,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2955,9 +2982,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2972,9 +2999,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3030,9 +3057,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3043,7 +3070,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -3067,7 +3094,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3297,13 +3324,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.1.0.tgz",
-      "integrity": "sha512-Vo0Mvhxi6B63gLIDI86QChkiKE79MxxM0I16gMN/HJn0rvJvMIG/nmn+KPcsx+GWYDQq6X0UfNRjRK1+97NYVg==",
+      "version": "63.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.0.tgz",
+      "integrity": "sha512-3075zO1xCb7rxIx4gv1LsF5dh9dr84hRP85M8suIxp34TDMXNeSroMG3m8tZNxFFyHztzhaXmShIWPMNDOnknA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.88.0",
+        "@es-joy/jsdoccomment": "~0.90.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -3315,7 +3342,7 @@
         "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
         "semver": "^7.8.5",
-        "spdx-expression-parse": "^4.0.0",
+        "spdx-expression-parse": "^5.0.0",
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
@@ -3323,6 +3350,23 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/@es-joy/jsdoccomment": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
+      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.65.0",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
@@ -3354,6 +3398,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
+      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/eslint-plugin-jsonc": {
@@ -3470,9 +3524,9 @@
       }
     },
     "node_modules/eslint-plugin-pnpm": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.6.1.tgz",
-      "integrity": "sha512-pgcaJclu3YxZ/WMsiKMF58bHQasbGVARSMqCJvFaETYxSc7KcR2H74UVWV6exuGv9nNv9c0KKqn4PVHQlzMSEg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.7.0.tgz",
+      "integrity": "sha512-SZaPARN1+NMqAjQOlQjHu59SnN/o299N5Z4HTyhwWYnfkQkjdiydayHBegwXER3VecRF/Rf7eHw3sGcTF+uLOQ==",
       "dev": true,
       "funding": [
         {
@@ -3489,10 +3543,10 @@
         "empathic": "^2.0.1",
         "jsonc-eslint-parser": "^3.1.0",
         "pathe": "^2.0.3",
-        "pnpm-workspace-yaml": "1.6.1",
-        "tinyglobby": "^0.2.16",
+        "pnpm-workspace-yaml": "1.7.0",
+        "tinyglobby": "^0.2.17",
         "yaml": "^2.9.0",
-        "yaml-eslint-parser": "^2.0.0"
+        "yaml-eslint-parser": "^2.1.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
@@ -3521,9 +3575,9 @@
       }
     },
     "node_modules/eslint-plugin-toml": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-1.4.0.tgz",
-      "integrity": "sha512-3ErTnfUjXq/23f72XeyRcE0Y4Sd/ME1lsZeezczqpn2R4tE7+Sgco/NUKDXm0xAMz15tzcRz/9RfJRm6AqRO+A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-1.5.0.tgz",
+      "integrity": "sha512-qBjRywEkKxO2uYOjus//6GVF1r+Hg5QDkRO8RTY6XcaXgWfBU0DhwpFmJa2Ljf0Sz49r7DdZlpKwwHmJ4nmH1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3544,28 +3598,32 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "68.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-68.0.0.tgz",
-      "integrity": "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ==",
+      "version": "72.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
+      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
         "@eslint-community/eslint-utils": "^4.9.1",
-        "browserslist": "^4.28.2",
+        "@eslint/css-tree": "^4.0.4",
+        "browserslist": "^4.28.4",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
         "core-js-compat": "^3.49.0",
         "detect-indent": "^7.0.2",
+        "entities": "^4.5.0",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.6.0",
+        "globals": "^17.7.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
-        "jsesc": "^3.1.0",
+        "is-identifier": "^1.1.0",
         "pluralize": "^8.0.0",
-        "regjsparser": "^0.13.1",
-        "semver": "^7.8.4",
-        "strip-indent": "^4.1.1"
+        "quote-js-string": "^0.1.0",
+        "regjsparser": "^0.13.2",
+        "reserved-identifiers": "^1.2.0",
+        "semver": "^7.8.5",
+        "strip-indent": "^4.1.1",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22"
@@ -3575,6 +3633,19 @@
       },
       "peerDependencies": {
         "eslint": ">=10.4"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/eslint-plugin-unused-imports": {
@@ -3594,18 +3665,18 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
-      "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+      "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^7.1.0",
-        "semver": "^7.6.3",
-        "xml-name-validator": "^4.0.0"
+        "postcss-selector-parser": "^7.1.4",
+        "semver": "^7.8.5",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4029,9 +4100,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -4052,9 +4123,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4078,6 +4149,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/futoin-hkdf": {
@@ -4213,6 +4297,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/identifier-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+      "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
@@ -4304,6 +4404,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+      "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "identifier-regex": "^1.1.0",
+        "super-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -4513,9 +4630,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -4529,23 +4646,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -4564,9 +4681,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -4585,9 +4702,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -4606,9 +4723,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -4627,9 +4744,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -4648,9 +4765,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -4672,9 +4789,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -4696,9 +4813,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -4720,9 +4837,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -4744,9 +4861,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -4765,9 +4882,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -4894,6 +5011,24 @@
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -5242,10 +5377,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
+      "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5957,9 +6099,9 @@
       }
     },
     "node_modules/module-replacements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-3.0.0.tgz",
-      "integrity": "sha512-tHIZqde+RlyNRobAIjfcH5UIgIrEbZbDGRL6J/x+HERX/g8O9mrm0p6knJbsTXmQtDvZ+eFP+xfOP3/9jHk6YA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-3.1.0.tgz",
+      "integrity": "sha512-MSTNGqlp2q0seRlrAA/FK3SUkGnmPeexeKWuCjeJ7HobD2RCjk4f8ry8lJ+nUQFDVBAHSdC4TdjyJSaocnR7Uw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6206,6 +6348,22 @@
         "@oxfmt/binding-win32-x64-msvc": "0.35.0"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6240,6 +6398,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -6248,9 +6419,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
-      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "dev": true,
       "license": "MIT"
     },
@@ -6382,9 +6553,9 @@
       }
     },
     "node_modules/pnpm-workspace-yaml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.6.1.tgz",
-      "integrity": "sha512-yTeZntGWi8m9WNuhoVsP0DpFc4sC1U0+rr/qR6Zi9n2g3sxXY+JfccjXjjruNz96tM8I09yaJUA86doRnNLkbg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.7.0.tgz",
+      "integrity": "sha512-cgjaozHkjWL4H8oKZydEWE4mg31XydK3/1cLKjHvwnFAXutp45yAlMKljpOdZEq4TtLuzYAMvy9j05wRm3aoPw==",
       "dev": true,
       "funding": [
         {
@@ -6402,9 +6573,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -6455,9 +6626,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6546,6 +6717,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quote-js-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+      "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6718,9 +6902,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6842,9 +7026,9 @@
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6908,6 +7092,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6962,6 +7164,22 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7166,6 +7384,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedoc": {
@@ -7565,6 +7796,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7611,13 +7849,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/hap-nodejs": "2.1.9",
-        "@matter/main": "0.17.7-alpha.0-20260724-baac832f7",
+        "@matter/main": "0.17.7",
         "chalk": "5.6.2",
         "commander": "15.0.0",
         "fs-extra": "^11.4.0",
@@ -768,86 +768,86 @@
       "license": "MIT"
     },
     "node_modules/@matter/general": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-c9D2bDP/DAa7godehOxlIt9t9/y29+lu1O1w9nuQZrBRzmZQ1XZtQLask+aQzQtGJB4Zz4aYcH9lqVgDPX+u0A==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7.tgz",
+      "integrity": "sha512-1k1px59FraPyge6wuK+1Wf/RyK/FpKoyOL6F8JpNRaMKh0CsIBkqcj6R46no2vkcqe7yzUBIo50x9dKklDJzJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-ZdhYfLVAtV+8ZAq3LyfGjAY6ffhBcfuiOBKSaeISLYBtjC10VX2jKDfzdlrbSFkSuA2VFPk4YvGtiOF6BtDCfA==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7.tgz",
+      "integrity": "sha512-3D/n9Q6JiqWdkPI49CRDY76GUHJ1GqlKIZ1YEeQp93khf+MAtzS9ttT98ifuVQUMpK/l5i/xcJRWJtHU28fKBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/node": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/node": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/nodejs": "0.17.7"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-N/x4dgH6RmP0m7LgVB9swyoHJZx/P5Loml/NJbFQLYpozbCHzS0Z2b4Mg3UUnr5a7R9vrOZXBLwjxayc77xZyQ==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7.tgz",
+      "integrity": "sha512-e8L/JVt3pG97aYZ/JU5R3dRSv664qR7/3y+B0ySXRbbdOwirL7u4CCPRURDFG+u2yvsGSIh+18uABj6yIcP3CA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-dqPVzKJC8WgtLfTpfmILIVe8tCm1Dv+v+WF5PUzHpcXAw/DL/Gm1EXBGOAbB/F3W7c5cJhgMfYpFgrQZpno0jg==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7.tgz",
+      "integrity": "sha512-vqAorFQPQ7aa5Qhpu7iRUALKwuDUazuAiotyUyhjpR7GF6zFCZ90xJwfCWKYhTsTao6Ylr2nGFtEPsbjBXpqzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-rqm6zD0YEFtM7nP39aS0dGdd1mR8jmS0IHpa+4wGoJORp0OXDzQUBTZfceaQQeANRSDqzuJNnPY4Y+IjYgiCCQ==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7.tgz",
+      "integrity": "sha512-9ZByr+p/Bf3ezip6IZ/4DdMLUo3xDdBO82IbTmqsga4aym5NyCdDH6FSGZfWi+sN85+ZmQdxGTJ8h5kr1FKLhQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/node": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/protocol": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7",
+        "@matter/node": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-WZPqd5eR0LKSAhgRnjFCR3GZTXBNAWvbs1DuaJpdRJt3sNcWaHm9YM1bvkFkS1qJJNHOK1jvV9bsk6B/DpY6CA==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7.tgz",
+      "integrity": "sha512-q9e96VBrrMJFS0PYlTAW2YD7qVzhnqI3U/AvqFAhgd/Czo60DuAsPjttmI+VYijuK1oyho1Bi7BCJGgMjbtPhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/types": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/types": "0.17.7"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.7-alpha.0-20260724-baac832f7",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7-alpha.0-20260724-baac832f7.tgz",
-      "integrity": "sha512-r7QG9GRkUt63x6dG6fz4LZ6rL+hCJMhWDb4RHmkYwQOJ/MFieWt1OyquFsmjGaWs/4M8JfREreCZj/OtFwemvg==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7.tgz",
+      "integrity": "sha512-NSFAlSyMUkCuYSzwtlOGb1gkmH8uFaZwpTelZY6EdTjhVMDu+meOE/CEHVzQmcAK+x8Mv2hjKlv1qCzUOqj7zQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.7-alpha.0-20260724-baac832f7",
-        "@matter/model": "0.17.7-alpha.0-20260724-baac832f7"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1808,9 +1808,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2493,9 +2493,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
-      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
+      "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3324,9 +3324,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.0.tgz",
-      "integrity": "sha512-3075zO1xCb7rxIx4gv1LsF5dh9dr84hRP85M8suIxp34TDMXNeSroMG3m8tZNxFFyHztzhaXmShIWPMNDOnknA==",
+      "version": "63.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.1.tgz",
+      "integrity": "sha512-yVyTPtOY2tA8EjTwUtaM3pFxj9i/3m4/FSPMv5gMnDHSSleCpzIYQLyV8KnVmEIkkPpNhDlkDQ99mTfjxgqLxA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4226,9 +4226,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6020,13 +6020,13 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@homebridge/hap-nodejs": "2.1.9",
-    "@matter/main": "0.17.7-alpha.0-20260724-baac832f7",
+    "@matter/main": "0.17.7",
     "chalk": "5.6.2",
     "commander": "15.0.0",
     "fs-extra": "^11.4.0",

--- a/package.json
+++ b/package.json
@@ -50,16 +50,16 @@
   },
   "dependencies": {
     "@homebridge/hap-nodejs": "2.1.9",
-    "@matter/main": "0.17.6",
+    "@matter/main": "0.17.7-alpha.0-20260724-baac832f7",
     "chalk": "5.6.2",
     "commander": "15.0.0",
-    "fs-extra": "11.3.6",
+    "fs-extra": "^11.4.0",
     "qrcode-terminal": "0.12.0",
     "semver": "7.8.5",
     "source-map-support": "0.5.21"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "^9.1.0",
+    "@antfu/eslint-config": "^9.2.0",
     "@prettier/plugin-xml": "^3.4.2",
     "@types/debug": "^4.1.13",
     "@types/fs-extra": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "type": "module",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "HomeKit support for the impatient",
   "author": "Nick Farina",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -49,22 +49,22 @@
     "watch": "nodemon"
   },
   "dependencies": {
-    "@homebridge/hap-nodejs": "2.1.10-beta.0",
-    "@matter/main": "0.17.7",
-    "chalk": "5.6.2",
+    "@homebridge/hap-nodejs": "2.2.0",
+    "@matter/main": "0.17.9",
+    "chalk": "6.0.0",
     "commander": "15.0.0",
-    "fs-extra": "^11.4.0",
+    "fs-extra": "11.4.0",
     "qrcode-terminal": "0.12.0",
     "semver": "7.8.5",
     "source-map-support": "0.5.21"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "^9.2.0",
+    "@antfu/eslint-config": "^9.3.0",
     "@prettier/plugin-xml": "^3.4.2",
     "@types/debug": "^4.1.13",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^26.1.1",
-    "@types/semver": "^7.7.1",
+    "@types/node": "^26.2.0",
+    "@types/semver": "^7.8.0",
     "@types/source-map-support": "^0.5.10",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint-plugin-format": "^2.0.1",
@@ -76,6 +76,6 @@
     "vitest": "^4.1.10"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true
+    "fsevents": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^22 || ^24"
+    "node": "^22 || ^24 || ^26"
   },
   "scripts": {
     "build": "npm run clean && tsc",
@@ -49,7 +49,7 @@
     "watch": "nodemon"
   },
   "dependencies": {
-    "@homebridge/hap-nodejs": "2.1.9",
+    "@homebridge/hap-nodejs": "2.1.10-beta.0",
     "@matter/main": "0.17.7",
     "chalk": "5.6.2",
     "commander": "15.0.0",

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -72,7 +72,7 @@ describe('homebridgeAPI', () => {
       // API directly, so stand in a manager stub to satisfy that precondition.
       // getExternalServer is included because getAccessoryState consults it;
       // hasActiveMatter returns true so the register/update guards pass.
-      ;(api as any)._matterManager = { getExternalServer: () => undefined, hasActiveMatter: () => true }
+      ;(api as any)._matterManager = { getExternalServer: () => undefined, hasActiveMatter: () => true, isBridgeServerStarting: () => false }
     })
 
     describe('loadMatterAPI lifecycle', () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,7 @@ import type {
   deviceTypes,
   MatterAccessory,
   MatterServer,
+  MatterStatus,
   MatterTypes,
 } from './matter/index.js'
 import type { SwitchAPI } from './matter/SwitchAPI.js'
@@ -287,6 +288,32 @@ export interface MatterAPI {
    * ```
    */
   readonly types: typeof MatterTypes
+
+  /**
+   * Matter protocol status errors for handlers.
+   *
+   * Throw one of these from a handler to send a specific Matter status code to
+   * the controller instead of failing the endpoint. Prefer this over importing
+   * `MatterStatus` from the `homebridge` package: a value import resolves the
+   * package when the plugin file is loaded, which fails on installs that keep
+   * Homebridge in a separate `node_modules` tree, taking the whole plugin down
+   * with it. The `api` object a plugin already holds has no such problem.
+   *
+   * @example
+   * ```typescript
+   * handlers: {
+   *   onOff: {
+   *     on: async () => {
+   *       if (deviceIsBusy) {
+   *         throw new api.matter!.status.Busy('Device is processing another command')
+   *       }
+   *       // ... control device
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  readonly status: typeof MatterStatus
 
   /**
    * Register Matter platform accessories (works exactly like HAP's registerPlatformAccessories)

--- a/src/childBridgeFork.spec.ts
+++ b/src/childBridgeFork.spec.ts
@@ -351,6 +351,8 @@ describe('childBridgeFork - Matter Handlers', () => {
           manualPairingCode: '12345-67890',
           serialNumber: 'SN-1',
           commissioned: false,
+          fabricCount: 0,
+          fabrics: [],
         })),
       }
 
@@ -364,6 +366,8 @@ describe('childBridgeFork - Matter Handlers', () => {
           manualPairingCode: '12345-67890',
           serialNumber: 'SN-1',
           commissioned: false,
+          fabricCount: 0,
+          fabrics: [],
         },
       })
     })

--- a/src/childBridgeService.spec.ts
+++ b/src/childBridgeService.spec.ts
@@ -289,7 +289,9 @@ describe('childBridgeService', () => {
             qrCode: 'MT:ABCD',
             manualPairingCode: '12345-67890',
             serialNumber: 'SN-1',
-            commissioned: false,
+            commissioned: true,
+            fabricCount: 1,
+            fabrics: [{ fabricIndex: 1, fabricId: '1', nodeId: '10', rootVendorId: 0x1349, label: 'My Home' }],
           },
         },
       })
@@ -298,10 +300,17 @@ describe('childBridgeService', () => {
       expect((service as any).setupUri).toBe('X-HM://abc')
       expect((service as any).matterCommissioningInfo).toMatchObject({
         qrCode: 'MT:ABCD',
-        commissioned: false,
+        commissioned: true,
+        fabricCount: 1,
+        fabrics: [{ fabricIndex: 1, rootVendorId: 0x1349, label: 'My Home' }],
       })
       // sendStatusUpdate called as part of handler
       expect(ipcService.sendMessage).toHaveBeenCalled()
+
+      // The fabric list flows on into the metadata the UI consumes
+      const metadata = service.getMetadata()
+      expect(metadata.matterFabricCount).toBe(1)
+      expect(metadata.matterFabrics).toEqual([{ fabricIndex: 1, fabricId: '1', nodeId: '10', rootVendorId: 0x1349, label: 'My Home' }])
     })
 
     it('on PORT_REQUEST, forwards to externalPortService and replies with PORT_ALLOCATED', async () => {

--- a/src/childBridgeService.ts
+++ b/src/childBridgeService.ts
@@ -13,7 +13,7 @@ import type {
 import type { ExternalPortService } from './externalPortService.js'
 import type { IpcService, MatterEvent } from './ipcService.js'
 import type { Logging } from './logger.js'
-import type { MatterConfig } from './matter/index.js'
+import type { FabricInfo, MatterConfig } from './matter/index.js'
 import type { Plugin } from './plugin.js'
 import type { HomebridgeOptions } from './server.js'
 
@@ -171,6 +171,8 @@ export interface ChildBridgePairedStatusEventData {
     serialNumber?: string
     commissioned: boolean
     deviceCount: number
+    fabricCount?: number
+    fabrics?: FabricInfo[]
   }
 }
 
@@ -203,6 +205,8 @@ export interface ChildMetadata {
   matterSerialNumber?: string
   matterCommissioned?: boolean
   matterDeviceCount?: number
+  matterFabricCount?: number
+  matterFabrics?: FabricInfo[]
 }
 
 /**
@@ -224,6 +228,8 @@ export class ChildBridgeService {
     serialNumber?: string
     commissioned: boolean
     deviceCount?: number
+    fabricCount?: number
+    fabrics?: FabricInfo[]
   }
 
   private pluginConfig: Array<PlatformConfig | AccessoryConfig> = []
@@ -478,6 +484,8 @@ export class ChildBridgeService {
               serialNumber: statusData.matter.serialNumber,
               commissioned: statusData.matter.commissioned || false,
               deviceCount: statusData.matter.deviceCount,
+              fabricCount: statusData.matter.fabricCount,
+              fabrics: statusData.matter.fabrics,
             }
           }
 
@@ -866,6 +874,8 @@ export class ChildBridgeService {
       matterSerialNumber: this.matterCommissioningInfo?.serialNumber,
       matterCommissioned: this.matterCommissioningInfo?.commissioned,
       matterDeviceCount: this.matterCommissioningInfo?.deviceCount,
+      matterFabricCount: this.matterCommissioningInfo?.fabricCount,
+      matterFabrics: this.matterCommissioningInfo?.fabrics,
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,15 +129,22 @@ export { MatterRequests } from './matter/index.js'
 
 /**
  * Matter protocol status errors for plugin handlers
+ *
+ * Prefer `api.matter.status`, which carries the same error classes. Importing
+ * `MatterStatus` from this package is a value import, so it resolves the
+ * `homebridge` package when the plugin file is loaded rather than when an
+ * error is thrown. On installs that keep Homebridge in a separate
+ * `node_modules` tree that resolution fails, and because platforms usually
+ * import every accessory file at startup, a single such import takes down the
+ * entire plugin.
+ *
  * @example
  * ```typescript
- * import { MatterStatus } from 'homebridge'
- *
  * handlers: {
  *   onOff: {
  *     on: async () => {
  *       if (deviceIsBusy) {
- *         throw new MatterStatus.Busy('Device is processing another command')
+ *         throw new api.matter!.status.Busy('Device is processing another command')
  *       }
  *       // ... control device
  *     }

--- a/src/matter/BaseMatterManager.spec.ts
+++ b/src/matter/BaseMatterManager.spec.ts
@@ -89,6 +89,52 @@ describe('baseMatterManager', () => {
     })
   })
 
+  describe('isBridgeServerStarting', () => {
+    it('is false when no bridge MatterServer exists', () => {
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+
+    it('is false once the server is running', () => {
+      manager.setMatterServer({ isServerRunning: () => true, isDeferredPreOnline: () => false } as any)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+
+    it('is true while the server is still starting (not running, not deferred)', () => {
+      manager.setMatterServer({ isServerRunning: () => false, isDeferredPreOnline: () => false } as any)
+      expect(manager.isBridgeServerStarting()).toBe(true)
+    })
+
+    it('is false while deliberately offline in deferOnline mode, so registrations are accepted', () => {
+      // The deadlock this guards against: if registrations were rejected while
+      // the deferred node is offline, the settle signal would never fire and
+      // the node would come online with no accessories.
+      manager.setMatterServer({ isServerRunning: () => false, isDeferredPreOnline: () => true } as any)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+
+    it('treats a constructed but not yet built deferred server as starting (real isDeferredPreOnline)', () => {
+      // Exercises the real method, not a stub: between `new MatterServer()`
+      // and start() building the node, deferOnline is already set but no
+      // aggregator exists yet. Registrations in that gap must be rejected as
+      // "starting", or they would hit the silent-drop path from #3970.
+      const server = new MatterServer({ uniqueId: 'test-bridge', deferOnline: true })
+      manager.setMatterServer(server as any)
+      expect(server.isDeferredPreOnline()).toBe(false)
+      expect(manager.isBridgeServerStarting()).toBe(true)
+
+      // Once start() has built the aggregator, the defer window opens...
+      ;(server as any).aggregator = {}
+      expect(server.isDeferredPreOnline()).toBe(true)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+
+      // ...and once the node is online, normal behaviour resumes
+      // (running, so no longer "starting" either).
+      ;(server as any).isRunning = true
+      expect(server.isDeferredPreOnline()).toBe(false)
+      expect(manager.isBridgeServerStarting()).toBe(false)
+    })
+  })
+
   describe('handleTriggerCommand', () => {
     it('should route commands to external server if accessory is external', async () => {
       const uuid = 'test-uuid'

--- a/src/matter/BaseMatterManager.ts
+++ b/src/matter/BaseMatterManager.ts
@@ -65,6 +65,13 @@ export abstract class BaseMatterManager {
    * are intentionally dropped by the drop stubs — that must not throw.
    */
   isBridgeServerStarting(): boolean {
+    // In deferOnline mode the server is deliberately built but kept offline
+    // until the initial registration burst settles, so registrations MUST be
+    // accepted while it is offline — otherwise they are rejected, the settle
+    // signal never fires, and the node comes online with no accessories.
+    if (this.matterServer?.isDeferredPreOnline()) {
+      return false
+    }
     return this.matterServer !== undefined && !this.matterServer.isServerRunning()
   }
 

--- a/src/matter/BaseMatterManager.ts
+++ b/src/matter/BaseMatterManager.ts
@@ -50,6 +50,25 @@ export abstract class BaseMatterManager {
   }
 
   /**
+   * Whether a bridge Matter server has been constructed but its node has not
+   * finished starting.
+   *
+   * `hasActiveMatter()` becomes true as soon as the MatterServer is constructed,
+   * which is BEFORE `start()` completes. Registering a bridged accessory in that
+   * window is silently dropped — the bridged register event is emitted
+   * fire-and-forget, and the "Matter server not started" error thrown downstream
+   * is only logged, so the plugin's `registerPlatformAccessories()` still
+   * resolves. Callers reject such a registration instead.
+   *
+   * This is deliberately distinct from externalsOnly mode, where there is no
+   * bridge server at all (`matterServer` is undefined) and bridged registrations
+   * are intentionally dropped by the drop stubs — that must not throw.
+   */
+  isBridgeServerStarting(): boolean {
+    return this.matterServer !== undefined && !this.matterServer.isServerRunning()
+  }
+
+  /**
    * Release a Matter port previously claimed for an external accessory.
    * Subclasses override to route to the right port service (the local
    * allocator on the main bridge, or an IPC call on a child bridge).

--- a/src/matter/ChildBridgeMatterManager.spec.ts
+++ b/src/matter/ChildBridgeMatterManager.spec.ts
@@ -221,6 +221,11 @@ describe('childBridgeMatterManager', () => {
         mockPluginManager,
       )
 
+      const fabrics = [
+        { fabricIndex: 1, fabricId: '1', nodeId: '10', rootVendorId: 0x1349, label: 'My Home' },
+        { fabricIndex: 2, fabricId: '2', nodeId: '11', rootVendorId: 0x1384, label: '' },
+      ]
+
       const mockMatterServer = {
         getCommissioningInfo: vi.fn().mockReturnValue({
           qrCode: 'MT:Y.K9000ABC1234567890',
@@ -228,6 +233,7 @@ describe('childBridgeMatterManager', () => {
           serialNumber: '0EDC5DBED675',
           commissioned: true,
         }),
+        getCommissioningSnapshot: vi.fn().mockReturnValue({ commissioned: true, fabricCount: 2, fabrics }),
         getAccessories: vi.fn().mockReturnValue([{ UUID: 'test' }]),
       } as any
 
@@ -239,6 +245,45 @@ describe('childBridgeMatterManager', () => {
       expect(statusInfo?.serialNumber).toBe('0EDC5DBED675')
       expect(statusInfo?.commissioned).toBe(true)
       expect(statusInfo?.deviceCount).toBe(1)
+      expect(statusInfo?.fabricCount).toBe(2)
+      expect(statusInfo?.fabrics).toEqual(fabrics)
+    })
+
+    it('takes commissioned from the fabric snapshot, not the lagging serverNode flag', () => {
+      const configWithMatter = {
+        ...mockBridgeConfig,
+        matter: { port: 5540 } as MatterConfig,
+      }
+
+      manager = new ChildBridgeMatterManager(
+        configWithMatter,
+        mockBridgeOptions,
+        mockApi,
+        mockExternalPortService,
+        mockPluginManager,
+      )
+
+      // After a controller-side removal of the last fabric, the serverNode's
+      // commissioning flag (surfaced via getCommissioningInfo) can stay true
+      // until restart, while the fabric list is already empty. The status
+      // payload must follow the fabric list (#3974).
+      const mockMatterServer = {
+        getCommissioningInfo: vi.fn().mockReturnValue({
+          qrCode: 'MT:Y.K9000ABC1234567890',
+          manualPairingCode: '12345678900',
+          serialNumber: '0EDC5DBED675',
+          commissioned: true,
+        }),
+        getCommissioningSnapshot: vi.fn().mockReturnValue({ commissioned: false, fabricCount: 0, fabrics: [] }),
+        getAccessories: vi.fn().mockReturnValue([]),
+      } as any
+
+      ;(manager as any).matterServer = mockMatterServer
+
+      const statusInfo = manager.getMatterStatusInfo()
+      expect(statusInfo?.commissioned).toBe(false)
+      expect(statusInfo?.fabricCount).toBe(0)
+      expect(statusInfo?.fabrics).toEqual([])
     })
   })
 

--- a/src/matter/ChildBridgeMatterManager.spec.ts
+++ b/src/matter/ChildBridgeMatterManager.spec.ts
@@ -3,7 +3,7 @@ import type { BridgeConfiguration, BridgeOptions } from '../bridgeService.js'
 import type { ChildBridgeExternalPortService } from '../externalPortService.js'
 import type { MatterConfig } from './types.js'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { InternalAPIEvent } from '../api.js'
 import { Logger } from '../logger.js'
@@ -549,6 +549,105 @@ describe('childBridgeMatterManager', () => {
       // REGISTER and UPDATE etc. appear at least twice — once for the normal listener, once for the drop stub.
       const registerRemovals = removed.filter((e: any) => e === InternalAPIEvent.REGISTER_MATTER_PLATFORM_ACCESSORIES)
       expect(registerRemovals.length).toBe(2)
+    })
+  })
+
+  describe('runServerWhenSettled (deferred online)', () => {
+    const SETTLE_MS = 2000
+    const CAP_MS = 45000
+
+    function makeManager(): ChildBridgeMatterManager {
+      return new ChildBridgeMatterManager(
+        { ...mockBridgeConfig, matter: { enabled: true } } as any,
+        mockBridgeOptions,
+        mockApi,
+        mockExternalPortService,
+        mockPluginManager,
+      )
+    }
+
+    function makeServer(overrides: Partial<{ inFlight: number, lastRegistrationAt: number }> = {}): any {
+      return {
+        getRegistrationsInFlight: vi.fn(() => overrides.inFlight ?? 0),
+        getLastRegistrationAt: vi.fn(() => overrides.lastRegistrationAt ?? 0),
+        runServer: vi.fn().mockResolvedValue(undefined),
+      }
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('brings the node online once registrations settle', async () => {
+      const manager = makeManager()
+      const server = makeServer({ lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Still within the settle window after the last registration.
+      await vi.advanceTimersByTimeAsync(SETTLE_MS - 100)
+      expect(server.runServer).not.toHaveBeenCalled()
+
+      // Past the settle window -> online.
+      await vi.advanceTimersByTimeAsync(600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('goes online promptly when no registrations ever arrive', async () => {
+      const manager = makeManager()
+      const server = makeServer({ lastRegistrationAt: 0, inFlight: 0 })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Online just after the settle window, long before the 45s cap - if it
+      // waited for the cap it would not have fired at 2.6s.
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not go online while a registration is still in flight', async () => {
+      const manager = makeManager()
+      const server = makeServer({ inFlight: 1, lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 2000)
+      expect(server.runServer).not.toHaveBeenCalled()
+
+      // Once in flight drains and the window passes, it comes online.
+      server.getRegistrationsInFlight.mockReturnValue(0)
+      server.getLastRegistrationAt.mockReturnValue(Date.now())
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + 600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops polling if the server is torn down mid-wait', async () => {
+      const manager = makeManager()
+      const server = makeServer()
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // A restart mid-wait replaces the server reference.
+      ;(manager as any).matterServer = makeServer()
+      await vi.advanceTimersByTimeAsync(SETTLE_MS + CAP_MS)
+      expect(server.runServer).not.toHaveBeenCalled()
+    })
+
+    it('goes online at the cap if registrations never drain', async () => {
+      const manager = makeManager()
+      const server = makeServer({ inFlight: 1, lastRegistrationAt: Date.now() })
+      ;(manager as any).matterServer = server
+      ;(manager as any).runServerWhenSettled(server)
+
+      // Never settles (in flight stuck), so it only comes online at the cap.
+      await vi.advanceTimersByTimeAsync(CAP_MS - 1000)
+      expect(server.runServer).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1600)
+      expect(server.runServer).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/matter/ChildBridgeMatterManager.ts
+++ b/src/matter/ChildBridgeMatterManager.ts
@@ -9,6 +9,7 @@ import type { HomebridgeAPI } from '../api.js'
 import type { BridgeConfiguration, BridgeOptions } from '../bridgeService.js'
 import type { ChildBridgeExternalPortService } from '../externalPortService.js'
 import type { AccessoryInfo } from './managerTypes.js'
+import type { FabricInfo } from './server/FabricManager.js'
 import type { InternalMatterAccessory, MatterAccessory, MatterConfig } from './types.js'
 
 import process from 'node:process'
@@ -45,6 +46,8 @@ export interface ChildBridgeMatterStatusInfo {
   serialNumber?: string
   commissioned: boolean
   deviceCount: number
+  fabricCount: number
+  fabrics: FabricInfo[]
 }
 
 /**
@@ -448,12 +451,22 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
     }
 
     const commissioningInfo = this.matterServer.getCommissioningInfo()
+
+    // The fabric list and commissioned state come from the coalesced snapshot,
+    // which treats the fabric list as the source of truth. isCommissioned()
+    // trusts the serverNode's commissioning flag first, and that flag can lag
+    // behind a controller-side removal — reporting "commissioned" with zero
+    // fabrics until the next restart (#3974).
+    const snapshot = this.matterServer.getCommissioningSnapshot()
+
     return {
       qrCode: commissioningInfo.qrCode,
       manualPairingCode: commissioningInfo.manualPairingCode,
       serialNumber: this.matterSerialNumber || commissioningInfo.serialNumber,
-      commissioned: commissioningInfo.commissioned || false,
+      commissioned: snapshot.commissioned,
       deviceCount: this.matterServer.getAccessories().length,
+      fabricCount: snapshot.fabricCount,
+      fabrics: snapshot.fabrics,
     }
   }
 

--- a/src/matter/ChildBridgeMatterManager.ts
+++ b/src/matter/ChildBridgeMatterManager.ts
@@ -28,6 +28,14 @@ import { appendUsernameSuffix, getMatterJsVersion, normalizeBindConfig } from '.
 const log = Logger.withPrefix('Matter/ChildManager')
 const COLON_RE = /:/g
 
+// Deferred-online settle loop tuning (see startMatterServer): the node goes
+// online once registrations have been idle for SETTLE_MS, checked every
+// POLL_MS, capped at CAP_MS so a stuck or registration-less plugin cannot
+// keep the bridge offline.
+const DEFER_ONLINE_SETTLE_MS = 2000
+const DEFER_ONLINE_CAP_MS = 45000
+const DEFER_ONLINE_POLL_MS = 500
+
 /**
  * Matter status information for child bridge IPC communication
  */
@@ -242,6 +250,12 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
       serialNumber,
       networkInterfaces,
       disableIpv4: matterConfig.disableIpv4,
+      // Build the node fully (accessory cache restored, initial plugin
+      // registrations applied offline) before it goes online, so a
+      // commissioned controller's subscription re-establishment - which runs
+      // once, right after the node comes online, with a short per-peer
+      // connection timeout - is not aborted by registration transactions.
+      deferOnline: true,
     })
 
     await this.matterServer.start()
@@ -260,6 +274,48 @@ export class ChildBridgeMatterManager extends BaseMatterManager {
 
     // Set up event listeners for Matter API calls
     this.setupEventListeners()
+
+    // Deferred-online: bring the node online once the initial plugin
+    // registration burst has settled.
+    this.runServerWhenSettled(this.matterServer)
+  }
+
+  /**
+   * Poll until plugin registrations have been idle for DEFER_ONLINE_SETTLE_MS
+   * (capped at DEFER_ONLINE_CAP_MS so a stuck or registration-less plugin
+   * cannot keep the bridge offline), then bring the deferred node online.
+   */
+  private runServerWhenSettled(server: MatterServer): void {
+    const deferStartedAt = Date.now()
+
+    const check = (): void => {
+      // Stop polling if the server was torn down (or replaced) mid-defer.
+      if (this.matterServer !== server) {
+        return
+      }
+
+      // Settle once no registration has started or been in flight for the
+      // settle window. A bridge that never registers (or restores purely from
+      // the accessory cache) settles the window after deferStartedAt, so it
+      // goes online promptly rather than waiting for the cap.
+      const idleSince = Math.max(server.getLastRegistrationAt(), deferStartedAt)
+      const settled = server.getRegistrationsInFlight() === 0 && Date.now() - idleSince >= DEFER_ONLINE_SETTLE_MS
+      const capped = Date.now() - deferStartedAt >= DEFER_ONLINE_CAP_MS
+
+      if (!settled && !capped) {
+        setTimeout(check, DEFER_ONLINE_POLL_MS)
+        return
+      }
+
+      if (capped && !settled) {
+        log.warn(`Deferred Matter start: no registrations settled within ${DEFER_ONLINE_CAP_MS / 1000}s - going online anyway`)
+      }
+      server.runServer().catch((error) => {
+        log.error('Deferred Matter server start failed:', error)
+      })
+    }
+
+    setTimeout(check, DEFER_ONLINE_POLL_MS)
   }
 
   /**

--- a/src/matter/MatterAPIImpl.spec.ts
+++ b/src/matter/MatterAPIImpl.spec.ts
@@ -9,6 +9,7 @@ vi.mock('./index.js', () => ({
   clusterNames: {},
   clusters: {},
   deviceTypes: { RoboticVacuumCleaner: { deviceType: 0x74 } },
+  MatterStatus: { Busy: class Busy extends Error {} },
   MatterTypes: {},
 }))
 
@@ -189,5 +190,33 @@ describe('matterAPIImpl.unregisterPlatformAccessories — guard before the manag
     await impl.unregisterPlatformAccessories('homebridge-test', 'TestPlatform', [{ UUID: 'uuid-1', deviceType: 'OnOff' } as any])
 
     expect(api.emit).toHaveBeenCalled()
+  })
+})
+
+describe('matterAPIImpl.status — Matter status errors without a runtime homebridge import (#3966)', () => {
+  it('exposes the Matter status error classes', () => {
+    const impl = new MatterAPIImpl(makeApi())
+
+    expect(impl.status).toBeDefined()
+    expect(impl.status.Busy).toBeDefined()
+  })
+
+  it('returns throwable error classes', () => {
+    const impl = new MatterAPIImpl(makeApi())
+
+    const error = new impl.status.Busy('Device is processing another command')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(() => {
+      throw error
+    }).toThrow('Device is processing another command')
+  })
+
+  it('is available before the Matter manager is attached', () => {
+    // Plugins construct handlers at registration time, so the error classes
+    // must not depend on the manager being ready.
+    const impl = new MatterAPIImpl(makeApi({ _matterManager: undefined }))
+
+    expect(impl.status.Busy).toBeDefined()
   })
 })

--- a/src/matter/MatterAPIImpl.spec.ts
+++ b/src/matter/MatterAPIImpl.spec.ts
@@ -220,3 +220,45 @@ describe('matterAPIImpl.status — Matter status errors without a runtime homebr
     expect(impl.status.Busy).toBeDefined()
   })
 })
+
+describe('matterAPIImpl.registerPlatformAccessories — bridged registration before the server is running (#3970)', () => {
+  const bridgedAccessory = {
+    UUID: 'uuid-1',
+    displayName: 'Light',
+    deviceType: { deviceType: 0x0100 }, // not RoboticVacuumCleaner → bridged
+    manufacturer: 'Acme',
+    model: 'X',
+    serialNumber: 'S1',
+  } as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects and does not emit when the bridge server is still starting', async () => {
+    // hasActiveMatter() is true (server constructed) but the node has not started
+    // yet — the previously silent-drop window.
+    const api = makeApi({ _matterManager: { hasActiveMatter: () => true, isBridgeServerStarting: () => true } })
+    const impl = new MatterAPIImpl(api)
+    vi.spyOn(impl as any, 'validateAccessories').mockReturnValue([bridgedAccessory])
+
+    await expect(
+      impl.registerPlatformAccessories('homebridge-test', 'TestPlatform', [bridgedAccessory]),
+    ).rejects.toThrow(/still starting/)
+
+    // Must not have emitted a (fire-and-forget) registration the plugin can't see fail.
+    expect(api.emit).not.toHaveBeenCalled()
+  })
+
+  it('emits the registration once the bridge server is running', async () => {
+    const api = makeApi({ _matterManager: { hasActiveMatter: () => true, isBridgeServerStarting: () => false } })
+    const impl = new MatterAPIImpl(api)
+    vi.spyOn(impl as any, 'validateAccessories').mockReturnValue([bridgedAccessory])
+
+    await expect(
+      impl.registerPlatformAccessories('homebridge-test', 'TestPlatform', [bridgedAccessory]),
+    ).resolves.toBeUndefined()
+
+    expect(api.emit).toHaveBeenCalled()
+  })
+})

--- a/src/matter/MatterAPIImpl.ts
+++ b/src/matter/MatterAPIImpl.ts
@@ -308,6 +308,20 @@ export class MatterAPIImpl implements MatterAPI {
 
     // Handle normal accessories (added to bridge)
     if (normalAccessories.length > 0) {
+      // The bridged register event is emitted fire-and-forget, so if the bridge
+      // Matter server node is not running yet the registration is silently
+      // dropped (the downstream "Matter server not started" error is only
+      // logged) and this call would still resolve. Reject instead, so the plugin
+      // can tell the accessory was not registered. External accessories are
+      // unaffected — they run on their own dedicated server and already await a
+      // completion resolver.
+      const matterManager = (this.api as unknown as HomebridgeAPIInternals)._matterManager
+      if (matterManager && matterManager.isBridgeServerStarting()) {
+        throw new Error(
+          `${pluginIdentifier}: Cannot register Matter accessories yet — the Matter server for this bridge is still starting. Register from your platform's 'didFinishLaunching' event; if you already do, this is transient and the accessories are restored from cache on the next start.`,
+        )
+      }
+
       // Add plugin/platform association
       normalAccessories.forEach((accessory) => {
         const internal = accessory as InternalMatterAccessory

--- a/src/matter/MatterAPIImpl.ts
+++ b/src/matter/MatterAPIImpl.ts
@@ -23,7 +23,7 @@ import type { InternalMatterAccessory, MatterAccessory, MatterServer } from './i
 
 import { InternalAPIEvent } from '../api.js'
 import { Logger } from '../logger.js'
-import { clusterNames, clusters, deviceTypes, MatterTypes } from './index.js'
+import { clusterNames, clusters, deviceTypes, MatterStatus, MatterTypes } from './index.js'
 import { SwitchAPIImpl } from './SwitchAPI.js'
 
 /**
@@ -216,6 +216,17 @@ export class MatterAPIImpl implements MatterAPI {
    */
   get types() {
     return MatterTypes
+  }
+
+  /**
+   * Matter protocol status errors for handlers
+   *
+   * Exposed here so plugins never need a runtime import of the `homebridge`
+   * package, which cannot resolve on installs that keep Homebridge in a
+   * separate node_modules tree.
+   */
+  get status() {
+    return MatterStatus
   }
 
   /**

--- a/src/matter/behaviors/ClosureControlBehavior.spec.ts
+++ b/src/matter/behaviors/ClosureControlBehavior.spec.ts
@@ -1,0 +1,117 @@
+import type { BehaviorRegistry } from './BehaviorRegistry.js'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DefaultClosureControlServer, HomebridgeClosureControlServer } from './ClosureControlBehavior.js'
+import { setRegistryManager } from './EndpointContext.js'
+import { RegistryManager } from './RegistryManager.js'
+
+interface ClosureState {
+  overallCurrentState?: Record<string, unknown>
+  overallTargetState?: Record<string, unknown>
+  mainState?: number
+}
+
+function makeBehavior<T>(prototype: object, state: ClosureState, endpoint?: unknown): T {
+  const behavior = Object.create(prototype)
+  Object.defineProperty(behavior, 'state', { get: () => state, configurable: true })
+  if (endpoint) {
+    Object.defineProperty(behavior, 'endpoint', { get: () => endpoint, configurable: true })
+  }
+  return behavior as T
+}
+
+describe('defaultClosureControlServer', () => {
+  let state: ClosureState
+  let behavior: DefaultClosureControlServer
+
+  beforeEach(() => {
+    state = {}
+    behavior = makeBehavior(DefaultClosureControlServer.prototype, state)
+  })
+
+  it('should record the requested position as both target and current', async () => {
+    // The matter.js base server leaves every command unimplemented (it throws
+    // NotImplementedError), so the default server must record the move itself.
+    await behavior.moveTo({ position: 1 } as any)
+
+    expect(state.overallTargetState).toEqual({ position: 1 })
+    expect(state.overallCurrentState).toEqual({ position: 1 })
+  })
+
+  it('should keep fields the request did not mention', async () => {
+    state.overallTargetState = { position: 0, latch: true }
+
+    await behavior.moveTo({ position: 1 } as any)
+
+    expect(state.overallTargetState).toEqual({ position: 1, latch: true })
+  })
+
+  it('should pull the target back to the current position on stop', async () => {
+    state.overallCurrentState = { position: 2 }
+    state.overallTargetState = { position: 1 }
+
+    await behavior.stop()
+
+    expect(state.overallTargetState).toEqual({ position: 2 })
+  })
+})
+
+describe('homebridgeClosureControlServer', () => {
+  let registry: BehaviorRegistry
+  let behavior: HomebridgeClosureControlServer
+  let state: ClosureState
+  const endpointId = 'test-endpoint-closure'
+
+  beforeEach(() => {
+    registry = {
+      executeHandler: vi.fn().mockResolvedValue(true),
+      syncStateToCache: vi.fn(),
+    } as any
+
+    state = {}
+    const endpoint = { id: endpointId }
+    const registryManager = new RegistryManager()
+    setRegistryManager(endpoint, registryManager)
+    registryManager.registerEndpoint(endpointId, registry)
+
+    behavior = makeBehavior(HomebridgeClosureControlServer.prototype, state, endpoint)
+  })
+
+  it('should execute the plugin handler for moveTo', async () => {
+    const request = { position: 1 } as any
+
+    await behavior.moveTo(request)
+
+    expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'closureControl', 'moveTo', request)
+  })
+
+  it('should record the state only after the handler succeeds', async () => {
+    vi.mocked(registry.executeHandler).mockRejectedValueOnce(new Error('gate jammed'))
+
+    await expect(behavior.moveTo({ position: 1 } as any)).rejects.toThrow('Failed to move closure')
+    expect(state.overallTargetState).toBeUndefined()
+  })
+
+  it('should sync the new state to the cache', async () => {
+    await behavior.moveTo({ position: 1 } as any)
+
+    expect(registry.syncStateToCache).toHaveBeenCalledWith(
+      endpointId,
+      'closureControl',
+      expect.objectContaining({ overallTargetState: { position: 1 } }),
+    )
+  })
+
+  it('should execute the plugin handler for stop', async () => {
+    await behavior.stop()
+
+    expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'closureControl', 'stop')
+  })
+
+  it('should wrap a handler failure so the endpoint stays online', async () => {
+    vi.mocked(registry.executeHandler).mockRejectedValueOnce(new Error('no response'))
+
+    await expect(behavior.stop()).rejects.toThrow('Failed to stop closure: no response')
+  })
+})

--- a/src/matter/behaviors/ClosureControlBehavior.ts
+++ b/src/matter/behaviors/ClosureControlBehavior.ts
@@ -1,0 +1,130 @@
+/**
+ * ClosureControl Cluster Behavior
+ *
+ * Handles move/stop commands for closures - garage doors, gates and similar.
+ */
+
+import { ClosureControlServer } from '@matter/main/behaviors/closure-control'
+import { ClosureControl } from '@matter/main/clusters/closure-control'
+import { Status, StatusResponseError } from '@matter/main/types'
+
+import { MatterStatus } from '../errors.js'
+import { getRegistryManager } from './EndpointContext.js'
+
+/**
+ * Default ClosureControl Server.
+ *
+ * matter.js's base ClosureControlServer implements none of the commands -
+ * invoking one throws NotImplementedError - so a closure without plugin
+ * handlers would advertise moveTo/stop and then fail every one. This default
+ * reflects the command in the cluster state instead, which is enough for the
+ * endpoint to behave sanely on its own.
+ *
+ * The move is reported as complete immediately. A plugin that knows better
+ * (a garage door takes ~15 seconds) should update `overallCurrentState` from
+ * its own device reports; the point here is only that the target is recorded
+ * and the closure never looks stuck.
+ */
+export class DefaultClosureControlServer extends ClosureControlServer {
+  override async moveTo(request: ClosureControl.MoveToRequest): Promise<void> {
+    const target = {
+      ...(this.state.overallTargetState ?? {}),
+      ...(request.position !== undefined ? { position: request.position } : {}),
+      ...(request.latch !== undefined ? { latch: request.latch } : {}),
+      ...(request.speed !== undefined ? { speed: request.speed } : {}),
+    }
+
+    this.state.overallTargetState = target as typeof this.state.overallTargetState
+    this.state.overallCurrentState = target as typeof this.state.overallCurrentState
+    this.state.mainState = ClosureControl.MainState.Stopped
+  }
+
+  override async stop(): Promise<void> {
+    // Stopping leaves the closure wherever it is, so the target becomes the
+    // current position rather than the other way round.
+    this.state.overallTargetState = this.state.overallCurrentState as typeof this.state.overallTargetState
+    this.state.mainState = ClosureControl.MainState.Stopped
+  }
+}
+
+/**
+ * Custom ClosureControl Server that calls plugin handlers.
+ *
+ * Extends the default server so `super.*()` records the state (the matter.js
+ * base would throw NotImplementedError).
+ */
+export class HomebridgeClosureControlServer extends DefaultClosureControlServer {
+  /**
+   * Get the registry for this behavior's endpoint
+   */
+  private getRegistry() {
+    return getRegistryManager(this.endpoint).getRegistry(this.endpoint.id)
+  }
+
+  /**
+   * Handle 'moveTo' command
+   */
+  override async moveTo(request: ClosureControl.MoveToRequest): Promise<void> {
+    const endpointId = this.endpoint.id
+    const registry = this.getRegistry()
+
+    try {
+      // Execute user handler
+      await registry.executeHandler(endpointId, 'closureControl', 'moveTo', request)
+
+      // Only reached if handler succeeded - update Matter state via super
+      await super.moveTo(request)
+
+      // Sync state to cache
+      registry.syncStateToCache(endpointId, 'closureControl', {
+        overallTargetState: this.state.overallTargetState,
+        overallCurrentState: this.state.overallCurrentState,
+        mainState: this.state.mainState,
+      })
+    } catch (error) {
+      // If user handler already threw a StatusResponseError, propagate it as-is
+      // This sends a proper Matter protocol error response to the controller
+      if (MatterStatus.isMatterProtocolError(error)) {
+        throw error
+      }
+
+      // For other errors, wrap in appropriate StatusResponseError
+      // This prevents the endpoint from crashing and keeps the device online
+      const message = error instanceof Error ? error.message : String(error)
+      throw new StatusResponseError(`Failed to move closure: ${message}`, Status.Failure)
+    }
+  }
+
+  /**
+   * Handle 'stop' command
+   */
+  override async stop(): Promise<void> {
+    const endpointId = this.endpoint.id
+    const registry = this.getRegistry()
+
+    try {
+      // Execute user handler
+      await registry.executeHandler(endpointId, 'closureControl', 'stop')
+
+      // Only reached if handler succeeded - update Matter state via super
+      await super.stop()
+
+      // Sync state to cache
+      registry.syncStateToCache(endpointId, 'closureControl', {
+        overallTargetState: this.state.overallTargetState,
+        mainState: this.state.mainState,
+      })
+    } catch (error) {
+      // If user handler already threw a StatusResponseError, propagate it as-is
+      // This sends a proper Matter protocol error response to the controller
+      if (MatterStatus.isMatterProtocolError(error)) {
+        throw error
+      }
+
+      // For other errors, wrap in appropriate StatusResponseError
+      // This prevents the endpoint from crashing and keeps the device online
+      const message = error instanceof Error ? error.message : String(error)
+      throw new StatusResponseError(`Failed to stop closure: ${message}`, Status.Failure)
+    }
+  }
+}

--- a/src/matter/behaviors/KeypadInputBehavior.spec.ts
+++ b/src/matter/behaviors/KeypadInputBehavior.spec.ts
@@ -1,0 +1,65 @@
+import type { BehaviorRegistry } from './BehaviorRegistry.js'
+
+import { KeypadInput } from '@matter/main/clusters/keypad-input'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setRegistryManager } from './EndpointContext.js'
+import { DefaultKeypadInputServer, HomebridgeKeypadInputServer } from './KeypadInputBehavior.js'
+import { RegistryManager } from './RegistryManager.js'
+
+function makeBehavior<T>(prototype: object, endpoint?: unknown): T {
+  const behavior = Object.create(prototype)
+  if (endpoint) {
+    Object.defineProperty(behavior, 'endpoint', { get: () => endpoint, configurable: true })
+  }
+  return behavior as T
+}
+
+describe('defaultKeypadInputServer', () => {
+  it('should answer UnsupportedKey rather than throwing', async () => {
+    // The matter.js base leaves sendKey unimplemented, so without this every
+    // key press on a player with no handler would fail as a protocol error.
+    const behavior = makeBehavior<DefaultKeypadInputServer>(DefaultKeypadInputServer.prototype)
+
+    const response = await behavior.sendKey({ keyCode: KeypadInput.CecKeyCode.Select })
+
+    expect(response.status).toBe(KeypadInput.Status.UnsupportedKey)
+  })
+})
+
+describe('homebridgeKeypadInputServer', () => {
+  let registry: BehaviorRegistry
+  let behavior: HomebridgeKeypadInputServer
+  const endpointId = 'test-endpoint-keypad'
+
+  beforeEach(() => {
+    registry = {
+      executeHandler: vi.fn().mockResolvedValue(true),
+      syncStateToCache: vi.fn(),
+    } as any
+
+    const endpoint = { id: endpointId }
+    const registryManager = new RegistryManager()
+    setRegistryManager(endpoint, registryManager)
+    registryManager.registerEndpoint(endpointId, registry)
+
+    behavior = makeBehavior(HomebridgeKeypadInputServer.prototype, endpoint)
+  })
+
+  it('should route the key press to the plugin handler', async () => {
+    const request = { keyCode: KeypadInput.CecKeyCode.Up }
+
+    const response = await behavior.sendKey(request)
+
+    expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'keypadInput', 'sendKey', request)
+    expect(response.status).toBe(KeypadInput.Status.Success)
+  })
+
+  it('should report a failed handler through the response, not as an exception', async () => {
+    vi.mocked(registry.executeHandler).mockRejectedValueOnce(new Error('remote unreachable'))
+
+    const response = await behavior.sendKey({ keyCode: KeypadInput.CecKeyCode.Down })
+
+    expect(response.status).toBe(KeypadInput.Status.UnsupportedKey)
+  })
+})

--- a/src/matter/behaviors/KeypadInputBehavior.ts
+++ b/src/matter/behaviors/KeypadInputBehavior.ts
@@ -1,0 +1,64 @@
+/**
+ * KeypadInput Cluster Behavior
+ *
+ * Handles remote-control key presses for media players.
+ */
+
+import { KeypadInputServer } from '@matter/main/behaviors/keypad-input'
+import { KeypadInput } from '@matter/main/clusters/keypad-input'
+
+import { MatterStatus } from '../errors.js'
+import { getRegistryManager } from './EndpointContext.js'
+
+/**
+ * Default KeypadInput Server.
+ *
+ * matter.js's base KeypadInputServer leaves sendKey unimplemented (it throws
+ * NotImplementedError), so a player without a plugin handler would advertise
+ * the keypad and fail every press. Answering UnsupportedKey is the honest
+ * response for a device that has nowhere to send the key.
+ */
+export class DefaultKeypadInputServer extends KeypadInputServer {
+  // The key is ignored here - there is nowhere to send it. The parameter must
+  // stay so HomebridgeKeypadInputServer can forward it.
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  override async sendKey(_request: KeypadInput.SendKeyRequest): Promise<KeypadInput.SendKeyResponse> {
+    return { status: KeypadInput.Status.UnsupportedKey }
+  }
+}
+
+/**
+ * Custom KeypadInput Server that calls plugin handlers.
+ */
+export class HomebridgeKeypadInputServer extends DefaultKeypadInputServer {
+  /**
+   * Get the registry for this behavior's endpoint
+   */
+  private getRegistry() {
+    return getRegistryManager(this.endpoint).getRegistry(this.endpoint.id)
+  }
+
+  /**
+   * Handle 'sendKey' command
+   */
+  override async sendKey(request: KeypadInput.SendKeyRequest): Promise<KeypadInput.SendKeyResponse> {
+    const endpointId = this.endpoint.id
+    const registry = this.getRegistry()
+
+    try {
+      await registry.executeHandler(endpointId, 'keypadInput', 'sendKey', request)
+      return { status: KeypadInput.Status.Success }
+    } catch (error) {
+      // If user handler already threw a StatusResponseError, propagate it as-is
+      // This sends a proper Matter protocol error response to the controller
+      if (MatterStatus.isMatterProtocolError(error)) {
+        throw error
+      }
+
+      // KeypadInput carries its own status in the response, so a failed handler
+      // is reported through that rather than as a protocol-level error - which
+      // keeps the endpoint online.
+      return { status: KeypadInput.Status.UnsupportedKey }
+    }
+  }
+}

--- a/src/matter/behaviors/MediaPlaybackBehavior.spec.ts
+++ b/src/matter/behaviors/MediaPlaybackBehavior.spec.ts
@@ -1,0 +1,130 @@
+import type { BehaviorRegistry } from './BehaviorRegistry.js'
+
+import { MediaPlayback } from '@matter/main/clusters/media-playback'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setRegistryManager } from './EndpointContext.js'
+import { DefaultMediaPlaybackServer, HomebridgeMediaPlaybackServer } from './MediaPlaybackBehavior.js'
+import { RegistryManager } from './RegistryManager.js'
+
+function makeBehavior<T>(prototype: object, state: { currentState?: number }, endpoint?: unknown): T {
+  const behavior = Object.create(prototype)
+  Object.defineProperty(behavior, 'state', { get: () => state, configurable: true })
+  if (endpoint) {
+    Object.defineProperty(behavior, 'endpoint', { get: () => endpoint, configurable: true })
+  }
+  return behavior as T
+}
+
+describe('defaultMediaPlaybackServer', () => {
+  let state: { currentState?: number }
+  let behavior: DefaultMediaPlaybackServer
+
+  beforeEach(() => {
+    state = { currentState: MediaPlayback.PlaybackState.NotPlaying }
+    behavior = makeBehavior(DefaultMediaPlaybackServer.prototype, state)
+  })
+
+  it.each([
+    ['play', MediaPlayback.PlaybackState.Playing],
+    ['pause', MediaPlayback.PlaybackState.Paused],
+    ['stop', MediaPlayback.PlaybackState.NotPlaying],
+  ] as const)('should record the playback state implied by %s', async (command, expected) => {
+    // The matter.js base server leaves every transport command unimplemented,
+    // so without this a player would advertise the controls and fail them all.
+    state.currentState = MediaPlayback.PlaybackState.Paused
+
+    const response = await behavior[command]()
+
+    expect(state.currentState).toBe(expected)
+    expect(response.status).toBe(MediaPlayback.Status.Success)
+  })
+
+  it.each(['startOver', 'previous', 'next'] as const)('should leave the playback state alone for %s', async (command) => {
+    // Track navigation does not say anything about whether the player is
+    // playing, so it must not overwrite the state.
+    state.currentState = MediaPlayback.PlaybackState.Playing
+
+    const response = await behavior[command]()
+
+    expect(state.currentState).toBe(MediaPlayback.PlaybackState.Playing)
+    expect(response.status).toBe(MediaPlayback.Status.Success)
+  })
+})
+
+describe('homebridgeMediaPlaybackServer', () => {
+  let registry: BehaviorRegistry
+  let behavior: HomebridgeMediaPlaybackServer
+  let state: { currentState?: number }
+  const endpointId = 'test-endpoint-player'
+
+  beforeEach(() => {
+    registry = {
+      executeHandler: vi.fn().mockResolvedValue(true),
+      syncStateToCache: vi.fn(),
+    } as any
+
+    state = { currentState: MediaPlayback.PlaybackState.NotPlaying }
+    const endpoint = { id: endpointId }
+    const registryManager = new RegistryManager()
+    setRegistryManager(endpoint, registryManager)
+    registryManager.registerEndpoint(endpointId, registry)
+
+    behavior = makeBehavior(HomebridgeMediaPlaybackServer.prototype, state, endpoint)
+  })
+
+  it.each(['play', 'pause', 'stop', 'startOver', 'previous', 'next'] as const)(
+    'should route %s to the plugin handler',
+    async (command) => {
+      await behavior[command]()
+
+      expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'mediaPlayback', command, undefined)
+    },
+  )
+
+  it('should pass the request through for skipForward', async () => {
+    const request = { deltaPositionMilliseconds: 30000 } as any
+
+    await behavior.skipForward(request)
+
+    expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'mediaPlayback', 'skipForward', request)
+  })
+
+  it('should pass the request through for skipBackward', async () => {
+    const request = { deltaPositionMilliseconds: 10000 } as any
+
+    await behavior.skipBackward(request)
+
+    expect(registry.executeHandler).toHaveBeenCalledWith(endpointId, 'mediaPlayback', 'skipBackward', request)
+  })
+
+  it('should record the state and sync it once the handler succeeds', async () => {
+    const response = await behavior.play()
+
+    expect(state.currentState).toBe(MediaPlayback.PlaybackState.Playing)
+    expect(response.status).toBe(MediaPlayback.Status.Success)
+    expect(registry.syncStateToCache).toHaveBeenCalledWith(endpointId, 'mediaPlayback', {
+      currentState: MediaPlayback.PlaybackState.Playing,
+    })
+  })
+
+  it('should report a failed handler through the response, not as an exception', async () => {
+    // MediaPlayback carries its own status, so a failure belongs there - and
+    // not throwing keeps the endpoint online.
+    vi.mocked(registry.executeHandler).mockRejectedValueOnce(new Error('receiver is off'))
+
+    const response = await behavior.play()
+
+    expect(response.status).toBe(MediaPlayback.Status.InvalidStateForCommand)
+    expect(state.currentState).toBe(MediaPlayback.PlaybackState.NotPlaying)
+  })
+
+  it('should not touch the state when no handler is registered', async () => {
+    vi.mocked(registry.executeHandler).mockRejectedValueOnce(new Error('No handler registered'))
+
+    await behavior.pause()
+
+    expect(state.currentState).toBe(MediaPlayback.PlaybackState.NotPlaying)
+    expect(registry.syncStateToCache).not.toHaveBeenCalled()
+  })
+})

--- a/src/matter/behaviors/MediaPlaybackBehavior.ts
+++ b/src/matter/behaviors/MediaPlaybackBehavior.ts
@@ -1,0 +1,174 @@
+/**
+ * MediaPlayback Cluster Behavior
+ *
+ * Handles transport commands - play, pause, stop and track navigation - for
+ * media players and speakers.
+ */
+
+import { MediaPlaybackServer } from '@matter/main/behaviors/media-playback'
+import { MediaPlayback } from '@matter/main/clusters/media-playback'
+
+import { MatterStatus } from '../errors.js'
+import { getRegistryManager } from './EndpointContext.js'
+
+/**
+ * Default MediaPlayback Server.
+ *
+ * matter.js's base MediaPlaybackServer implements none of the commands -
+ * invoking one throws NotImplementedError - so a player without plugin
+ * handlers would advertise the transport controls and fail every one. This
+ * default reflects the command in `currentState` and answers Success, which is
+ * enough for the endpoint to behave sanely on its own.
+ */
+export class DefaultMediaPlaybackServer extends MediaPlaybackServer {
+  /**
+   * Record a new playback state, when the command implies one.
+   */
+  protected reflect(state?: MediaPlayback.PlaybackState): MediaPlayback.PlaybackResponse {
+    if (state !== undefined) {
+      this.state.currentState = state
+    }
+    return { status: MediaPlayback.Status.Success }
+  }
+
+  override async play(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect(MediaPlayback.PlaybackState.Playing)
+  }
+
+  override async pause(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect(MediaPlayback.PlaybackState.Paused)
+  }
+
+  override async stop(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect(MediaPlayback.PlaybackState.NotPlaying)
+  }
+
+  // Track navigation does not change whether the player is playing, so these
+  // only acknowledge the command.
+  override async startOver(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect()
+  }
+
+  override async previous(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect()
+  }
+
+  override async next(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect()
+  }
+
+  // The requests are ignored here - the default server has no position to
+  // seek. The parameters must stay so HomebridgeMediaPlaybackServer can
+  // forward them.
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  override async skipForward(_request: MediaPlayback.SkipForwardRequest): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect()
+  }
+
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  override async skipBackward(_request: MediaPlayback.SkipBackwardRequest): Promise<MediaPlayback.PlaybackResponse> {
+    return this.reflect()
+  }
+}
+
+/**
+ * The transport commands routed to plugin handlers, and the playback state
+ * each one implies once the handler succeeds.
+ *
+ * Kept as data rather than one method per command: every command has the same
+ * shape - run the handler, record the state, answer Success - so writing them
+ * out longhand would be eight copies of the same error handling.
+ */
+const PLAYBACK_COMMANDS = {
+  play: MediaPlayback.PlaybackState.Playing,
+  pause: MediaPlayback.PlaybackState.Paused,
+  stop: MediaPlayback.PlaybackState.NotPlaying,
+  startOver: undefined,
+  previous: undefined,
+  next: undefined,
+  skipForward: undefined,
+  skipBackward: undefined,
+} as const
+
+/**
+ * Custom MediaPlayback Server that calls plugin handlers.
+ *
+ * Extends the default server for its `reflect()` state handling (the matter.js
+ * base implements nothing at all).
+ */
+export class HomebridgeMediaPlaybackServer extends DefaultMediaPlaybackServer {
+  /**
+   * Get the registry for this behavior's endpoint
+   */
+  private getRegistry() {
+    return getRegistryManager(this.endpoint).getRegistry(this.endpoint.id)
+  }
+
+  /**
+   * Run a plugin handler and reflect the resulting playback state.
+   *
+   * A handler that throws a Matter protocol error is propagated as-is so the
+   * controller gets the real status; anything else is answered with a
+   * cluster-level status rather than an exception, which keeps the endpoint
+   * online.
+   */
+  private async invoke(
+    commandName: keyof typeof PLAYBACK_COMMANDS,
+    request?: unknown,
+  ): Promise<MediaPlayback.PlaybackResponse> {
+    const endpointId = this.endpoint.id
+    const registry = this.getRegistry()
+
+    try {
+      await registry.executeHandler(endpointId, 'mediaPlayback', commandName, request)
+
+      // Only reached if the handler succeeded - update Matter state
+      const response = this.reflect(PLAYBACK_COMMANDS[commandName])
+
+      registry.syncStateToCache(endpointId, 'mediaPlayback', { currentState: this.state.currentState })
+
+      return response
+    } catch (error) {
+      if (MatterStatus.isMatterProtocolError(error)) {
+        throw error
+      }
+
+      // Unlike the on/off style clusters, MediaPlayback carries its own status
+      // in the response, so a failure is reported through that rather than as
+      // a protocol-level error.
+      return { status: MediaPlayback.Status.InvalidStateForCommand }
+    }
+  }
+
+  override async play(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('play')
+  }
+
+  override async pause(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('pause')
+  }
+
+  override async stop(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('stop')
+  }
+
+  override async startOver(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('startOver')
+  }
+
+  override async previous(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('previous')
+  }
+
+  override async next(): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('next')
+  }
+
+  override async skipForward(request: MediaPlayback.SkipForwardRequest): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('skipForward', request)
+  }
+
+  override async skipBackward(request: MediaPlayback.SkipBackwardRequest): Promise<MediaPlayback.PlaybackResponse> {
+    return this.invoke('skipBackward', request)
+  }
+}

--- a/src/matter/behaviors/index.ts
+++ b/src/matter/behaviors/index.ts
@@ -6,6 +6,7 @@
 export { HomebridgeAirQualityServer } from './AirQualityBehavior.js'
 export type { MatterAccessoryMap, MatterCommandHandler } from './BehaviorRegistry.js'
 export { BehaviorRegistry } from './BehaviorRegistry.js'
+export { DefaultClosureControlServer, HomebridgeClosureControlServer } from './ClosureControlBehavior.js'
 export { HomebridgeColorControlServer } from './ColorControlBehavior.js'
 export {
   HomebridgeCarbonMonoxideConcentrationMeasurementServer,
@@ -17,7 +18,9 @@ export {
 export { HomebridgeDoorLockServer } from './DoorLockBehavior.js'
 export { HomebridgeFanControlServer } from './FanControlBehavior.js'
 export { HomebridgeIdentifyServer } from './IdentifyBehavior.js'
+export { DefaultKeypadInputServer, HomebridgeKeypadInputServer } from './KeypadInputBehavior.js'
 export { HomebridgeLevelControlServer } from './LevelControlBehavior.js'
+export { DefaultMediaPlaybackServer, HomebridgeMediaPlaybackServer } from './MediaPlaybackBehavior.js'
 export { HomebridgeOnOffServer } from './OnOffBehavior.js'
 export { RegistryManager } from './RegistryManager.js'
 export { HomebridgeRvcCleanModeServer } from './RvcCleanModeBehavior.js'

--- a/src/matter/clusterHandlerMap.ts
+++ b/src/matter/clusterHandlerMap.ts
@@ -9,7 +9,7 @@
  * so they automatically update when matter.js is bumped.
  */
 
-import type { ColorControl, DoorLock, FanControl, Identify, LevelControl, ModeBase, ServiceArea, Thermostat, ValveConfigurationAndControl, WindowCovering } from '@matter/main/clusters'
+import type { ClosureControl, ColorControl, DoorLock, FanControl, Identify, KeypadInput, LevelControl, MediaPlayback, ModeBase, ServiceArea, Thermostat, ValveConfigurationAndControl, WindowCovering } from '@matter/main/clusters'
 
 import type { MatterCommandHandler } from './types.js'
 
@@ -156,6 +156,44 @@ export interface ServiceAreaHandlers {
 }
 
 /**
+ * ClosureControl cluster handler methods
+ *
+ * `stop` is not available on a closure composed with the Instantaneous
+ * feature - such a closure reaches its target immediately, so the spec has
+ * nothing for Stop to do.
+ */
+export interface ClosureControlHandlers {
+  moveTo?: MatterCommandHandler<ClosureControl.MoveToRequest>
+  stop?: MatterCommandHandler
+}
+
+/**
+ * MediaPlayback cluster handler methods
+ *
+ * The transport controls a player always has. The feature-gated commands
+ * (Rewind and FastForward behind VariableSpeed, Seek behind AdvancedSeek, the
+ * track commands behind AudioTracks/TextTracks) are not routed - a plugin that
+ * composes those features needs to supply its own behavior for them.
+ */
+export interface MediaPlaybackHandlers {
+  play?: MatterCommandHandler
+  pause?: MatterCommandHandler
+  stop?: MatterCommandHandler
+  startOver?: MatterCommandHandler
+  previous?: MatterCommandHandler
+  next?: MatterCommandHandler
+  skipForward?: MatterCommandHandler<MediaPlayback.SkipForwardRequest>
+  skipBackward?: MatterCommandHandler<MediaPlayback.SkipBackwardRequest>
+}
+
+/**
+ * KeypadInput cluster handler methods
+ */
+export interface KeypadInputHandlers {
+  sendKey?: MatterCommandHandler<KeypadInput.SendKeyRequest>
+}
+
+/**
  * ValveConfigurationAndControl cluster handler methods
  */
 export interface ValveConfigurationAndControlHandlers {
@@ -203,4 +241,7 @@ export interface ClusterHandlerMap {
   rvcOperationalState: RvcOperationalStateHandlers
   serviceArea: ServiceAreaHandlers
   valveConfigurationAndControl: ValveConfigurationAndControlHandlers
+  closureControl: ClosureControlHandlers
+  mediaPlayback: MediaPlaybackHandlers
+  keypadInput: KeypadInputHandlers
 }

--- a/src/matter/clusterNames.spec.ts
+++ b/src/matter/clusterNames.spec.ts
@@ -12,6 +12,20 @@ describe('clusterNames', () => {
     expect(values).toContain('electricalEnergyMeasurement')
   })
 
+  it('includes the clusters carried by the closure, media player and speaker types', () => {
+    // Exposing a device type without listing its clusters here leaves plugins
+    // with no api.matter.clusterNames constant to pass, and makes
+    // updateAccessoryState warn on every single update - which is what the
+    // electrical measurement entries above were added to stop.
+    const values = Object.values(clusterNames)
+    expect(values).toContain('closureControl')
+    expect(values).toContain('mediaPlayback')
+    expect(values).toContain('keypadInput')
+    // the speaker's two clusters are shared with lights and outlets
+    expect(values).toContain('levelControl')
+    expect(values).toContain('onOff')
+  })
+
   it('lists every cluster routable via ClusterStateMap (compile-time drift guard)', () => {
     // MatterAPIImpl.validateClusterName warns for any cluster missing from
     // clusterNames - if this assertion fails, a cluster was added to

--- a/src/matter/deviceTypes.spec.ts
+++ b/src/matter/deviceTypes.spec.ts
@@ -62,6 +62,12 @@ describe('deviceTypes mandatory clusters', () => {
     ['GenericSwitch', ['switch']],
     ['Pump', ['onOff', 'pumpConfigurationAndControl']],
     ['RoomAirConditioner', ['onOff', 'thermostat']],
+    // Closures, for garage doors and gates
+    ['Closure', ['closureControl']],
+    // Media. MediaPlayer carries playback and source selection but NOT volume,
+    // which lives on a separate Speaker endpoint composed alongside it
+    ['MediaPlayer', ['mediaPlayback']],
+    ['Speaker', ['onOff', 'levelControl']],
   ]
 
   it.each(cases)('%s includes %j', (name, expectedBehaviors) => {

--- a/src/matter/deviceTypes.spec.ts
+++ b/src/matter/deviceTypes.spec.ts
@@ -34,6 +34,9 @@ describe('deviceTypes mandatory clusters', () => {
   //   auto-detected Lift/Tilt features (see applyWindowCoveringFeatures)
   // - SmokeSensor: its cluster is added at registration time with
   //   auto-detected SmokeAlarm/CoAlarm features (see applySmokeCoAlarmFeatures)
+  // - Thermostat: its cluster is added at registration time with
+  //   auto-detected Heating/Cooling features (see applyThermostatFeatures), so a
+  //   heating-only thermostat is not forced to advertise cooling
   // - OnOffSwitch: per the Matter spec the OnOff cluster on a light switch is
   //   a client cluster (it controls other devices), so the server type only
   //   carries Identify
@@ -52,7 +55,6 @@ describe('deviceTypes mandatory clusters', () => {
     ['MotionSensor', ['occupancySensing']],
     ['ContactSensor', ['booleanState']],
     ['LeakSensor', ['booleanState']],
-    ['Thermostat', ['thermostat']],
     ['Fan', ['fanControl']],
     ['DoorLock', ['doorLock']],
     ['RoboticVacuumCleaner', ['rvcRunMode', 'rvcOperationalState']],

--- a/src/matter/deviceTypes.spec.ts
+++ b/src/matter/deviceTypes.spec.ts
@@ -14,6 +14,7 @@ import type { Behavior } from '@matter/node'
 
 import { describe, expect, it } from 'vitest'
 
+import { CORE_CLUSTER_BEHAVIOR_MAP } from './server/BehaviorMap.js'
 import { deviceTypes } from './types.js'
 
 /** Read the supported behavior classes off a device type. */
@@ -75,6 +76,52 @@ describe('deviceTypes mandatory clusters', () => {
     for (const behaviorId of expectedBehaviors) {
       expect(behaviors[behaviorId], `expected ${name} to include the '${behaviorId}' cluster`).toBeDefined()
     }
+  })
+})
+
+describe('command clusters are routable to plugin handlers', () => {
+  // Carrying the cluster is only half the job. If CORE_CLUSTER_BEHAVIOR_MAP has
+  // no entry for it, the plugin's handlers are registered but nothing ever
+  // invokes them - the endpoint advertises controls that silently do nothing.
+  // That is what shipped for Closure and MediaPlayer, so guard it by name.
+  const cases: Array<[keyof typeof deviceTypes, string[]]> = [
+    ['Closure', ['closureControl']],
+    ['MediaPlayer', ['mediaPlayback', 'keypadInput']],
+    ['Speaker', ['onOff', 'levelControl']],
+    ['WaterValve', ['valveConfigurationAndControl']],
+    ['DoorLock', ['doorLock']],
+  ]
+
+  it.each(cases)('%s can route %j', (name, clusterNames) => {
+    for (const clusterName of clusterNames) {
+      expect(
+        CORE_CLUSTER_BEHAVIOR_MAP[clusterName],
+        `${name} advertises '${clusterName}' but no behavior routes its commands`,
+      ).toBeDefined()
+    }
+  })
+})
+
+describe('closure and media default servers', () => {
+  // matter.js implements none of these commands, so the base servers throw
+  // NotImplementedError. The device types must compose ours instead, or a
+  // plugin that supplies no handlers gets an endpoint that fails every command.
+  it.each([
+    ['Closure', 'closureControl', 'DefaultClosureControlServer'],
+    ['MediaPlayer', 'mediaPlayback', 'DefaultMediaPlaybackServer'],
+    ['MediaPlayer', 'keypadInput', 'DefaultKeypadInputServer'],
+  ] as const)('%s uses our %s implementation', (name, clusterName, expectedBase) => {
+    const behavior = supportedBehaviors(deviceTypes[name])[clusterName]
+
+    // `.with(...)` produces an anonymous subclass, so walk up to the named one.
+    let current: any = behavior
+    const names: string[] = []
+    while (current) {
+      names.push(current.name)
+      current = Object.getPrototypeOf(current)
+    }
+
+    expect(names).toContain(expectedBase)
   })
 })
 

--- a/src/matter/errors.ts
+++ b/src/matter/errors.ts
@@ -8,18 +8,21 @@
  * the appropriate status code to the controller (e.g., Home app) instead
  * of crashing the endpoint.
  *
+ * Reach these through `api.matter.status` rather than importing `MatterStatus`
+ * from the `homebridge` package: the import is a value import, so it resolves
+ * the package at plugin load time and fails on installs that keep Homebridge in
+ * a separate `node_modules` tree.
+ *
  * @example
  * ```typescript
- * import { MatterStatus } from 'homebridge'
- *
  * handlers: {
  *   onOff: {
  *     on: async () => {
  *       if (deviceIsBusy) {
- *         throw new MatterStatus.Busy('Device is processing another command')
+ *         throw new api.matter!.status.Busy('Device is processing another command')
  *       }
  *       if (requestTimedOut) {
- *         throw new MatterStatus.Timeout('Device did not respond in time')
+ *         throw new api.matter!.status.Timeout('Device did not respond in time')
  *       }
  *       // ... control device
  *     }

--- a/src/matter/index.ts
+++ b/src/matter/index.ts
@@ -29,6 +29,7 @@ export { type MatterConfigValidationResult, MatterConfigValidator } from './conf
 export { MatterStatus } from './errors.js'
 export { MatterBridgeManager } from './MatterBridgeManager.js'
 export { MatterServer } from './server.js'
+export type { CommissioningSnapshot, FabricInfo } from './server/FabricManager.js'
 export {
   clusterNames,
   clusters,

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -60,6 +60,8 @@ export class MatterServer extends EventEmitter {
   private readonly behaviorRegistry: BehaviorRegistry
   private readonly registryManager: RegistryManager
   private isRunning = false
+  private lastRegistrationAt = 0
+  private registrationsInFlight = 0
   private shutdownHandler: (() => Promise<void>) | null = null
   private cleanupHandlers: Array<() => void | Promise<void>> = []
   private accessoryCache: MatterAccessoryCache | null = null
@@ -151,9 +153,33 @@ export class MatterServer extends EventEmitter {
   // Accessory registration (Plugin API - matches HAP pattern)
   // ============================================================================
 
+  /**
+   * When the last registerPlatformAccessories() call arrived. The
+   * deferred-online settle loop (ChildBridgeMatterManager) polls this to
+   * detect when the initial registration burst has gone idle.
+   */
+  getLastRegistrationAt(): number {
+    return this.lastRegistrationAt
+  }
+
+  /** Registration calls that have started but not finished; used by the deferred-online settle check. */
+  getRegistrationsInFlight(): number {
+    return this.registrationsInFlight
+  }
+
   async registerPlatformAccessories(pluginIdentifier: string, platformName: string, accessories: MatterAccessory[]): Promise<void> {
-    for (const accessory of accessories) {
-      await this.accessoryManager.registerAccessory(pluginIdentifier, platformName, accessory, this.getAccessoryManagerDeps())
+    // Stamp on both entry and exit and track in-flight calls so the deferred-
+    // online settle check never treats a batch that is still registering (or
+    // one that takes longer than the settle window) as idle.
+    this.registrationsInFlight++
+    this.lastRegistrationAt = Date.now()
+    try {
+      for (const accessory of accessories) {
+        await this.accessoryManager.registerAccessory(pluginIdentifier, platformName, accessory, this.getAccessoryManagerDeps())
+      }
+    } finally {
+      this.lastRegistrationAt = Date.now()
+      this.registrationsInFlight--
     }
   }
 
@@ -315,6 +341,18 @@ export class MatterServer extends EventEmitter {
 
   isServerRunning(): boolean {
     return this.isRunning
+  }
+
+  /**
+   * True while the node is built but deliberately kept offline in deferOnline
+   * mode, waiting for the initial registration burst to settle. Registrations
+   * are expected in this window, so callers must not treat it as "starting".
+   * The aggregator check keeps this false before start() has built the node
+   * (and when start() failed) - registrations in that gap must be rejected as
+   * "starting", or they would be silently dropped (#3970).
+   */
+  isDeferredPreOnline(): boolean {
+    return this.config.deferOnline === true && !this.isRunning && this.aggregator !== null
   }
 
   getDeviceTypes(): typeof deviceTypes {

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -1,6 +1,7 @@
 import type { InternalMatterAccessory, MatterAccessory } from '../types.js'
 import type { AccessoryManagerDeps } from './AccessoryManager.js'
 
+import { DescriptorServer, FixedLabelServer } from '@matter/main/behaviors'
 import { PowerSourceServer } from '@matter/node/behaviors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -26,12 +27,19 @@ vi.mock('@matter/main', () => {
       this.id = options?.id
     }
   }
-  return { Endpoint: MockEndpoint }
+  return { Endpoint: MockEndpoint, VendorId: vi.fn((id: number) => id) }
 })
 vi.mock('@matter/main/behaviors', () => ({
   BasicInformationServer: { name: 'BasicInformationServer' },
-  BridgedDeviceBasicInformationServer: { name: 'BridgedDeviceBasicInformationServer' },
-  DescriptorServer: { name: 'DescriptorServer' },
+  BridgedDeviceBasicInformationServer: {
+    name: 'BridgedDeviceBasicInformationServer',
+    enable: vi.fn(() => ({ name: 'BridgedDeviceBasicInformationServer.enable' })),
+  },
+  DescriptorServer: {
+    name: 'DescriptorServer',
+    with: vi.fn((...args: any[]) => ({ name: `DescriptorServer.with(${args.join(',')})` })),
+  },
+  FixedLabelServer: { name: 'FixedLabelServer' },
 }))
 vi.mock('@matter/node/behaviors', () => ({
   PowerSourceServer: { name: 'PowerSourceServer', with: vi.fn((...args: any[]) => ({ name: `PowerSourceServer.with(${args.join(',')})` })) },
@@ -171,11 +179,38 @@ function createMockDeps(overrides: Partial<AccessoryManagerDeps> = {}): Accessor
   }
 }
 
+// Composed (parts-bearing) accessories chain several `.with()` calls on the
+// parent device type (BridgedDeviceBasicInformation, FixedLabel, PowerSource),
+// so the mock must stay chainable at any depth.
+function createChainableDeviceType(props: Record<string, unknown>): any {
+  return { ...props, with: vi.fn(() => createChainableDeviceType(props)) }
+}
+
+// A parent device type whose `.with()` is a single self-returning spy, so a
+// test can assert exactly which behaviors (FixedLabel, wired PowerSource) were
+// composed onto it across the several chained `.with()` calls registerAccessory
+// makes on the parent.
+function createSpyDeviceType(props: Record<string, unknown>): any {
+  const deviceType: any = { ...props }
+  deviceType.with = vi.fn(() => deviceType)
+  return deviceType
+}
+
+// A composed-device part: a plain device type plus a cluster, no handlers.
+function createComposedPart(id = 'part-1'): any {
+  return {
+    id,
+    displayName: `Part ${id}`,
+    deviceType: createChainableDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+    clusters: { onOff: { onOff: false } },
+  }
+}
+
 function createMockAccessory(overrides: Partial<MatterAccessory> = {}): MatterAccessory {
   return {
     UUID: 'test-uuid-001',
     displayName: 'Test Light',
-    deviceType: { deviceType: 0x0100, name: 'OnOffLight', with: vi.fn(() => ({ deviceType: 0x0100, with: vi.fn() })) } as any,
+    deviceType: createChainableDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
     serialNumber: 'SN-001',
     manufacturer: 'Test Mfg',
     model: 'Test Model',
@@ -559,6 +594,94 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
+    })
+  })
+
+  describe('composed parent (FixedLabel + wired PowerSource + tag list)', () => {
+    // A parts-bearing (composed/BridgedNode) parent must carry a FixedLabel and,
+    // unless the accessory declared its own PowerSource, a wired (AC) PowerSource
+    // — Apple's controller needs both to finish per-accessory session setup.
+    // Flat accessories get neither, and part endpoints carry a semantic tag list.
+
+    it('a composed accessory gets a FixedLabel and a wired PowerSource on the parent', async () => {
+      const deps = createMockDeps()
+      const deviceType = createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' })
+      const accessory = createMockAccessory({
+        deviceType,
+        parts: [createComposedPart()],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // FixedLabelServer is composed onto the parent device type...
+      expect(deviceType.with).toHaveBeenCalledWith(FixedLabelServer)
+      // ...and a wired PowerSource is synthesized.
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Wired')
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.fixedLabel).toEqual({
+        labelList: [{ label: 'composed', value: 'true' }],
+      })
+      // wiredCurrentType 0 = AC.
+      expect(internal.endpoint.options.powerSource.wiredCurrentType).toBe(0)
+    })
+
+    it('a composed accessory that declares its own PowerSource (battery) keeps it and gets no wired PowerSource', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+        clusters: {
+          onOff: { onOff: false },
+          powerSource: { batPercentRemaining: 200, batChargeLevel: 0 },
+        },
+        parts: [createComposedPart()],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // The plugin's battery PowerSource is composed...
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+      // ...and our wired PowerSource must never overwrite it.
+      expect(PowerSourceServer.with).not.toHaveBeenCalledWith('Wired')
+      const internal = deps.accessories.get('test-uuid-001') as any
+      // The plugin's battery cluster state survives, untouched by a wired override.
+      expect(internal.endpoint.options.powerSource.batPercentRemaining).toBe(200)
+      expect(internal.endpoint.options.powerSource.wiredCurrentType).toBeUndefined()
+    })
+
+    it('a flat accessory (no parts) gets no FixedLabel or synthesized PowerSource', async () => {
+      const deps = createMockDeps()
+      const deviceType = createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' })
+      const accessory = createMockAccessory({ deviceType })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(deviceType.with).not.toHaveBeenCalledWith(FixedLabelServer)
+      expect(PowerSourceServer.with).not.toHaveBeenCalledWith('Wired')
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.fixedLabel).toBeUndefined()
+      expect(internal.endpoint.options.powerSource).toBeUndefined()
+    })
+
+    it('part endpoints carry a tag list', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: createSpyDeviceType({ deviceType: 0x0100, name: 'OnOffLight' }),
+        parts: [createComposedPart('outlet-1')],
+      } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // The part's Descriptor gains the TagList feature...
+      expect(DescriptorServer.with).toHaveBeenCalledWith('TagList')
+      // ...and the part endpoint carries a Number-namespace (7) tag per part index.
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal._parts[0].endpoint.options.descriptor.tagList).toEqual([{
+        mfgCode: null,
+        namespaceId: 7,
+        tag: 0,
+        label: 'Part outlet-1',
+      }])
     })
   })
 

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -685,6 +685,93 @@ describe('accessoryManager', () => {
     })
   })
 
+  describe('bridged firmware version (BDBI software version)', () => {
+    // The firmwareRevision every plugin already provides is surfaced to
+    // controllers via BridgedDeviceBasicInformation, so e.g. Apple Home can
+    // show the bridged device's firmware in the accessory details.
+
+    it('maps firmwareRevision to softwareVersionString with a derived numeric softwareVersion', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '1.7.5-g9979d16' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('1.7.5-g9979d16')
+      // (1 << 16) | (7 << 8) | 5
+      expect(bdbi.softwareVersion).toBe(67333)
+    })
+
+    it('keeps the string but omits the numeric version when no semver triplet leads the string', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: 'build-2026' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('build-2026')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('encodes a large major that still fits 16 bits as an unsigned value', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '40000.0.0' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('40000.0.0')
+      // 40000 sets the sign bit under a plain 32-bit shift; the value must stay unsigned
+      expect(bdbi.softwareVersion).toBe(40000 * 0x10000)
+    })
+
+    it('omits the numeric version when the major does not fit 16 bits', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '70000.0.0' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('70000.0.0')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('omits the numeric version when minor or patch exceeds 255', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({ firmwareRevision: '1.7.300' } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe('1.7.300')
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+
+    it('truncates softwareVersionString to the 64-character spec limit', async () => {
+      const deps = createMockDeps()
+      const longRevision = `1.2.3+${'a'.repeat(80)}`
+      const accessory = createMockAccessory({ firmwareRevision: longRevision } as any)
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBe(longRevision.slice(0, 64))
+      expect(bdbi.softwareVersionString).toHaveLength(64)
+      expect(bdbi.softwareVersion).toBe((1 << 16) | (2 << 8) | 3)
+    })
+
+    it('sets neither field when the accessory has no firmwareRevision', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory()
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const bdbi = (deps.accessories.get('test-uuid-001') as any).endpoint.options.bridgedDeviceBasicInformation
+      expect(bdbi.softwareVersionString).toBeUndefined()
+      expect(bdbi.softwareVersion).toBeUndefined()
+    })
+  })
+
   describe('unregisterAccessory', () => {
     it('should remove an accessory from the map', async () => {
       const deps = createMockDeps()

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -290,6 +290,75 @@ describe('accessoryManager', () => {
       ).rejects.toThrow('already registered')
     })
 
+    // Cache-restored accessories are rebuilt into the bridge before going online
+    // (#3969). When the plugin later re-registers the same UUID it must attach to
+    // the existing endpoint in place (no parts-list churn) rather than hitting the
+    // duplicate-UUID error, and a genuine structural change must re-register fresh.
+    describe('cache-restored attach-in-place (#3969)', () => {
+      it('attaches a plugin registration to a restored accessory in place when the shape is unchanged', async () => {
+        const deps = createMockDeps()
+        const restored = {
+          ...createMockAccessory(),
+          endpoint: { marker: 'restored-endpoint' },
+          registered: false,
+          _restoredFromCache: true,
+        } as any
+        deps.accessories.set('test-uuid-001', restored)
+
+        // Same UUID, same device type, now carrying the plugin's real handlers.
+        const pluginAccessory = createMockAccessory({
+          handlers: { onOff: { on: vi.fn(), off: vi.fn() } },
+        } as any)
+
+        await manager.registerAccessory('homebridge-test', 'TestPlatform', pluginAccessory, deps)
+
+        const stored = deps.accessories.get('test-uuid-001') as any
+        expect(stored.registered).toBe(true)
+        expect(stored._restoredFromCache).toBe(false)
+        // Kept the endpoint built during restore — no new endpoint, no parts-list churn.
+        expect(stored.endpoint).toEqual({ marker: 'restored-endpoint' })
+        expect(deps.accessories.size).toBe(1)
+        // The plugin's handlers were wired to the existing endpoint.
+        expect(deps.behaviorRegistry.registerHandler).toHaveBeenCalledWith('test-uuid-001', 'onOff', 'on', expect.any(Function))
+      })
+
+      it('does not throw the duplicate-UUID error for a restored accessory', async () => {
+        const deps = createMockDeps()
+        deps.accessories.set('test-uuid-001', {
+          ...createMockAccessory(),
+          endpoint: { close: vi.fn() },
+          registered: false,
+          _restoredFromCache: true,
+        } as any)
+
+        await expect(
+          manager.registerAccessory('homebridge-test', 'TestPlatform', createMockAccessory(), deps),
+        ).resolves.toBeUndefined()
+      })
+
+      it('re-registers fresh when a restored accessory changed device type', async () => {
+        const deps = createMockDeps()
+        const restored = {
+          ...createMockAccessory(),
+          deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) },
+          endpoint: { close: vi.fn() },
+          registered: false,
+          _restoredFromCache: true,
+        } as any
+        deps.accessories.set('test-uuid-001', restored)
+        const unregisterSpy = vi.spyOn(manager, 'unregisterAccessory')
+
+        // Plugin registers the same UUID but as a different device type.
+        await manager.registerAccessory('homebridge-test', 'TestPlatform', createMockAccessory(), deps)
+
+        expect(unregisterSpy).toHaveBeenCalledWith('test-uuid-001', deps)
+        const stored = deps.accessories.get('test-uuid-001') as any
+        expect(stored).toBeDefined()
+        expect((stored.deviceType as any).name).toBe('OnOffLight')
+        expect(stored._restoredFromCache).toBeFalsy()
+      })
+    })
+
     it('should throw when server is not started', async () => {
       const deps = createMockDeps({
         getServerNode: () => null,

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -56,6 +56,7 @@ vi.mock('../serverHelpers.js', () => ({
   applySmokeCoAlarmFeatures: vi.fn((dt: any) => dt),
   detectElectricalMeasurementClusters: vi.fn(() => ({ hasPowerMeasurement: false, energyFeatures: [] })),
   applyElectricalMeasurementDefaults: vi.fn(),
+  applyLevelControlLightingFloor: vi.fn(),
   applyElectricalMeasurementClusters: vi.fn((dt: any) => dt),
   detectBehaviorFeatures: vi.fn(() => null),
   extractColorControlFeatures: vi.fn(() => []),

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -80,6 +80,7 @@ vi.mock('../types.js', () => {
     devices: {
       RoboticVacuumCleanerDevice: { deviceType: 0x0074 },
       SmokeCoAlarmDevice: { deviceType: 0x0076 },
+      ThermostatDevice: { deviceType: 0x0301 },
       ElectricalSensorEndpoint: { deviceType: 0x0510 },
       RoboticVacuumCleanerRequirements: {
         RvcCleanModeServer: { name: 'RvcCleanModeServer' },

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -8,7 +8,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   applyElectricalMeasurementClusters,
   applyElectricalMeasurementDefaults,
+  applyLevelControlLightingFloor,
+  applyThermostatFeatures,
   detectElectricalMeasurementClusters,
+  detectThermostatFeatures,
 } from '../serverHelpers.js'
 import { AccessoryManager } from './AccessoryManager.js'
 
@@ -72,6 +75,8 @@ vi.mock('../serverHelpers.js', () => ({
   applyWindowCoveringFeatures: vi.fn((dt: any) => dt),
   detectSmokeCoAlarmFeatures: vi.fn(() => ['SmokeAlarm']),
   applySmokeCoAlarmFeatures: vi.fn((dt: any) => dt),
+  detectThermostatFeatures: vi.fn(() => ['Heating']),
+  applyThermostatFeatures: vi.fn((dt: any) => dt),
   detectElectricalMeasurementClusters: vi.fn(() => ({ hasPowerMeasurement: false, energyFeatures: [] })),
   applyElectricalMeasurementDefaults: vi.fn(),
   applyLevelControlLightingFloor: vi.fn(),
@@ -80,10 +85,13 @@ vi.mock('../serverHelpers.js', () => ({
   extractColorControlFeatures: vi.fn(() => []),
   extractLevelControlFeatures: vi.fn(() => []),
   extractThermostatFeatures: vi.fn(() => []),
+  extractDeclaredFeatures: vi.fn(() => []),
   determineColorControlFeaturesFromHandlers: vi.fn(() => []),
   CLUSTER_IDS: {
+    CLOSURE_CONTROL: 0x0104,
     COLOR_CONTROL: 0x0300,
     LEVEL_CONTROL: 0x0008,
+    MEDIA_PLAYBACK: 0x0506,
     THERMOSTAT: 0x0201,
   },
 }))
@@ -572,10 +580,14 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect(applyElectricalMeasurementDefaults).toHaveBeenCalledTimes(1)
-      expect(applyElectricalMeasurementDefaults).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'outlet-1' }),
-        expect.objectContaining({ hasPowerMeasurement: true }),
-      )
+      // The part runs through the parent's preparation pipeline as an
+      // accessory-shaped view of itself. `clusters` must be the part's own
+      // object, not a copy, or the defaults written here would be applied to
+      // something that is then thrown away.
+      const [target, detection] = vi.mocked(applyElectricalMeasurementDefaults).mock.calls[0]
+      expect(target.displayName).toBe('Metered Outlet 1')
+      expect(target.clusters).toBe(accessory.parts![0].clusters)
+      expect(detection).toEqual(expect.objectContaining({ hasPowerMeasurement: true }))
       const internal = deps.accessories.get('test-uuid-001') as any
       expect(internal.endpoint.act).not.toHaveBeenCalled() // main endpoint unaffected
       expect(internal._parts[0].endpoint.act).toHaveBeenCalledTimes(1) // part advertises 0x0510
@@ -763,6 +775,101 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect(PowerSourceServer.with).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('parts get the same preparation as their parent', () => {
+    // Child endpoints used to run a cut-down pipeline that only looked up
+    // behaviors by cluster name. Everything the parent's preparation decides
+    // was skipped, silently: a composed battery was never exposed, a
+    // thermostat part had no thermostat cluster at all, and a dimmable part
+    // declaring minLevel 0 still failed to register.
+
+    function partsAccessory(part: Record<string, unknown>) {
+      return createMockAccessory({
+        deviceType: createChainableDeviceType({ deviceType: 0x000E, name: 'Aggregator' }),
+        clusters: {},
+        parts: [{
+          id: 'child-1',
+          displayName: 'Child One',
+          deviceType: createChainableDeviceType({ deviceType: 0x0101, name: 'DimmableLight' }),
+          ...part,
+        }],
+      } as any)
+    }
+
+    it('composes a battery PowerSource declared on a part', async () => {
+      const deps = createMockDeps()
+
+      await manager.registerAccessory(
+        'homebridge-test',
+        'TestPlatform',
+        partsAccessory({ clusters: { onOff: { onOff: false }, powerSource: { batPercentRemaining: 150 } } }),
+        deps,
+      )
+
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
+    })
+
+    it('advertises the PowerSource device type on the part endpoint', async () => {
+      const deps = createMockDeps()
+
+      await manager.registerAccessory(
+        'homebridge-test',
+        'TestPlatform',
+        partsAccessory({ clusters: { onOff: { onOff: false }, powerSource: { batPercentRemaining: 150 } } }),
+        deps,
+      )
+
+      // Composing the cluster is not enough - without the device type in the
+      // descriptor no controller has a reason to read the battery.
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal._parts[0].endpoint.advertisedDeviceTypes).toContain('PowerSource')
+    })
+
+    it('seeds the batChargeState of a part battery, as it does for the parent', async () => {
+      const deps = createMockDeps()
+      const accessory = partsAccessory({ clusters: { powerSource: { batPercentRemaining: 150 } } })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect((accessory.parts![0].clusters as any).powerSource.batChargeState).toBe(0)
+    })
+
+    it('adds the feature-gated Thermostat cluster to a thermostat part', async () => {
+      const deps = createMockDeps()
+
+      await manager.registerAccessory(
+        'homebridge-test',
+        'TestPlatform',
+        partsAccessory({
+          deviceType: createChainableDeviceType({ deviceType: 0x0301, name: 'Thermostat' }),
+          clusters: { thermostat: { occupiedHeatingSetpoint: 2000 } },
+        }),
+        deps,
+      )
+
+      // matter.js gates the cluster behind features, so the base device type
+      // carries none - skipping this dropped the part's thermostat entirely.
+      expect(applyThermostatFeatures).toHaveBeenCalledTimes(1)
+      expect(detectThermostatFeatures).toHaveBeenCalledTimes(1)
+    })
+
+    it('applies the LevelControl lighting floor to a part', async () => {
+      const deps = createMockDeps()
+
+      await manager.registerAccessory(
+        'homebridge-test',
+        'TestPlatform',
+        partsAccessory({
+          clusters: { levelControl: { currentLevel: 0, minLevel: 0 } },
+          handlers: { levelControl: { moveToLevel: vi.fn() } },
+        }),
+        deps,
+      )
+
+      // Two calls: once for the parent, once for the part.
+      expect(applyLevelControlLightingFloor).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -228,6 +228,55 @@ describe('accessoryManager', () => {
       expect(serverNode.act).not.toHaveBeenCalled()
     })
 
+    it('retries the parts-list notification when the config-version bump hits a synchronous lock (#3970)', async () => {
+      const increaseConfigurationVersion = vi.fn()
+      const deps = createMockDeps({ isCommissioned: () => true })
+      const serverNode = deps.getServerNode() as any
+      // First act() loses the lock race (matter.js-internal offline transaction),
+      // then the lock clears and it succeeds.
+      serverNode.act = vi.fn()
+        .mockRejectedValueOnce(new Error('Cannot lock test-bridge.basicInformation.state synchronously'))
+        .mockImplementation(async (fn: any) => fn({ get: vi.fn(() => ({ increaseConfigurationVersion })) }))
+      const accessory = createMockAccessory()
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(serverNode.act).toHaveBeenCalledTimes(2)
+      expect(increaseConfigurationVersion).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up without throwing when the lock never clears (#3970)', async () => {
+      const deps = createMockDeps({ isCommissioned: () => true })
+      const serverNode = deps.getServerNode() as any
+      serverNode.act = vi.fn().mockRejectedValue(
+        new Error('Cannot lock test-bridge.basicInformation.state synchronously'),
+      )
+      const accessory = createMockAccessory()
+
+      // The failure must be swallowed — a dropped notification must never fail
+      // the accessory registration.
+      await expect(
+        manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps),
+      ).resolves.toBeUndefined()
+
+      // PARTS_LIST_NOTIFY_ATTEMPTS = 5.
+      expect(serverNode.act).toHaveBeenCalledTimes(5)
+      expect(deps.accessories.has('test-uuid-001')).toBe(true)
+    })
+
+    it('does not retry a non-lock notification error (#3970)', async () => {
+      const deps = createMockDeps({ isCommissioned: () => true })
+      const serverNode = deps.getServerNode() as any
+      serverNode.act = vi.fn().mockRejectedValue(new Error('some other failure'))
+      const accessory = createMockAccessory()
+
+      await expect(
+        manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps),
+      ).resolves.toBeUndefined()
+
+      expect(serverNode.act).toHaveBeenCalledTimes(1)
+    })
+
     it('should reject duplicate UUIDs', async () => {
       const deps = createMockDeps()
       const accessory = createMockAccessory()

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -612,7 +612,10 @@ describe('accessoryManager', () => {
 
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
-      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+      // Every battery composes Rechargeable, with batChargeState seeded, so a
+      // device that starts reporting a charge state later is not rejected by
+      // conformance (#3982)
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
     })
 
     it('composes PowerSource for a non-RVC device with no handlers (e.g. a battery-powered sensor)', async () => {
@@ -630,7 +633,7 @@ describe('accessoryManager', () => {
 
       // Regression guard for the no-handlers early return: without the fix this
       // accessory bails before the battery is ever composed.
-      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
     })
 
     it('composes the Rechargeable feature when a charge state is declared', async () => {
@@ -647,6 +650,119 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
+    })
+
+    it('seeds batChargeState to Unknown for a battery that has not reported one yet (#3982)', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          // asleep at startup: a battery, but no charge state reported yet
+          powerSource: { batPercentRemaining: 180, batChargeLevel: 0 },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // The seed must reach the endpoint's registration-time state - the
+      // Rechargeable feature's conformance requires the attribute to exist
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.powerSource.batChargeState).toBe(0)
+      // 0 = PowerSource.BatChargeState.Unknown; the device's first real report
+      // replaces it through a normal state update instead of being rejected
+    })
+
+    it('keeps a plugin-reported batChargeState instead of overwriting it with the seed', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          powerSource: { batPercentRemaining: 180, batChargeLevel: 0, batChargeState: 1 },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.powerSource.batChargeState).toBe(1)
+    })
+
+    it('seeds batFunctionalWhileCharging, which Rechargeable also requires (#3982)', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          powerSource: { batPercentRemaining: 180, batChargeLevel: 0 },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      // matter.js defaults this to false, so registration would succeed without
+      // it - seeding it keeps the feature and both required attributes together
+      // rather than depending on that default
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.powerSource.batFunctionalWhileCharging).toBe(false)
+    })
+
+    it('keeps a plugin-reported batFunctionalWhileCharging', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          powerSource: { batPercentRemaining: 180, batFunctionalWhileCharging: true },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.options.powerSource.batFunctionalWhileCharging).toBe(true)
+    })
+
+    it('composes Battery from static battery facts alone, before any reading arrives (#3982)', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          // a sleeping device: the plugin knows the battery facts but has no
+          // level or percentage yet. Gating on the live values would compose no
+          // Battery feature, and the first real reading would then be rejected
+          // for the life of the process - #3982 one level up.
+          powerSource: { status: 0, order: 0, description: 'Battery', batReplaceability: 2, batPresent: true },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
+    })
+
+    it('leaves a power source with no battery attributes as a plain PowerSource', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        deviceType: { deviceType: 0x000A, name: 'DoorLock', with: vi.fn(() => ({ deviceType: 0x000A, with: vi.fn() })) } as any,
+        clusters: {
+          doorLock: { lockState: 1 },
+          // indistinguishable from a wired source - do not guess a battery
+          powerSource: { status: 0, order: 0, description: 'AC Power' },
+        },
+        handlers: { doorLock: { lockDoor: vi.fn(), unlockDoor: vi.fn() } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(PowerSourceServer.with).not.toHaveBeenCalled()
     })
   })
 
@@ -693,7 +809,7 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       // The plugin's battery PowerSource is composed...
-      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery')
+      expect(PowerSourceServer.with).toHaveBeenCalledWith('Battery', 'Rechargeable')
       // ...and our wired PowerSource must never overwrite it.
       expect(PowerSourceServer.with).not.toHaveBeenCalledWith('Wired')
       const internal = deps.accessories.get('test-uuid-001') as any

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -20,7 +20,17 @@ vi.mock('@matter/main', () => {
     id: string | undefined
     close = vi.fn()
     add = vi.fn()
-    act = vi.fn(async (fn: any) => fn({ get: vi.fn(() => ({ addDeviceTypes: vi.fn() })) }))
+    // Device types advertised through the descriptor, so tests can assert WHICH
+    // type was added rather than only how many times act() ran.
+    advertisedDeviceTypes: string[] = []
+    act = vi.fn(async (fn: any) => fn({
+      get: vi.fn(() => ({
+        addDeviceTypes: vi.fn((name: string) => {
+          this.advertisedDeviceTypes.push(name)
+        }),
+      })),
+    }))
+
     constructor(deviceType: any, options: any) {
       this.deviceType = deviceType
       this.options = options
@@ -499,6 +509,49 @@ describe('accessoryManager', () => {
       // after the endpoint joins the node.
       const internal = deps.accessories.get('test-uuid-001') as any
       expect(internal.endpoint.act).toHaveBeenCalledTimes(1)
+    })
+
+    /**
+     * ⚠️ A battery is invisible to a controller unless the endpoint advertises
+     * the PowerSource device type as well as carrying the cluster. Apple Home
+     * showed no battery at all while every attribute was present and correct
+     * (homebridge-sharkiq#88).
+     */
+    it('advertises the PowerSource device type for a declared battery', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        clusters: {
+          onOff: { onOff: false },
+          powerSource: { batPercentRemaining: 180, batChargeLevel: 0, batChargeState: 1 },
+        },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.advertisedDeviceTypes).toContain('PowerSource')
+    })
+
+    it('advertises PowerSource for a non-battery power source too', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        clusters: { onOff: { onOff: false }, powerSource: { status: 1, order: 0, description: 'AC Power' } },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.advertisedDeviceTypes).toContain('PowerSource')
+    })
+
+    it('does not advertise PowerSource when the accessory declares none', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory()
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      const internal = deps.accessories.get('test-uuid-001') as any
+      expect(internal.endpoint.advertisedDeviceTypes).not.toContain('PowerSource')
     })
 
     it('runs electrical detection for composed-device parts too', async () => {

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -18,6 +18,7 @@ import type {
   InternalMatterAccessoryPart,
   MatterAccessory,
   MatterAccessoryEventEmitter,
+  MatterAccessoryPart,
 } from '../types.js'
 
 import { EventEmitter } from 'node:events'
@@ -46,6 +47,7 @@ import {
   detectWindowCoveringFeatures,
   determineColorControlFeaturesFromHandlers,
   extractColorControlFeatures,
+  extractDeclaredFeatures,
   extractLevelControlFeatures,
   extractThermostatFeatures,
   validateAccessoryRequiredFields,
@@ -73,6 +75,8 @@ interface DetectedClusterFeatures {
   serviceAreaFeatures: string[] | null
   colorControlFeatures: string[] | null
   thermostatFeatures: string[] | null
+  closureControlFeatures: string[] | null
+  mediaPlaybackFeatures: string[] | null
   /**
    * LevelControl features to apply via `.with(...)`. `null` means the accessory
    * has no `levelControl` handler and we should leave the base class alone.
@@ -179,58 +183,9 @@ export class AccessoryManager {
     }
 
     try {
-      let deviceType = accessory.deviceType
-      const windowCoveringFeatures = detectWindowCoveringFeatures(accessory)
-      if (windowCoveringFeatures.length > 0) {
-        deviceType = applyWindowCoveringFeatures(deviceType, accessory, windowCoveringFeatures)
-      }
-
-      // SmokeCoAlarm is feature-gated in matter.js, so the base SmokeCoAlarmDevice
-      // carries no SmokeCoAlarm cluster. Add it with features detected from the
-      // accessory's declared attributes — unless the plugin already composed a
-      // device type that includes it.
-      const hasSmokeCoAlarm = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.smokeCoAlarm !== undefined
-      if (deviceType.deviceType === devices.SmokeCoAlarmDevice.deviceType && !hasSmokeCoAlarm) {
-        deviceType = applySmokeCoAlarmFeatures(deviceType, accessory, detectSmokeCoAlarmFeatures(accessory))
-      }
-
-      // Thermostat is feature-gated in the same way, so the base ThermostatDevice
-      // carries no thermostat cluster. Add it with features detected from the
-      // declared setpoints, so a heating-only thermostat is not forced to claim
-      // cooling - unless the plugin already composed the cluster itself.
-      const hasThermostat = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.thermostat !== undefined
-      if (deviceType.deviceType === devices.ThermostatDevice?.deviceType && !hasThermostat) {
-        deviceType = applyThermostatFeatures(deviceType, accessory, detectThermostatFeatures(accessory))
-      }
-
-      // Electrical measurement clusters (power/energy metering) are feature-gated
-      // in matter.js and not part of any base device type. Detect them from the
-      // accessory's declared cluster state so any device type - outlets included -
-      // can report power/energy (surfaced by e.g. the iOS 27+ Home app energy view).
-      const electricalDetection = detectElectricalMeasurementClusters(accessory)
-      const hasElectrical = electricalDetection.hasPowerMeasurement || electricalDetection.energyFeatures.length > 0
-      if (hasElectrical) {
-        applyElectricalMeasurementDefaults(accessory, electricalDetection)
-        deviceType = applyElectricalMeasurementClusters(deviceType, accessory, electricalDetection)
-      } else if (deviceType.deviceType === devices.ElectricalSensorEndpoint?.deviceType) {
-        log.warn(
-          `${accessory.displayName} uses the ElectricalSensor device type but declares no `
-          + 'electricalPowerMeasurement or electricalEnergyMeasurement cluster state - '
-          + 'the endpoint will expose no measurement clusters.',
-        )
-      }
-
-      const features = this.detectClusterFeatures(accessory, deviceType)
-
-      // Now that we know whether LevelControl keeps its Lighting feature, make
-      // sure the declared levels are legal for it.
-      applyLevelControlLightingFloor(accessory, features.levelControlFeatures)
-
-      const customBehaviors = await this.buildCustomBehaviors(accessory, deviceType, features)
-      if (customBehaviors.length > 0) {
-        deviceType = (deviceType as any).with(...customBehaviors)
-        log.info(`Applied ${customBehaviors.length} custom behavior(s) to device type`)
-      }
+      const prepared = await this.prepareDeviceType(accessory)
+      const { hasElectrical } = prepared
+      let { deviceType } = prepared
 
       if (!deps.config.externalAccessory) {
         // Skip if device type already includes BridgedDeviceBasicInformation
@@ -416,6 +371,103 @@ export class AccessoryManager {
   }
 
   /**
+   * Work out the endpoint's final device type: compose the feature-gated
+   * clusters it needs, fix up any state that would fail conformance, and
+   * attach the Homebridge behaviors that route commands to plugin handlers.
+   *
+   * ⚠️ Shared by the parent accessory AND by every part. Child endpoints used
+   * to run a cut-down version of this that only looked up behaviors by name,
+   * so a composed part quietly lost anything decided here — its battery was
+   * never composed, a thermostat part had no thermostat cluster at all
+   * (matter.js gates it behind features, so the base device type carries
+   * none), and a dimmable part declaring the once-documented `minLevel: 0`
+   * still failed to register. Anything added here must therefore stay free of
+   * parent-only assumptions; the caller handles what genuinely differs
+   * (bridged info, the composed-parent labels, the child tag list).
+   */
+  private async prepareDeviceType(
+    accessory: MatterAccessory,
+  ): Promise<{ deviceType: EndpointType, hasElectrical: boolean }> {
+    let deviceType = accessory.deviceType
+    const windowCoveringFeatures = detectWindowCoveringFeatures(accessory)
+    if (windowCoveringFeatures.length > 0) {
+      deviceType = applyWindowCoveringFeatures(deviceType, accessory, windowCoveringFeatures)
+    }
+
+    // SmokeCoAlarm is feature-gated in matter.js, so the base SmokeCoAlarmDevice
+    // carries no SmokeCoAlarm cluster. Add it with features detected from the
+    // accessory's declared attributes — unless the plugin already composed a
+    // device type that includes it.
+    const hasSmokeCoAlarm = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.smokeCoAlarm !== undefined
+    if (deviceType.deviceType === devices.SmokeCoAlarmDevice.deviceType && !hasSmokeCoAlarm) {
+      deviceType = applySmokeCoAlarmFeatures(deviceType, accessory, detectSmokeCoAlarmFeatures(accessory))
+    }
+
+    // Thermostat is feature-gated in the same way, so the base ThermostatDevice
+    // carries no thermostat cluster. Add it with features detected from the
+    // declared setpoints, so a heating-only thermostat is not forced to claim
+    // cooling - unless the plugin already composed the cluster itself.
+    const hasThermostat = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.thermostat !== undefined
+    if (deviceType.deviceType === devices.ThermostatDevice?.deviceType && !hasThermostat) {
+      deviceType = applyThermostatFeatures(deviceType, accessory, detectThermostatFeatures(accessory))
+    }
+
+    // Electrical measurement clusters (power/energy metering) are feature-gated
+    // in matter.js and not part of any base device type. Detect them from the
+    // accessory's declared cluster state so any device type - outlets included -
+    // can report power/energy (surfaced by e.g. the iOS 27+ Home app energy view).
+    const electricalDetection = detectElectricalMeasurementClusters(accessory)
+    const hasElectrical = electricalDetection.hasPowerMeasurement || electricalDetection.energyFeatures.length > 0
+    if (hasElectrical) {
+      applyElectricalMeasurementDefaults(accessory, electricalDetection)
+      deviceType = applyElectricalMeasurementClusters(deviceType, accessory, electricalDetection)
+    } else if (deviceType.deviceType === devices.ElectricalSensorEndpoint?.deviceType) {
+      log.warn(
+        `${accessory.displayName} uses the ElectricalSensor device type but declares no `
+        + 'electricalPowerMeasurement or electricalEnergyMeasurement cluster state - '
+        + 'the endpoint will expose no measurement clusters.',
+      )
+    }
+
+    const features = this.detectClusterFeatures(accessory, deviceType)
+
+    // Now that we know whether LevelControl keeps its Lighting feature, make
+    // sure the declared levels are legal for it.
+    applyLevelControlLightingFloor(accessory, features.levelControlFeatures)
+
+    const customBehaviors = await this.buildCustomBehaviors(accessory, deviceType, features)
+    if (customBehaviors.length > 0) {
+      deviceType = (deviceType as any).with(...customBehaviors)
+      log.info(`Applied ${customBehaviors.length} custom behavior(s) to device type`)
+    }
+
+    return { deviceType, hasElectrical }
+  }
+
+  /**
+   * Present a part as an accessory so it can go through {@link prepareDeviceType}.
+   *
+   * Parts carry the same `deviceType`/`clusters`/`handlers` shape as their
+   * parent, just without the bridge-level identity fields — which nothing in
+   * the preparation pipeline reads. `clusters` is passed by reference on
+   * purpose: the pipeline edits it (electrical defaults, the battery charge
+   * state seed, the LevelControl floor) and those edits have to land on the
+   * part object that is about to be registered.
+   */
+  private partAsAccessory(part: MatterAccessoryPart, partEndpointId: string): MatterAccessory {
+    return {
+      UUID: partEndpointId,
+      displayName: part.displayName || part.id,
+      deviceType: part.deviceType,
+      serialNumber: '',
+      manufacturer: '',
+      model: '',
+      clusters: part.clusters,
+      handlers: part.handlers,
+    } as MatterAccessory
+  }
+
+  /**
    * Detect cluster features for an accessory
    */
   private detectClusterFeatures(
@@ -460,6 +512,29 @@ export class AccessoryManager {
       )
     }
 
+    // ClosureControl and MediaPlayback are feature-gated too, and the device
+    // type is where the choice was made - Closure composes Positioning, and a
+    // plugin may have composed more. Read whatever is there so replacing the
+    // base behavior with the handler-calling one carries it across instead of
+    // resetting the cluster to its featureless form.
+    let closureControlFeatures: string[] | null = null
+    if (accessory.handlers?.closureControl) {
+      closureControlFeatures = detectBehaviorFeatures(
+        deviceType,
+        CLUSTER_IDS.CLOSURE_CONTROL,
+        extractDeclaredFeatures,
+      )
+    }
+
+    let mediaPlaybackFeatures: string[] | null = null
+    if (accessory.handlers?.mediaPlayback) {
+      mediaPlaybackFeatures = detectBehaviorFeatures(
+        deviceType,
+        CLUSTER_IDS.MEDIA_PLAYBACK,
+        extractDeclaredFeatures,
+      )
+    }
+
     // LevelControl: matter.js's public `LevelControlServer` inherits the
     // Lighting+OnOff feature set from its internal `LevelControlBase` (see
     // LevelControlServer.ts line ~20: `LevelControlBehavior.with(OnOff, Lighting)`).
@@ -499,6 +574,8 @@ export class AccessoryManager {
       serviceAreaFeatures,
       colorControlFeatures,
       thermostatFeatures,
+      closureControlFeatures,
+      mediaPlaybackFeatures,
       levelControlFeatures,
     }
   }
@@ -649,6 +726,16 @@ export class AccessoryManager {
         }
       }
 
+      if (clusterName === 'closureControl' && behaviorClass && features.closureControlFeatures && features.closureControlFeatures.length > 0) {
+        behaviorClass = (behaviorClass as any).with(...features.closureControlFeatures)
+        log.info(`ClosureControl custom behavior will preserve features: ${features.closureControlFeatures.join(', ')}`)
+      }
+
+      if (clusterName === 'mediaPlayback' && behaviorClass && features.mediaPlaybackFeatures && features.mediaPlaybackFeatures.length > 0) {
+        behaviorClass = (behaviorClass as any).with(...features.mediaPlaybackFeatures)
+        log.info(`MediaPlayback custom behavior will preserve features: ${features.mediaPlaybackFeatures.join(', ')}`)
+      }
+
       if (clusterName === 'serviceArea' && behaviorClass && features.serviceAreaFeatures && features.serviceAreaFeatures.length > 0) {
         behaviorClass = (behaviorClass as any).with(...features.serviceAreaFeatures)
         log.info(`ServiceArea custom behavior will preserve features: ${features.serviceAreaFeatures.join(', ')}`)
@@ -767,35 +854,12 @@ export class AccessoryManager {
 
       deps.behaviorRegistry.registerPartEndpoint(partEndpointId, accessory.UUID, part.id)
 
-      let partDeviceType: EndpointType = part.deviceType
-      const partCustomBehaviors: BehaviorType[] = []
-
-      if (part.handlers) {
-        for (const clusterName of Object.keys(part.handlers)) {
-          const behaviorClass = CORE_CLUSTER_BEHAVIOR_MAP[clusterName]
-          if (behaviorClass) {
-            partCustomBehaviors.push(behaviorClass)
-            log.info(`  Will use ${behaviorClass.name} for part ${part.id}`)
-          } else {
-            log.warn(`No custom behavior class available for cluster '${clusterName}' on part ${part.id}`)
-          }
-        }
-
-        if (partCustomBehaviors.length > 0) {
-          partDeviceType = (partDeviceType as any).with(...partCustomBehaviors)
-          log.info(`  Applied ${partCustomBehaviors.length} custom behavior(s) to part ${part.id}`)
-        }
-      }
-
-      // Electrical measurement detection runs for parts too, so composed
-      // devices (e.g. a power strip with metered outlets, or a solar setup
-      // exposing separate meters) can report power/energy per part.
-      const partElectrical = detectElectricalMeasurementClusters(part)
-      const partHasElectrical = partElectrical.hasPowerMeasurement || partElectrical.energyFeatures.length > 0
-      if (partHasElectrical) {
-        applyElectricalMeasurementDefaults(part, partElectrical)
-        partDeviceType = applyElectricalMeasurementClusters(partDeviceType, part, partElectrical)
-      }
+      // Parts go through the same preparation as their parent — feature-gated
+      // clusters, the battery PowerSource, conformance fix-ups and the
+      // behaviors that route commands to handlers. See prepareDeviceType().
+      const partPrepared = await this.prepareDeviceType(this.partAsAccessory(part, partEndpointId))
+      const partHasElectrical = partPrepared.hasElectrical
+      let partDeviceType: EndpointType = partPrepared.deviceType
 
       // Tag each child with a semantic Number tag so controllers can stably
       // re-map otherwise-identical children of a composed device; without it
@@ -823,6 +887,13 @@ export class AccessoryManager {
 
       if (partHasElectrical) {
         await this.advertiseUtilityDeviceType(partEndpoint, 'ElectricalSensor', part.displayName || part.id)
+      }
+
+      // Same rule as the parent: composing the battery cluster is not enough,
+      // the endpoint has to advertise the PowerSource device type or no
+      // controller has a reason to read it.
+      if (part.clusters?.powerSource) {
+        await this.advertiseUtilityDeviceType(partEndpoint, 'PowerSource', part.displayName || part.id)
       }
 
       log.info(`  Created part endpoint: ${part.displayName || part.id} (${partEndpointId}) as child of ${accessory.displayName}`)

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -646,6 +646,25 @@ export class AccessoryManager {
         serialNumber: accessory.serialNumber,
         reachable: true,
       }
+      // Surface the device's firmware version to controllers (shown in the
+      // accessory details of e.g. Apple Home). The numeric companion is
+      // derived from a leading semver triplet when the string has one and
+      // the parts fit the 16/8/8-bit encoding - otherwise only the string
+      // is set (both attributes are independently optional per spec, and a
+      // failed uint32 validation would block the accessory registering).
+      // The spec caps SoftwareVersionString at 64 characters.
+      if (typeof accessory.firmwareRevision === 'string' && accessory.firmwareRevision.length > 0) {
+        endpointOptions.bridgedDeviceBasicInformation.softwareVersionString = accessory.firmwareRevision.slice(0, 64)
+        const semver = accessory.firmwareRevision.match(/^(\d+)\.(\d+)\.(\d+)/)
+        if (semver) {
+          const [major, minor, patch] = [Number(semver[1]), Number(semver[2]), Number(semver[3])]
+          if (major <= 0xFFFF && minor <= 0xFF && patch <= 0xFF) {
+            // >>> 0 keeps the value unsigned - a signed << would go negative
+            // for majors >= 0x8000 and fail matter.js's uint32 validation.
+            endpointOptions.bridgedDeviceBasicInformation.softwareVersion = ((major << 16) | (minor << 8) | patch) >>> 0
+          }
+        }
+      }
     }
 
     return endpointOptions

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -292,7 +292,22 @@ export class AccessoryManager {
       }
 
       if (hasElectrical) {
-        await this.advertiseElectricalSensorDeviceType(endpoint, accessory.displayName)
+        await this.advertiseUtilityDeviceType(endpoint, 'ElectricalSensor', accessory.displayName)
+      }
+
+      // ⚠️ A battery is only visible to a controller once the endpoint also
+      // advertises the PowerSource device type. Composing the cluster is not
+      // enough - exactly as with ElectricalSensor above - because a controller
+      // that cannot see the type in the DeviceTypeList has no reason to read
+      // the cluster. Without this, Apple Home showed no battery anywhere while
+      // every attribute was present and correct (homebridge-sharkiq#88).
+      //
+      // Deliberately only for a power source the plugin declared. The wired one
+      // synthesized for composed parents above is left alone: it exists to
+      // satisfy Apple's controller in a case that already works, and this area
+      // fails silently and badly when disturbed.
+      if (accessory.clusters?.powerSource) {
+        await this.advertiseUtilityDeviceType(endpoint, 'PowerSource', accessory.displayName)
       }
 
       this.registerAccessoryHandlers(accessory, deps)
@@ -772,7 +787,7 @@ export class AccessoryManager {
       await parentEndpoint.add(partEndpoint)
 
       if (partHasElectrical) {
-        await this.advertiseElectricalSensorDeviceType(partEndpoint, part.displayName || part.id)
+        await this.advertiseUtilityDeviceType(partEndpoint, 'ElectricalSensor', part.displayName || part.id)
       }
 
       log.info(`  Created part endpoint: ${part.displayName || part.id} (${partEndpointId}) as child of ${accessory.displayName}`)
@@ -805,12 +820,12 @@ export class AccessoryManager {
    * dedupes the entry, so this is safe when the base device type already is
    * an ElectricalSensor.
    */
-  private async advertiseElectricalSensorDeviceType(endpoint: Endpoint, displayName: string): Promise<void> {
+  private async advertiseUtilityDeviceType(endpoint: Endpoint, deviceTypeName: string, displayName: string): Promise<void> {
     try {
-      await endpoint.act(agent => agent.get(DescriptorServer).addDeviceTypes('ElectricalSensor'))
-      log.debug(`Advertised ElectricalSensor device type for ${displayName}`)
+      await endpoint.act(agent => agent.get(DescriptorServer).addDeviceTypes(deviceTypeName as never))
+      log.debug(`Advertised ${deviceTypeName} device type for ${displayName}`)
     } catch (error) {
-      log.warn(`Could not advertise ElectricalSensor device type for ${displayName}:`, error)
+      log.warn(`Could not advertise ${deviceTypeName} device type for ${displayName}:`, error)
     }
   }
 

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -520,16 +520,51 @@ export class AccessoryManager {
     // (contact/leak/occupancy, etc.) are read-only and declare no handlers at
     // all, so gating this on handlers would silently drop their battery.
     if (accessory.clusters?.powerSource) {
-      const hasBattery = accessory.clusters.powerSource.batPercentRemaining !== undefined
-        || accessory.clusters.powerSource.batChargeLevel !== undefined
-      const hasRechargeable = accessory.clusters.powerSource.batChargeState !== undefined
+      // Any battery attribute at all marks this as a battery source. Reading
+      // only the live values (batPercentRemaining/batChargeLevel) reintroduced
+      // #3982 one level up: a plugin that declares the static battery facts it
+      // knows at startup - batReplaceability, batPresent, batQuantity - but has
+      // no reading yet from a sleeping device would compose a PowerSource with
+      // no Battery feature at all, and then its first real reading would be
+      // rejected for the life of the process. Static facts are the declaration
+      // of intent, so they count. Nothing here invents a reading: a source that
+      // declares no battery attribute whatsoever is indistinguishable from a
+      // wired one and is left alone.
+      const powerSource = accessory.clusters.powerSource as Record<string, unknown>
+      const hasBattery = Object.keys(powerSource).some(
+        key => /^(?:bat|activeBat)/.test(key) && powerSource[key] !== undefined,
+      )
       let powerSourceBehavior: BehaviorType = PowerSourceServer
-      if (hasBattery && hasRechargeable) {
+      if (hasBattery) {
+        // The feature set is decided once, here, but a device can start
+        // reporting batChargeState later (e.g. a vacuum asleep on its dock at
+        // startup). If the feature were gated on the attribute being present
+        // now, that first report would be rejected by conformance, and the
+        // rollback discards every attribute in the same update - the battery
+        // freezes at its startup value until a restart happens to catch the
+        // device awake (#3982). So every battery carries Rechargeable, seeded
+        // with Unknown: the endpoint options spread this same object, so the
+        // seed is also the registration-time value the feature's conformance
+        // requires.
+        //
+        // The trade is deliberate: a non-rechargeable battery ends up
+        // advertising Rechargeable with a charge state of Unknown, which is not
+        // strictly true. Determinism is worth more here than that precision -
+        // the alternative decides a device's feature set on whether it happened
+        // to be awake when homebridge last restarted, and fails invisibly.
+        if (accessory.clusters.powerSource.batChargeState === undefined) {
+          accessory.clusters.powerSource.batChargeState = 0 // PowerSource.BatChargeState.Unknown
+        }
+        // Rechargeable also makes batFunctionalWhileCharging mandatory. matter.js
+        // happens to default it to false, so registration succeeds without it -
+        // but seeding it here means the feature and BOTH of its required
+        // attributes are introduced together, rather than resting on a default
+        // in someone else's package that could change.
+        if (accessory.clusters.powerSource.batFunctionalWhileCharging === undefined) {
+          accessory.clusters.powerSource.batFunctionalWhileCharging = false
+        }
         powerSourceBehavior = (PowerSourceServer as any).with('Battery', 'Rechargeable')
         log.debug('Adding PowerSource server with battery and rechargeable features')
-      } else if (hasBattery) {
-        powerSourceBehavior = (PowerSourceServer as any).with('Battery')
-        log.debug('Adding PowerSource server with battery feature')
       } else {
         log.debug('Adding base PowerSource server')
       }

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -35,11 +35,13 @@ import {
   applyElectricalMeasurementClusters,
   applyElectricalMeasurementDefaults,
   applySmokeCoAlarmFeatures,
+  applyThermostatFeatures,
   applyWindowCoveringFeatures,
   CLUSTER_IDS,
   detectBehaviorFeatures,
   detectElectricalMeasurementClusters,
   detectSmokeCoAlarmFeatures,
+  detectThermostatFeatures,
   detectWindowCoveringFeatures,
   determineColorControlFeaturesFromHandlers,
   extractColorControlFeatures,
@@ -180,6 +182,15 @@ export class AccessoryManager {
       const hasSmokeCoAlarm = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.smokeCoAlarm !== undefined
       if (deviceType.deviceType === devices.SmokeCoAlarmDevice.deviceType && !hasSmokeCoAlarm) {
         deviceType = applySmokeCoAlarmFeatures(deviceType, accessory, detectSmokeCoAlarmFeatures(accessory))
+      }
+
+      // Thermostat is feature-gated in the same way, so the base ThermostatDevice
+      // carries no thermostat cluster. Add it with features detected from the
+      // declared setpoints, so a heating-only thermostat is not forced to claim
+      // cooling - unless the plugin already composed the cluster itself.
+      const hasThermostat = (deviceType as { behaviors?: Record<string, unknown> }).behaviors?.thermostat !== undefined
+      if (deviceType.deviceType === devices.ThermostatDevice?.deviceType && !hasThermostat) {
+        deviceType = applyThermostatFeatures(deviceType, accessory, detectThermostatFeatures(accessory))
       }
 
       // Electrical measurement clusters (power/energy metering) are feature-gated

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -34,6 +34,7 @@ import { HomebridgeRvcCleanModeServer, HomebridgeServiceAreaServer } from '../be
 import {
   applyElectricalMeasurementClusters,
   applyElectricalMeasurementDefaults,
+  applyLevelControlLightingFloor,
   applySmokeCoAlarmFeatures,
   applyThermostatFeatures,
   applyWindowCoveringFeatures,
@@ -211,6 +212,11 @@ export class AccessoryManager {
       }
 
       const features = this.detectClusterFeatures(accessory, deviceType)
+
+      // Now that we know whether LevelControl keeps its Lighting feature, make
+      // sure the declared levels are legal for it.
+      applyLevelControlLightingFloor(accessory, features.levelControlFeatures)
+
       const customBehaviors = await this.buildCustomBehaviors(accessory, deviceType, features)
       if (customBehaviors.length > 0) {
         deviceType = (deviceType as any).with(...customBehaviors)

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -57,6 +57,15 @@ import {
 import { stripVendorFromLabel } from '../utils.js'
 import { CORE_CLUSTER_BEHAVIOR_MAP } from './BehaviorMap.js'
 
+// The parts-list update and ConfigurationVersion bump run inside matter.js
+// transactions that acquire their resource lock synchronously. A controller
+// re-establishing its subscription (matter.js-internal "offline" transactions)
+// can briefly hold that lock, making the synchronous acquisition throw. Those
+// transactions release almost immediately, so retry with a short yield rather
+// than dropping the structure-change notification (#3970).
+const PARTS_LIST_NOTIFY_ATTEMPTS = 5
+const PARTS_LIST_NOTIFY_RETRY_DELAY_MS = 50
+
 type BehaviorType = Behavior.Type
 
 interface DetectedClusterFeatures {
@@ -793,37 +802,66 @@ export class AccessoryManager {
       return
     }
 
-    try {
-      const aggregatorState = aggregator as any
+    for (let attempt = 1; attempt <= PARTS_LIST_NOTIFY_ATTEMPTS; attempt++) {
+      try {
+        await this.applyPartsListNotification(aggregator, deps)
+        return
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
 
-      if (aggregatorState.state?.descriptor) {
-        const partsList = aggregatorState.state.descriptor.partsList || []
-
-        if (deps.config.debugModeEnabled) {
-          log.debug(`Parts list changed: ${partsList.length} devices (endpoints: ${partsList.join(', ')})`)
+        // matter.js reports synchronous lock contention with "Cannot lock ...
+        // synchronously" / "acquire locks asynchronously". The blocking
+        // transaction releases almost immediately, so yield and retry rather
+        // than dropping the notification.
+        const isLockContention = errorMessage.includes('Cannot lock') || errorMessage.includes('acquire locks')
+        if (isLockContention && attempt < PARTS_LIST_NOTIFY_ATTEMPTS) {
+          await new Promise(resolve => setTimeout(resolve, PARTS_LIST_NOTIFY_RETRY_DELAY_MS))
+          continue
         }
 
-        await aggregator.set({
-          descriptor: {
-            partsList,
-          },
-        } as any)
-
-        log.info(`Notified controllers of parts list change (${deps.accessories.size} devices)`)
+        log.warn(`Failed to notify controllers of parts list change: ${errorMessage}`)
+        return
       }
-
-      // Matter 1.6 signals bridge structure changes to controllers via
-      // BasicInformation's ConfigurationVersion. matter.js seeds the attribute
-      // but does not bump it when endpoints are added or removed — that is the
-      // bridge's job.
-      const serverNode = deps.getServerNode()
-      if (serverNode) {
-        await serverNode.act(agent => agent.get(BasicInformationServer).increaseConfigurationVersion())
-        log.debug('Increased bridge configuration version')
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      log.warn(`Failed to notify controllers of parts list change: ${errorMessage}`)
     }
+  }
+
+  /**
+   * A single attempt at pushing the parts-list change to controllers: update the
+   * aggregator's parts list and bump the bridge ConfigurationVersion. Both bump
+   * once per successful call, so retrying the whole thing after a mid-way lock
+   * failure does not double-count (the parts-list set is idempotent and only a
+   * successful `increaseConfigurationVersion()` mutates the version).
+   */
+  private async applyPartsListNotification(
+    aggregator: NonNullable<ReturnType<AccessoryManagerDeps['getAggregator']>>,
+    deps: AccessoryManagerDeps,
+  ): Promise<void> {
+    const aggregatorState = aggregator as any
+
+    if (aggregatorState.state?.descriptor) {
+      const partsList = aggregatorState.state.descriptor.partsList || []
+
+      if (deps.config.debugModeEnabled) {
+        log.debug(`Parts list changed: ${partsList.length} devices (endpoints: ${partsList.join(', ')})`)
+      }
+
+      await aggregator.set({
+        descriptor: {
+          partsList,
+        },
+      } as any)
+    }
+
+    // Matter 1.6 signals bridge structure changes to controllers via
+    // BasicInformation's ConfigurationVersion. matter.js seeds the attribute
+    // but does not bump it when endpoints are added or removed — that is the
+    // bridge's job.
+    const serverNode = deps.getServerNode()
+    if (serverNode) {
+      await serverNode.act(agent => agent.get(BasicInformationServer).increaseConfigurationVersion())
+      log.debug('Increased bridge configuration version')
+    }
+
+    log.info(`Notified controllers of parts list change (${deps.accessories.size} devices)`)
   }
 }

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -24,7 +24,7 @@ import { EventEmitter } from 'node:events'
 import process from 'node:process'
 
 import { Endpoint } from '@matter/main'
-import { BasicInformationServer, BridgedDeviceBasicInformationServer, DescriptorServer } from '@matter/main/behaviors'
+import { BasicInformationServer, BridgedDeviceBasicInformationServer, DescriptorServer, FixedLabelServer } from '@matter/main/behaviors'
 import { PowerSourceServer } from '@matter/node/behaviors'
 
 import { IpcOutgoingEvent } from '../../ipcService.js'
@@ -243,6 +243,36 @@ export class AccessoryManager {
       }
 
       const endpointOptions = this.createEndpointOptions(accessory, deps.config)
+
+      // Composed parents carry a FixedLabel marking the composition, matching
+      // known-good bridges - Apple's controller needs it to bind child endpoints
+      // to the composed accessory. Without it (plus the PowerSource below),
+      // homed never finishes its per-accessory session setup: commands fail
+      // silently ("No Response") from ~30s after pairing while reads keep working.
+      if (accessory.parts && accessory.parts.length > 0) {
+        if ((deviceType as { behaviors?: Record<string, unknown> }).behaviors?.fixedLabel === undefined) {
+          deviceType = (deviceType as any).with(FixedLabelServer)
+          endpointOptions.fixedLabel = {
+            labelList: [{ label: 'composed', value: 'true' }],
+          }
+        }
+
+        // Known-good bridges also expose a wired PowerSource on composed
+        // parents; Apple's controller appears to expect it. Only synthesize it
+        // when the accessory has not declared its own PowerSource — otherwise a
+        // plugin-provided battery PowerSource (added below) would be overwritten.
+        if (!accessory.clusters?.powerSource) {
+          deviceType = (deviceType as any).with((PowerSourceServer as any).with('Wired'))
+          endpointOptions.powerSource = {
+            status: 1, // Active
+            order: 0,
+            description: 'AC Power',
+            endpointList: [],
+            wiredCurrentType: 0, // AC (PowerSource.WiredCurrentType.Ac)
+          }
+        }
+      }
+
       const endpoint = new Endpoint(deviceType, endpointOptions)
 
       setRegistryManager(endpoint, deps.registryManager)
@@ -663,7 +693,7 @@ export class AccessoryManager {
 
     log.info(`Creating ${accessory.parts.length} child endpoint(s) for ${accessory.displayName}`)
 
-    for (const part of accessory.parts) {
+    for (const [partIndex, part] of accessory.parts.entries()) {
       const partEndpointId = `${accessory.UUID}-part-${part.id}`
 
       deps.behaviorRegistry.registerPartEndpoint(partEndpointId, accessory.UUID, part.id)
@@ -698,8 +728,22 @@ export class AccessoryManager {
         partDeviceType = applyElectricalMeasurementClusters(partDeviceType, part, partElectrical)
       }
 
+      // Tag each child with a semantic Number tag so controllers can stably
+      // re-map otherwise-identical children of a composed device; without it
+      // they are distinguishable only by transient endpoint number, which
+      // Apple Home mishandles across hub changes.
+      partDeviceType = (partDeviceType as any).with(DescriptorServer.with('TagList'))
+
       const partEndpointOptions: any = {
         id: partEndpointId,
+        descriptor: {
+          tagList: [{
+            mfgCode: null,
+            namespaceId: 7, // Number namespace
+            tag: partIndex,
+            label: (part.displayName || part.id).slice(0, 64),
+          }],
+        },
         ...part.clusters,
       }
 

--- a/src/matter/server/BehaviorMap.ts
+++ b/src/matter/server/BehaviorMap.ts
@@ -10,11 +10,14 @@ import type { Behavior } from '@matter/node'
 import {
   HomebridgeAirQualityServer,
   HomebridgeCarbonMonoxideConcentrationMeasurementServer,
+  HomebridgeClosureControlServer,
   HomebridgeColorControlServer,
   HomebridgeDoorLockServer,
   HomebridgeFanControlServer,
   HomebridgeIdentifyServer,
+  HomebridgeKeypadInputServer,
   HomebridgeLevelControlServer,
+  HomebridgeMediaPlaybackServer,
   HomebridgeNitrogenDioxideConcentrationMeasurementServer,
   HomebridgeOnOffServer,
   HomebridgeOzoneConcentrationMeasurementServer,
@@ -46,9 +49,14 @@ export const CORE_CLUSTER_BEHAVIOR_MAP: Record<string, BehaviorType> = {
   levelControl: HomebridgeLevelControlServer,
   colorControl: HomebridgeColorControlServer,
 
-  // Coverings & locks
+  // Coverings, closures & locks
   windowCovering: HomebridgeWindowCoveringServer,
+  closureControl: HomebridgeClosureControlServer,
   doorLock: HomebridgeDoorLockServer,
+
+  // Media players & speakers
+  mediaPlayback: HomebridgeMediaPlaybackServer,
+  keypadInput: HomebridgeKeypadInputServer,
 
   // Climate control
   fanControl: HomebridgeFanControlServer,

--- a/src/matter/server/CommissioningManager.spec.ts
+++ b/src/matter/server/CommissioningManager.spec.ts
@@ -266,4 +266,34 @@ describe('commissioningManager', () => {
       await expect(manager.updateCommissioningFile(deps)).resolves.not.toThrow()
     })
   })
+
+  describe('purgeSubscriptionsForFabric', () => {
+    function serverNodeWith(subs: any[]) {
+      const subscriptions = { state: { subscriptions: subs } }
+      return {
+        node: { act: async (cb: any) => cb({ get: () => subscriptions }) },
+        subscriptions,
+      }
+    }
+
+    it('removes only the persisted subscriptions of the deleted fabric', async () => {
+      const { node, subscriptions } = serverNodeWith([
+        { peerAddress: { fabricIndex: 1 } },
+        { peerAddress: { fabricIndex: 2 } },
+        { peerAddress: { fabricIndex: 1 } },
+      ])
+      await (manager as any).purgeSubscriptionsForFabric(node, 1)
+      expect(subscriptions.state.subscriptions).toEqual([{ peerAddress: { fabricIndex: 2 } }])
+    })
+
+    it('leaves subscriptions untouched when none belong to the fabric', async () => {
+      const { node, subscriptions } = serverNodeWith([{ peerAddress: { fabricIndex: 2 } }])
+      await (manager as any).purgeSubscriptionsForFabric(node, 1)
+      expect(subscriptions.state.subscriptions).toEqual([{ peerAddress: { fabricIndex: 2 } }])
+    })
+
+    it('is a no-op when there is no server node', async () => {
+      await expect((manager as any).purgeSubscriptionsForFabric(null, 1)).resolves.toBeUndefined()
+    })
+  })
 })

--- a/src/matter/server/CommissioningManager.ts
+++ b/src/matter/server/CommissioningManager.ts
@@ -15,6 +15,7 @@ import { randomBytes } from 'node:crypto'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { SubscriptionsServer } from '@matter/node'
 import { ManualPairingCodeCodec, QrCode, QrPairingCodeCodec } from '@matter/types/schema'
 
 import { Logger } from '../../logger.js'
@@ -308,6 +309,12 @@ export class CommissioningManager {
       this.onFabricsChanged = (fabricIndex, action) => {
         log.info(`Fabric ${action}: index ${fabricIndex}`)
 
+        if (action === 'deleted') {
+          this.purgeSubscriptionsForFabric(deps.serverNode, fabricIndex).catch((error) => {
+            log.debug(`Failed to purge persisted subscriptions for removed fabric ${fabricIndex}:`, error)
+          })
+        }
+
         // Compute commissioning state once and reuse for both the file update
         // and the IPC emit, then push the snapshot into updateCommissioningFile
         // so it doesn't redo the same fabric reads.
@@ -348,6 +355,34 @@ export class CommissioningManager {
       // Roll back any partial registration so a retry can succeed
       this.teardownCommissioningEventListeners(deps.serverNode)
     }
+  }
+
+  /**
+   * Delete persisted subscriptions belonging to a removed fabric.
+   *
+   * matter.js persists controller subscriptions so it can proactively
+   * re-establish them when the node next comes online (a single pass with a
+   * short, no-retry connection timeout per peer). It removes the fabric's
+   * sessions on removal but leaves the persisted subscription entries behind,
+   * so re-establishment wastes its window on peers that can never answer
+   * ("Failed to connect to ... Fabric index #N does not exist").
+   */
+  private async purgeSubscriptionsForFabric(serverNode: ServerNode | null, fabricIndex: number): Promise<void> {
+    if (!serverNode) {
+      return
+    }
+
+    await serverNode.act((agent) => {
+      const subscriptions = agent.get(SubscriptionsServer)
+      const remaining = subscriptions.state.subscriptions.filter(
+        subscription => subscription.peerAddress.fabricIndex !== fabricIndex,
+      )
+      const purged = subscriptions.state.subscriptions.length - remaining.length
+      if (purged > 0) {
+        subscriptions.state.subscriptions = remaining
+        log.debug(`Purged ${purged} persisted subscription(s) for removed fabric ${fabricIndex}`)
+      }
+    })
   }
 
   /**

--- a/src/matter/server/FabricManager.spec.ts
+++ b/src/matter/server/FabricManager.spec.ts
@@ -1,0 +1,102 @@
+import type { ServerNode } from '@matter/main'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { FabricManager } from './FabricManager.js'
+
+vi.mock('../../logger.js', () => {
+  const mockLogger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    log: vi.fn(),
+  }
+  return { Logger: { withPrefix: vi.fn(() => mockLogger) } }
+})
+
+function makeFabricManager(serverNode: unknown, storagePath?: string): FabricManager {
+  return new FabricManager(
+    () => serverNode as ServerNode | null,
+    () => storagePath,
+  )
+}
+
+function makeServerNode(fabrics: unknown[]): unknown {
+  return {
+    env: {},
+    state: {
+      operationalCredentials: { fabrics },
+      commissioning: { commissioned: true },
+    },
+  }
+}
+
+describe('fabricManager', () => {
+  describe('getFabricInfo', () => {
+    it('maps vendorId from cluster-shaped FabricDescriptorStruct entries (#3974)', () => {
+      // The operational credentials cluster names the vendor field `vendorId`
+      // (per the Matter spec) - there is no `rootVendorId` on this shape
+      const manager = makeFabricManager(makeServerNode([
+        { fabricIndex: 1, fabricId: 100n, nodeId: 200n, vendorId: 0x1349, label: 'AppleHome' },
+        { fabricIndex: 2, fabricId: 101n, nodeId: 201n, vendorId: 0x1384, label: '' },
+      ]))
+
+      const fabrics = manager.getFabricInfo()
+      expect(fabrics).toEqual([
+        { fabricIndex: 1, fabricId: '100', nodeId: '200', rootVendorId: 0x1349, label: 'AppleHome' },
+        { fabricIndex: 2, fabricId: '101', nodeId: '201', rootVendorId: 0x1384, label: '' },
+      ])
+    })
+
+    it('maps rootVendorId from internal matter.js Fabric-shaped entries', () => {
+      const manager = makeFabricManager(makeServerNode([
+        { fabricIndex: 1, fabricId: 100n, nodeId: 200n, rootVendorId: 0x6006, label: 'Google' },
+      ]))
+
+      const fabrics = manager.getFabricInfo()
+      expect(fabrics).toEqual([
+        { fabricIndex: 1, fabricId: '100', nodeId: '200', rootVendorId: 0x6006, label: 'Google' },
+      ])
+    })
+
+    it('prefers rootVendorId when both vendor fields are present', () => {
+      const manager = makeFabricManager(makeServerNode([
+        { fabricIndex: 1, fabricId: 100n, nodeId: 200n, rootVendorId: 0x1217, vendorId: 0x1049, label: '' },
+      ]))
+
+      expect(manager.getFabricInfo()[0].rootVendorId).toBe(0x1217)
+    })
+
+    it('defaults the vendor to 0 when neither field is present', () => {
+      const manager = makeFabricManager(makeServerNode([
+        { fabricIndex: 1, fabricId: 100n, nodeId: 200n, label: '' },
+      ]))
+
+      expect(manager.getFabricInfo()[0].rootVendorId).toBe(0)
+    })
+
+    it('returns an empty list when there is no server node and no storage path', () => {
+      const manager = makeFabricManager(null)
+      expect(manager.getFabricInfo()).toEqual([])
+    })
+  })
+
+  describe('getCommissioningSnapshot', () => {
+    it('reports commissioned with the mapped fabrics from cluster-shaped entries', () => {
+      const manager = makeFabricManager(makeServerNode([
+        { fabricIndex: 1, fabricId: 100n, nodeId: 200n, vendorId: 0x1349, label: 'AppleHome' },
+      ]))
+
+      const snapshot = manager.getCommissioningSnapshot()
+      expect(snapshot.commissioned).toBe(true)
+      expect(snapshot.fabricCount).toBe(1)
+      expect(snapshot.fabrics[0].rootVendorId).toBe(0x1349)
+    })
+
+    it('reports not commissioned when there are no fabrics and no commissioning flag', () => {
+      const manager = makeFabricManager({ env: {}, state: {} })
+      expect(manager.getCommissioningSnapshot()).toEqual({ commissioned: false, fabricCount: 0, fabrics: [] })
+    })
+  })
+})

--- a/src/matter/server/FabricManager.spec.ts
+++ b/src/matter/server/FabricManager.spec.ts
@@ -98,5 +98,23 @@ describe('fabricManager', () => {
       const manager = makeFabricManager({ env: {}, state: {} })
       expect(manager.getCommissioningSnapshot()).toEqual({ commissioned: false, fabricCount: 0, fabrics: [] })
     })
+
+    it('reports not commissioned for an empty fabric list even while the flag still says otherwise (#3974)', () => {
+      // The controller-side removal of the last fabric leaves
+      // state.commissioning.commissioned true until the next restart. Trusting
+      // it here is what showed the bridge as paired with nothing attached -
+      // and hid the QR code the owner needed to pair again.
+      const manager = makeFabricManager(makeServerNode([]))
+
+      expect(manager.getCommissioningSnapshot()).toEqual({ commissioned: false, fabricCount: 0, fabrics: [] })
+    })
+
+    it('still trusts the commissioning flag when the fabric list cannot be read at all', () => {
+      // No operationalCredentials means we do not know, rather than know there
+      // is nothing - so the flag stays the tie-breaker for that one case.
+      const manager = makeFabricManager({ env: {}, state: { commissioning: { commissioned: true } } })
+
+      expect(manager.getCommissioningSnapshot()).toEqual({ commissioned: true, fabricCount: 0, fabrics: [] })
+    })
   })
 })

--- a/src/matter/server/FabricManager.ts
+++ b/src/matter/server/FabricManager.ts
@@ -80,6 +80,23 @@ export class FabricManager {
   }
 
   /**
+   * Whether the running server node is actually reporting its fabric list.
+   *
+   * `getFabricInfo()` returns `[]` both for "no controller is paired" and for
+   * "the list could not be read", and the two need different answers. When the
+   * operational credentials cluster hands back an array — even an empty one —
+   * that array is the truth.
+   */
+  private hasLiveFabricList(): boolean {
+    try {
+      const serverNode = this.getServerNode() as any
+      return Array.isArray(serverNode?.state?.operationalCredentials?.fabrics)
+    } catch {
+      return false
+    }
+  }
+
+  /**
    * Read fabric information from storage files
    */
   private readFabricsFromStorage(): FabricInfo[] {
@@ -169,8 +186,19 @@ export class FabricManager {
       return { commissioned: true, fabricCount, fabrics }
     }
 
-    // Fabric list is empty — fall back to the serverNode commissioning flag in
-    // case the state is reachable but fabric enumeration didn't return rows.
+    // The fabric list is empty. ⚠️ The serverNode commissioning flag is NOT a
+    // tie-breaker here. It lags behind a controller-side fabric removal, so
+    // consulting it would report "commissioned" with nothing paired right up
+    // until the next restart — the #3974 symptom this snapshot exists to fix,
+    // and the state that hides the QR code the owner needs to re-pair.
+    //
+    // So only fall back to the flag when the live list could not be read at
+    // all, which is the one case where an empty list means "don't know" rather
+    // than "nothing is paired".
+    if (this.hasLiveFabricList()) {
+      return { commissioned: false, fabricCount, fabrics }
+    }
+
     let commissioned = false
     try {
       const serverNode = this.getServerNode()

--- a/src/matter/server/FabricManager.ts
+++ b/src/matter/server/FabricManager.ts
@@ -60,7 +60,10 @@ export class FabricManager {
             fabricIndex: fabric.fabricIndex || 0,
             fabricId: fabric.fabricId?.toString() || '',
             nodeId: fabric.nodeId?.toString() || '',
-            rootVendorId: fabric.rootVendorId || 0,
+            // The operational credentials cluster's FabricDescriptorStruct names
+            // the vendor field `vendorId` (per the Matter spec); matter.js's
+            // internal Fabric object and persisted storage use `rootVendorId`
+            rootVendorId: fabric.rootVendorId ?? fabric.vendorId ?? 0,
             label: fabric.label || '',
           }))
         }
@@ -101,7 +104,7 @@ export class FabricManager {
               fabricIndex: fabric.fabricIndex || 0,
               fabricId: fabric.fabricId?.value?.toString() || fabric.fabricId?.toString() || '',
               nodeId: fabric.nodeId?.value?.toString() || fabric.nodeId?.toString() || '',
-              rootVendorId: fabric.rootVendorId || 0,
+              rootVendorId: fabric.rootVendorId ?? fabric.vendorId ?? 0,
               label: fabric.label || '',
             }))
           }

--- a/src/matter/server/ServerConfig.ts
+++ b/src/matter/server/ServerConfig.ts
@@ -20,6 +20,14 @@ export const SERVER_READY_POLL_INTERVAL_MS = 100
 export const SERVER_INIT_DELAY_MS = 200
 export const MAX_PASSCODE_ATTEMPTS = 100
 
+// A quick restart can race the previous process's release of the Matter
+// storage directory lock. matter.js reclaims *stale* locks itself (crashed
+// owner); this only fires while the previous instance is still alive and
+// shutting down, which clears within a second or two. Retry rather than
+// giving up and disabling Matter for the whole process lifetime.
+export const STORAGE_LOCK_RETRY_ATTEMPTS = 5
+export const STORAGE_LOCK_RETRY_DELAY_MS = 1000
+
 /**
  * Validate and sanitize Matter server configuration
  * Throws descriptive errors if configuration is invalid

--- a/src/matter/server/ServerConfig.ts
+++ b/src/matter/server/ServerConfig.ts
@@ -111,5 +111,6 @@ export function validateAndSanitizeConfig(config: MatterServerConfig): MatterSer
     externalAccessory,
     networkInterfaces: config.networkInterfaces,
     disableIpv4: config.disableIpv4,
+    deferOnline: config.deferOnline,
   }
 }

--- a/src/matter/server/ServerLifecycle.spec.ts
+++ b/src/matter/server/ServerLifecycle.spec.ts
@@ -340,6 +340,30 @@ describe('serverLifecycle — network.interface env var handling (#3910)', () =>
     })
   })
 
+  describe('restoring cached accessories before going online (#3969)', () => {
+    it('runs restoreAccessoriesFromCache before startServerNode', async () => {
+      const order: string[] = []
+      const proto = Object.getPrototypeOf(lifecycle) as { startServerNode: (...args: unknown[]) => Promise<void> }
+      vi.spyOn(proto, 'startServerNode').mockImplementation(async () => {
+        order.push('startServerNode')
+      })
+      const restoreAccessoriesFromCache = vi.fn(async () => {
+        order.push('restore')
+      })
+
+      await lifecycle.start(createMockDeps({ restoreAccessoriesFromCache }))
+
+      expect(restoreAccessoriesFromCache).toHaveBeenCalledTimes(1)
+      // The controller prunes bridged devices missing from the parts list the
+      // moment the node comes online, so the rebuild must happen first.
+      expect(order).toEqual(['restore', 'startServerNode'])
+    })
+
+    it('still starts when no restoreAccessoriesFromCache hook is provided', async () => {
+      await expect(lifecycle.start(createMockDeps())).resolves.not.toThrow()
+    })
+  })
+
   describe('setting network.interface after ServerNode creation', () => {
     it('sets network.interface only after MatterServerNode.create resolves', async () => {
       const deps = createMockDeps({

--- a/src/matter/server/ServerLifecycle.spec.ts
+++ b/src/matter/server/ServerLifecycle.spec.ts
@@ -164,10 +164,13 @@ vi.mock('./ServerConfig.js', () => ({
   SERVER_INIT_DELAY_MS: 0,
   SERVER_READY_POLL_INTERVAL_MS: 0,
   SERVER_READY_TIMEOUT_MS: 1000,
+  STORAGE_LOCK_RETRY_ATTEMPTS: 3,
+  STORAGE_LOCK_RETRY_DELAY_MS: 0,
 }))
 
 // Import after mocks are registered so the module under test binds to the mocked symbols.
 const { ServerLifecycle } = await import('./ServerLifecycle.js')
+const { ServerNode: MatterServerNode } = await import('@matter/main')
 
 function createMockDeps(overrides: Partial<ServerLifecycleDeps> = {}): ServerLifecycleDeps {
   let serverNode: unknown = null
@@ -1007,5 +1010,66 @@ describe('serverLifecycle.start — port-binding signal when the half-built node
 
     expect(thrown.message).toBe('commissioning failed')
     expect(thrown.portMayStillBeBound).toBeUndefined()
+  })
+})
+
+describe('serverLifecycle.createServerNodeWithRecovery — transient storage-lock retry (#3970)', () => {
+  let lifecycle: InstanceType<typeof ServerLifecycle>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    lifecycle = new ServerLifecycle()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retries and succeeds once a lock held by another process clears', async () => {
+    // A quick restart: the previous instance still holds the storage lock on the
+    // first attempt, then releases it.
+    vi.mocked(MatterServerNode.create).mockRejectedValueOnce(
+      new Error('Storage is locked by another process (pid 1234)'),
+    )
+
+    const node = await lifecycle.createServerNodeWithRecovery({} as never, 'TEST0001')
+
+    expect(node).toBeDefined()
+    expect(MatterServerNode.create).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after the retry budget when the lock never clears', async () => {
+    vi.mocked(MatterServerNode.create).mockRejectedValue(
+      new Error('Storage is locked by another process (pid 1234)'),
+    )
+
+    await expect(
+      lifecycle.createServerNodeWithRecovery({} as never, 'TEST0001'),
+    ).rejects.toThrow(/locked by another process/)
+
+    // STORAGE_LOCK_RETRY_ATTEMPTS is mocked to 3.
+    expect(MatterServerNode.create).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry "already locked by this process" — that is a bug, not a race', async () => {
+    vi.mocked(MatterServerNode.create).mockRejectedValue(
+      new Error('Storage is already locked by this process'),
+    )
+
+    await expect(
+      lifecycle.createServerNodeWithRecovery({} as never, 'TEST0001'),
+    ).rejects.toThrow(/already locked by this process/)
+
+    expect(MatterServerNode.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry an unrelated creation error', async () => {
+    vi.mocked(MatterServerNode.create).mockRejectedValue(new Error('boom'))
+
+    await expect(
+      lifecycle.createServerNodeWithRecovery({} as never, 'TEST0001'),
+    ).rejects.toThrow('boom')
+
+    expect(MatterServerNode.create).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -39,6 +39,8 @@ import {
   SERVER_INIT_DELAY_MS,
   SERVER_READY_POLL_INTERVAL_MS,
   SERVER_READY_TIMEOUT_MS,
+  STORAGE_LOCK_RETRY_ATTEMPTS,
+  STORAGE_LOCK_RETRY_DELAY_MS,
 } from './ServerConfig.js'
 
 const log = Logger.withPrefix('Matter/Server')
@@ -79,6 +81,47 @@ export class ServerLifecycle {
   public matterStoragePath?: string
 
   /**
+   * Whether a ServerNode creation failure is a transient storage-lock contention
+   * (a previous instance still releasing the lock) rather than a hard failure.
+   *
+   * matter.js already reclaims stale locks left by a crashed owner, so only a
+   * live previous instance produces "locked by another process". The
+   * "already locked by this process" variant is a bug, not a race, so it is
+   * deliberately not treated as transient.
+   */
+  private isTransientStorageLock(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error)
+    return message.includes('locked by another process')
+  }
+
+  /**
+   * Create a ServerNode, retrying on transient storage-lock contention.
+   *
+   * Without this, a quick restart where the previous process is still releasing
+   * the storage lock throws straight out of start(), which disables Matter for
+   * the entire process lifetime with no retry (a transient condition turned into
+   * a hard failure).
+   */
+  private async createServerNode(
+    nodeOptions: Parameters<typeof MatterServerNode.create>[0],
+  ): Promise<ServerNode> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await MatterServerNode.create(nodeOptions)
+      } catch (error: unknown) {
+        if (!this.isTransientStorageLock(error) || attempt >= STORAGE_LOCK_RETRY_ATTEMPTS) {
+          throw error
+        }
+        log.warn(
+          'Matter storage is locked, most likely a previous instance is still shutting down '
+          + `(attempt ${attempt}/${STORAGE_LOCK_RETRY_ATTEMPTS}); retrying in ${STORAGE_LOCK_RETRY_DELAY_MS}ms...`,
+        )
+        await new Promise(resolve => setTimeout(resolve, STORAGE_LOCK_RETRY_DELAY_MS))
+      }
+    }
+  }
+
+  /**
    * Create ServerNode with automatic recovery from corrupted storage
    */
   async createServerNodeWithRecovery(
@@ -86,7 +129,7 @@ export class ServerLifecycle {
     sanitizedId: string,
   ): Promise<ServerNode> {
     try {
-      return await MatterServerNode.create(nodeOptions)
+      return await this.createServerNode(nodeOptions)
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : ''
       const causeMessage = error instanceof Error && error.cause instanceof Error ? error.cause.message : ''
@@ -147,7 +190,7 @@ export class ServerLifecycle {
           log.warn('No corrupted storage files found, corruption may be elsewhere')
         }
 
-        const serverNode = await MatterServerNode.create(nodeOptions)
+        const serverNode = await this.createServerNode(nodeOptions)
         log.info('Successfully recovered from corrupted Matter storage')
         return serverNode
       } catch (retryError) {

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -288,6 +288,15 @@ export class ServerLifecycle {
 
       const sanitizedId = deps.config.uniqueId!
 
+      // Apple homed refuses to register nodes whose firmware metadata is
+      // missing or unparseable ("invalid matter AFU settings") - which
+      // silently breaks its whole control path. Derive a consistent
+      // numeric+string version pair from the configured firmware revision.
+      const versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(deps.config.firmwareRevision || getVersion() || '')
+      const version = versionMatch
+        ? [Number(versionMatch[1]) & 0xFF, Number(versionMatch[2]) & 0xFF, Number(versionMatch[3]) & 0xFF]
+        : [1, 0, 0]
+
       const nodeOptions: Parameters<typeof MatterServerNode.create>[0] = {
         id: sanitizedId,
         network: {
@@ -307,7 +316,10 @@ export class ServerLifecycle {
           serialNumber: deps.config.serialNumber || deps.config.uniqueId,
           hardwareVersion: 1,
           hardwareVersionString: release(),
-          softwareVersion: 1,
+          softwareVersion: (version[0] << 16) | (version[1] << 8) | version[2],
+          // Keep the full version string (including any pre-release suffix) so
+          // beta builds remain identifiable to controllers/support; only the
+          // numeric softwareVersion is derived from the parsed triplet.
           softwareVersionString: deps.config.firmwareRevision || getVersion(),
           reachable: true,
         },
@@ -427,7 +439,15 @@ export class ServerLifecycle {
           await deps.restoreAccessoriesFromCache()
         }
 
-        await this.startServerNode(serverNode, deps)
+        if (deps.config.deferOnline) {
+          // Deferred-online mode: the node is fully built (cache restored) but
+          // stays offline until runServer() - plugins register against the
+          // offline node so its FIRST advertisement already carries the final
+          // structure, and subscription re-establishment runs on a quiet node.
+          log.info('Deferred online mode - Matter node built, waiting for initial registrations before going online')
+        } else {
+          await this.startServerNode(serverNode, deps)
+        }
       } else {
         log.debug('Deferred start mode - server prepared but not running yet (will start after device registration)')
       }
@@ -476,7 +496,8 @@ export class ServerLifecycle {
   }
 
   /**
-   * Run the server after devices have been added (for external accessory mode)
+   * Run the server after devices have been added (for external accessory and
+   * deferred-online modes)
    */
   async runServer(deps: ServerLifecycleDeps): Promise<void> {
     const serverNode = deps.getServerNode()
@@ -489,8 +510,8 @@ export class ServerLifecycle {
       return
     }
 
-    if (!deps.config.externalAccessory) {
-      throw new MatterDeviceError('runServer() should only be called when externalAccessory mode is enabled')
+    if (!deps.config.externalAccessory && !deps.config.deferOnline) {
+      throw new MatterDeviceError('runServer() should only be called when externalAccessory or deferOnline mode is enabled')
     }
 
     log.debug('Running deferred server with device(s) already attached')

--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -5,12 +5,14 @@ import {
   applyElectricalMeasurementDefaults,
   applyFeaturesToBehavior,
   applySmokeCoAlarmFeatures,
+  applyThermostatFeatures,
   applyWindowCoveringFeatures,
   CLUSTER_IDS,
   detectBehaviorFeatures,
   detectElectricalMeasurementClusters,
   detectServiceAreaFeatures,
   detectSmokeCoAlarmFeatures,
+  detectThermostatFeatures,
   detectWindowCoveringFeatures,
   determineColorControlFeaturesFromHandlers,
   extractColorControlFeatures,
@@ -551,6 +553,79 @@ describe('serverHelpers', () => {
 
       expect(accessory.context).toBeDefined()
       expect((accessory.context as any)._skipWindowCoveringBehavior).toBe(true)
+    })
+  })
+
+  describe('detectThermostatFeatures', () => {
+    it('should detect Heating alone for a heating-only thermostat', () => {
+      const accessory = {
+        displayName: 'Spa Heater',
+        clusters: { thermostat: { occupiedHeatingSetpoint: 3800, systemMode: 4 } },
+      } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Heating'])
+    })
+
+    it('should detect Cooling alone for a cooling-only thermostat', () => {
+      const accessory = {
+        displayName: 'Cooler',
+        clusters: { thermostat: { occupiedCoolingSetpoint: 2400 } },
+      } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Cooling'])
+    })
+
+    it('should add AutoMode only when the thermostat can both heat and cool', () => {
+      const accessory = {
+        displayName: 'Heat Pump',
+        clusters: { thermostat: { occupiedHeatingSetpoint: 2000, occupiedCoolingSetpoint: 2400 } },
+      } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Heating', 'Cooling', 'AutoMode'])
+    })
+
+    it('should add Occupancy when the unoccupied setpoints are declared', () => {
+      const accessory = {
+        displayName: 'Full Thermostat',
+        clusters: {
+          thermostat: {
+            occupiedHeatingSetpoint: 2000,
+            occupiedCoolingSetpoint: 2400,
+            unoccupiedHeatingSetpoint: 1800,
+            unoccupiedCoolingSetpoint: 2600,
+          },
+        },
+      } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Heating', 'Cooling', 'AutoMode', 'Occupancy'])
+    })
+
+    it('should fall back to Heating when no setpoints are declared', () => {
+      const accessory = {
+        displayName: 'Bare Thermostat',
+        clusters: { thermostat: { localTemperature: 2100 } },
+      } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Heating'])
+    })
+
+    it('should fall back to Heating when there is no thermostat cluster at all', () => {
+      const accessory = { displayName: 'Nothing Declared' } as any
+
+      expect(detectThermostatFeatures(accessory)).toEqual(['Heating'])
+    })
+  })
+
+  describe('applyThermostatFeatures', () => {
+    it('should add the Thermostat cluster with only the given features', () => {
+      const accessory = { displayName: 'Spa Heater' } as any
+
+      const result = applyThermostatFeatures(devices.ThermostatDevice, accessory, ['Heating']) as any
+
+      expect(result.behaviors.thermostat).toBeDefined()
+      expect(result.behaviors.thermostat.features.heating).toBe(true)
+      expect(result.behaviors.thermostat.features.cooling).toBe(false)
+      expect(result.behaviors.thermostat.features.autoMode).toBe(false)
     })
   })
 

--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -780,6 +780,69 @@ describe('serverHelpers', () => {
       expect(checkThermostatSetpointLimits(accessory, autoMode)).toBeUndefined()
     })
 
+    it('should prefer a declared absolute limit over the spec default', () => {
+      // An unset user limit falls back to the accessory's OWN absolute limit,
+      // which is what matter.js validates against. Heat tops out at its
+      // declared 2600 rather than the spec's 3000, so the 4.0°C gap to cool's
+      // 3200 is fine - measuring against the spec default would have warned.
+      const accessory = {
+        displayName: 'Custom Absolutes',
+        clusters: {
+          thermostat: {
+            absMaxHeatSetpointLimit: 2600,
+            maxCoolSetpointLimit: 3200,
+            minHeatSetpointLimit: 700,
+            minCoolSetpointLimit: 1600,
+            minSetpointDeadBand: 40,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toBeUndefined()
+    })
+
+    it('should catch a declared absolute limit that breaks the deadband', () => {
+      // The mirror case: cool's absolute maximum is pulled down to meet heat's,
+      // so no setpoint update can ever satisfy the deadband. Falling back to
+      // the spec default (3200) would have missed it entirely.
+      const accessory = {
+        displayName: 'Narrowed Absolutes',
+        clusters: {
+          thermostat: {
+            maxHeatSetpointLimit: 3000,
+            absMaxCoolSetpointLimit: 3050,
+            minHeatSetpointLimit: 700,
+            minCoolSetpointLimit: 1600,
+            minSetpointDeadBand: 20,
+          },
+        },
+      } as any
+
+      const warning = checkThermostatSetpointLimits(accessory, autoMode)
+      expect(warning).toContain('maxCoolSetpointLimit (3050)')
+      expect(warning).toContain('maxHeatSetpointLimit (3000)')
+    })
+
+    it('should let an explicit user limit win over the absolute limit', () => {
+      // Both are declared, so the user limit is the effective one - the
+      // absolute is only the fallback.
+      const accessory = {
+        displayName: 'Both Declared',
+        clusters: {
+          thermostat: {
+            maxHeatSetpointLimit: 2500,
+            absMaxHeatSetpointLimit: 3000,
+            maxCoolSetpointLimit: 3200,
+            minHeatSetpointLimit: 700,
+            minCoolSetpointLimit: 1600,
+            minSetpointDeadBand: 50,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toBeUndefined()
+    })
+
     it('should not throw when there is no thermostat cluster', () => {
       expect(checkThermostatSetpointLimits({ displayName: 'None' } as any, autoMode)).toBeUndefined()
     })

--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -8,6 +8,7 @@ import {
   applySmokeCoAlarmFeatures,
   applyThermostatFeatures,
   applyWindowCoveringFeatures,
+  checkThermostatSetpointLimits,
   CLUSTER_IDS,
   detectBehaviorFeatures,
   detectElectricalMeasurementClusters,
@@ -669,6 +670,118 @@ describe('serverHelpers', () => {
       const accessory = { displayName: 'Nothing Declared' } as any
 
       expect(detectThermostatFeatures(accessory)).toEqual(['Heating'])
+    })
+  })
+
+  describe('checkThermostatSetpointLimits', () => {
+    const autoMode = ['Heating', 'Cooling', 'AutoMode']
+
+    it('should accept limits that leave room for the deadband', () => {
+      const accessory = {
+        displayName: 'Good Thermostat',
+        clusters: {
+          thermostat: {
+            minHeatSetpointLimit: 700,
+            maxHeatSetpointLimit: 2950,
+            minCoolSetpointLimit: 1600,
+            maxCoolSetpointLimit: 3200,
+            minSetpointDeadBand: 25,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toBeUndefined()
+    })
+
+    it('should reject a deadband the max limits cannot satisfy', () => {
+      // The real case: both limits sit at the spec's absolute maxima, so the
+      // widest gap available is 2.0°C and a 2.5°C deadband is impossible.
+      // matter.js accepts the endpoint, then rejects every setpoint update.
+      const accessory = {
+        displayName: 'Impossible Thermostat',
+        clusters: {
+          thermostat: {
+            minHeatSetpointLimit: 700,
+            maxHeatSetpointLimit: 3000,
+            minCoolSetpointLimit: 1600,
+            maxCoolSetpointLimit: 3200,
+            minSetpointDeadBand: 25,
+          },
+        },
+      } as any
+
+      const warning = checkThermostatSetpointLimits(accessory, autoMode)
+      expect(warning).toContain('Impossible Thermostat')
+      expect(warning).toContain('maxCoolSetpointLimit (3200)')
+      expect(warning).toContain('maxHeatSetpointLimit (3000)')
+      expect(warning).toContain('250')
+    })
+
+    it('should catch the min limits being too close together too', () => {
+      const accessory = {
+        displayName: 'Tight Minimums',
+        clusters: {
+          thermostat: {
+            minHeatSetpointLimit: 1500,
+            maxHeatSetpointLimit: 2900,
+            minCoolSetpointLimit: 1600,
+            maxCoolSetpointLimit: 3200,
+            minSetpointDeadBand: 25,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toContain('minCoolSetpointLimit')
+    })
+
+    it('should say nothing when the thermostat has no Auto mode', () => {
+      // Without AutoMode matter.js reports a deadband of 0, so the limits
+      // cannot conflict however they are declared.
+      const accessory = {
+        displayName: 'Heat Only',
+        clusters: {
+          thermostat: {
+            maxHeatSetpointLimit: 3000,
+            maxCoolSetpointLimit: 3200,
+            minSetpointDeadBand: 25,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, ['Heating'])).toBeUndefined()
+    })
+
+    it('should assume the 2.0°C default when no deadband is declared', () => {
+      // matter.js seeds an undeclared deadband to 20, so limits only 1.0°C
+      // apart are still a problem even though nothing was declared.
+      const accessory = {
+        displayName: 'Defaulted Deadband',
+        clusters: {
+          thermostat: {
+            maxHeatSetpointLimit: 3000,
+            maxCoolSetpointLimit: 3100,
+            minCoolSetpointLimit: 1600,
+            minHeatSetpointLimit: 700,
+          },
+        },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toContain('deadband')
+    })
+
+    it('should fall back to the spec absolute limits when none are declared', () => {
+      // Declaring nothing leaves heat 700..3000 and cool 1600..3200, which is
+      // exactly 200 apart at the top - fine at the default 2.0°C deadband.
+      const accessory = {
+        displayName: 'Bare Thermostat',
+        clusters: { thermostat: { occupiedHeatingSetpoint: 2000, occupiedCoolingSetpoint: 2400 } },
+      } as any
+
+      expect(checkThermostatSetpointLimits(accessory, autoMode)).toBeUndefined()
+    })
+
+    it('should not throw when there is no thermostat cluster', () => {
+      expect(checkThermostatSetpointLimits({ displayName: 'None' } as any, autoMode)).toBeUndefined()
     })
   })
 

--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -4,6 +4,7 @@ import {
   applyElectricalMeasurementClusters,
   applyElectricalMeasurementDefaults,
   applyFeaturesToBehavior,
+  applyLevelControlLightingFloor,
   applySmokeCoAlarmFeatures,
   applyThermostatFeatures,
   applyWindowCoveringFeatures,
@@ -553,6 +554,61 @@ describe('serverHelpers', () => {
 
       expect(accessory.context).toBeDefined()
       expect((accessory.context as any)._skipWindowCoveringBehavior).toBe(true)
+    })
+  })
+
+  describe('applyLevelControlLightingFloor', () => {
+    it('should raise a minLevel of 0 to 1 when Lighting is active', () => {
+      const accessory = {
+        displayName: 'Dimmable Light',
+        clusters: { levelControl: { currentLevel: 0, minLevel: 0, maxLevel: 254 } },
+      } as any
+
+      applyLevelControlLightingFloor(accessory, ['OnOff', 'Lighting'])
+
+      expect(accessory.clusters.levelControl.minLevel).toBe(1)
+      expect(accessory.clusters.levelControl.currentLevel).toBe(1)
+    })
+
+    it('should leave levels alone when Lighting is not active', () => {
+      const accessory = {
+        displayName: 'Pump',
+        clusters: { levelControl: { currentLevel: 0, minLevel: 0, maxLevel: 254 } },
+      } as any
+
+      applyLevelControlLightingFloor(accessory, [])
+
+      expect(accessory.clusters.levelControl.minLevel).toBe(0)
+      expect(accessory.clusters.levelControl.currentLevel).toBe(0)
+    })
+
+    it('should leave already-valid levels untouched', () => {
+      const accessory = {
+        displayName: 'Dimmable Light',
+        clusters: { levelControl: { currentLevel: 127, minLevel: 1, maxLevel: 254 } },
+      } as any
+
+      applyLevelControlLightingFloor(accessory, ['OnOff', 'Lighting'])
+
+      expect(accessory.clusters.levelControl.minLevel).toBe(1)
+      expect(accessory.clusters.levelControl.currentLevel).toBe(127)
+    })
+
+    it('should do nothing when there is no levelControl cluster', () => {
+      const accessory = { displayName: 'Switch', clusters: { onOff: { onOff: true } } } as any
+
+      expect(() => applyLevelControlLightingFloor(accessory, ['Lighting'])).not.toThrow()
+    })
+
+    it('should do nothing when features could not be detected', () => {
+      const accessory = {
+        displayName: 'Unknown',
+        clusters: { levelControl: { minLevel: 0 } },
+      } as any
+
+      applyLevelControlLightingFloor(accessory, null)
+
+      expect(accessory.clusters.levelControl.minLevel).toBe(0)
     })
   })
 

--- a/src/matter/serverHelpers.spec.ts
+++ b/src/matter/serverHelpers.spec.ts
@@ -856,10 +856,24 @@ describe('serverHelpers', () => {
       expect(result.behaviors.powerTopology).toBeDefined()
       expect(result.behaviors.powerTopology.features.treeTopology).toBe(true)
       expect(result.behaviors.electricalPowerMeasurement).toBeDefined()
+      expect(result.behaviors.electricalPowerMeasurement.features.alternatingCurrent).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement).toBeDefined()
       expect(result.behaviors.electricalEnergyMeasurement.features.importedEnergy).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement.features.cumulativeEnergy).toBe(true)
       expect(result.behaviors.electricalEnergyMeasurement.features.exportedEnergy).toBe(false)
+    })
+
+    it('should declare DirectCurrent instead of AlternatingCurrent when the accessory declares DC powerMode', () => {
+      const accessory = {
+        displayName: 'USB Meter',
+        clusters: { electricalPowerMeasurement: { activePower: 0, powerMode: 1 } },
+      } as any
+      const detection = { hasPowerMeasurement: true, energyFeatures: [] }
+
+      const result = applyElectricalMeasurementClusters(devices.OnOffPlugInUnitDevice, accessory, detection) as any
+
+      expect(result.behaviors.electricalPowerMeasurement.features.directCurrent).toBe(true)
+      expect(result.behaviors.electricalPowerMeasurement.features.alternatingCurrent).toBe(false)
     })
 
     it('should return the device type unchanged when nothing was detected', () => {

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -53,6 +53,12 @@ interface BehaviorInfo {
     id: number
     supportedFeatures?: Record<string, boolean>
   }
+  /**
+   * Features of a composed behavior, as recorded by matter.js's `.with(...)`.
+   * This is where the feature flags actually live for the clusters inspected
+   * here; `cluster.supportedFeatures` stays undefined for them.
+   */
+  features?: Record<string, boolean>
 }
 
 /**
@@ -113,7 +119,7 @@ export function validateAccessoryRequiredFields(accessory: MatterAccessory): voi
         + 'Clusters define the functionality of your device. Example:\n'
         + '  clusters: {\n'
         + '    onOff: { onOff: false },\n'
-        + '    levelControl: { currentLevel: 0, minLevel: 0, maxLevel: 254 }\n'
+        + '    levelControl: { currentLevel: 1, minLevel: 1, maxLevel: 254 }\n'
         + '  }\n'
         + 'Alternatively, use "parts" array for composed devices with multiple endpoints.',
       )
@@ -201,11 +207,18 @@ export function detectBehaviorFeatures(
   const behaviorsArray = convertBehaviorsToArray(existingBehaviors)
   const behavior = findBehaviorByCluster(behaviorsArray, clusterIdOrName)
 
-  if (!behavior?.cluster?.supportedFeatures) {
+  // matter.js records a composed behavior's features on the behavior itself.
+  // `cluster.supportedFeatures` is only populated for clusters that declare it,
+  // which none of the ones we inspect here do — so relying on it alone meant
+  // this always returned null and every caller fell back to its "no features"
+  // path. Read the behavior's own features when the cluster does not carry them.
+  const supportedFeatures = behavior?.cluster?.supportedFeatures ?? behavior?.features
+
+  if (!supportedFeatures) {
     return null
   }
 
-  return featureExtractor(behavior.cluster.supportedFeatures)
+  return featureExtractor(supportedFeatures)
 }
 
 /**
@@ -392,6 +405,39 @@ export function applySmokeCoAlarmFeatures(
 
   const smokeCoAlarmWithFeatures = (devices.SmokeCoAlarmRequirements.SmokeCoAlarmServer as any).with(...features)
   return (deviceType as any).with(smokeCoAlarmWithFeatures)
+}
+
+/**
+ * Raise a LevelControl floor of 0 to 1 when the Lighting feature is active.
+ *
+ * The Lighting feature reserves level 0 for "off", so the spec constrains
+ * MinLevel to 1-254 and matter.js rejects 0 outright. Homebridge's own guidance
+ * has suggested `minLevel: 0`, so accessories in the wild carry it. Lift those
+ * to 1 with a warning rather than refusing to register the accessory.
+ */
+export function applyLevelControlLightingFloor(
+  accessory: MatterAccessory,
+  levelControlFeatures: string[] | null,
+): void {
+  if (!levelControlFeatures?.includes('Lighting')) {
+    return
+  }
+
+  const levelControl = accessory.clusters?.levelControl as Record<string, unknown> | undefined
+  if (!levelControl) {
+    return
+  }
+
+  for (const attribute of ['minLevel', 'currentLevel'] as const) {
+    const value = levelControl[attribute]
+    if (typeof value === 'number' && value < 1) {
+      log.warn(
+        `${accessory.displayName} declares levelControl.${attribute} of ${value}, but the Lighting `
+        + 'feature reserves level 0 - using 1 instead.',
+      )
+      levelControl[attribute] = 1
+    }
+  }
 }
 
 /**

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -474,6 +474,79 @@ export function detectThermostatFeatures(accessory: MatterAccessory): string[] {
 }
 
 /**
+ * The spec's absolute setpoint bounds, in 0.01°C. matter.js falls back to these
+ * when an accessory declares no abs*SetpointLimit of its own.
+ */
+const THERMOSTAT_ABS_LIMITS = {
+  Heat: { min: 700, max: 3000 },
+  Cool: { min: 1600, max: 3200 },
+} as const
+
+/**
+ * Check that an AutoMode thermostat's setpoint LIMITS can satisfy its deadband.
+ *
+ * ⚠️ The deadband applies to the limits, not only to the setpoints. matter.js
+ * requires both of these, in 0.01°C:
+ *   maxCoolSetpointLimit - maxHeatSetpointLimit >= deadband
+ *   minCoolSetpointLimit - minHeatSetpointLimit >= deadband
+ *
+ * `minSetpointDeadBand` is declared in 0.1°C, so it is multiplied by 10 first.
+ *
+ * This is easy to get wrong and the symptom is badly disconnected from the
+ * cause: the endpoint is created happily, then EVERY later setpoint update
+ * fails with "Thermostat setpoints could not be reconciled within the
+ * configured limits". matter.js 0.17.6 only validated the attribute being
+ * written, so an impossible configuration went unnoticed until 0.17.7 began
+ * validating the whole cluster. Warning here points at the real problem.
+ *
+ * Returns a message describing the problem, or undefined when the limits are
+ * satisfiable.
+ */
+export function checkThermostatSetpointLimits(
+  accessory: MatterAccessory,
+  features: string[],
+): string | undefined {
+  if (!features.includes('AutoMode')) {
+    return undefined
+  }
+
+  const cluster = accessory.clusters?.thermostat as Record<string, number | undefined> | undefined
+  if (!cluster) {
+    return undefined
+  }
+
+  // matter.js treats an undeclared deadband as 2.0°C, and replaces anything
+  // above the legal 0..127 with the same value.
+  const declared = cluster.minSetpointDeadBand
+  const deadBand = (declared === undefined || declared > 127 ? 20 : declared) * 10
+
+  const limit = (scope: 'Heat' | 'Cool', bound: 'min' | 'max'): number =>
+    cluster[`${bound}${scope}SetpointLimit`]
+    ?? THERMOSTAT_ABS_LIMITS[scope][bound]
+
+  const problems: string[] = []
+  for (const bound of ['max', 'min'] as const) {
+    const cool = limit('Cool', bound)
+    const heat = limit('Heat', bound)
+    if (cool - heat < deadBand) {
+      problems.push(
+        `${bound}CoolSetpointLimit (${cool}) - ${bound}HeatSetpointLimit (${heat}) = ${cool - heat}, `
+        + `which is less than the ${deadBand} deadband`,
+      )
+    }
+  }
+
+  if (problems.length === 0) {
+    return undefined
+  }
+
+  return `${accessory.displayName} declares a thermostat with Auto mode whose setpoint limits cannot satisfy its `
+    + `minSetpointDeadBand of ${deadBand / 10} (${deadBand} in setpoint units): ${problems.join('; ')}. `
+    + 'Every setpoint update will be rejected until this is corrected - either lower minSetpointDeadBand, '
+    + 'or widen the gap between the heating and cooling limits.'
+}
+
+/**
  * Apply Thermostat features to device type.
  * Thermostat is not part of the base ThermostatDevice — matter.js requires the
  * features to be chosen — so without this the endpoint would be created without
@@ -485,6 +558,11 @@ export function applyThermostatFeatures(
   features: string[],
 ): EndpointType {
   log.info(`Auto-detected Thermostat features for ${accessory.displayName}: ${features.join(', ')}`)
+
+  const limitProblem = checkThermostatSetpointLimits(accessory, features)
+  if (limitProblem) {
+    log.warn(limitProblem)
+  }
 
   const thermostatWithFeatures = (devices.ThermostatRequirements.ThermostatServer as any).with(...features)
   return (deviceType as any).with(thermostatWithFeatures)

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -395,6 +395,56 @@ export function applySmokeCoAlarmFeatures(
 }
 
 /**
+ * Detect Thermostat features from accessory attributes.
+ *
+ * A thermostat that only heats should not advertise cooling, so the features
+ * follow the setpoints the accessory actually declares. The Matter spec requires
+ * at least one of Heating/Cooling, so an accessory declaring neither falls back
+ * to Heating. AutoMode is only meaningful when the device can do both, and
+ * Occupancy only when the unoccupied setpoints are present.
+ */
+export function detectThermostatFeatures(accessory: MatterAccessory): string[] {
+  const thermostatCluster = accessory.clusters?.thermostat as Record<string, unknown> | undefined
+  const has = (attribute: string): boolean => thermostatCluster !== undefined && attribute in thermostatCluster
+  const features: string[] = []
+
+  if (has('occupiedHeatingSetpoint') || has('unoccupiedHeatingSetpoint')) {
+    features.push('Heating')
+  }
+  if (has('occupiedCoolingSetpoint') || has('unoccupiedCoolingSetpoint')) {
+    features.push('Cooling')
+  }
+  if (features.length === 0) {
+    features.push('Heating')
+  }
+  if (features.includes('Heating') && features.includes('Cooling')) {
+    features.push('AutoMode')
+  }
+  if (has('unoccupiedHeatingSetpoint') || has('unoccupiedCoolingSetpoint')) {
+    features.push('Occupancy')
+  }
+
+  return features
+}
+
+/**
+ * Apply Thermostat features to device type.
+ * Thermostat is not part of the base ThermostatDevice — matter.js requires the
+ * features to be chosen — so without this the endpoint would be created without
+ * the cluster and the accessory's thermostat state silently dropped.
+ */
+export function applyThermostatFeatures(
+  deviceType: EndpointType,
+  accessory: MatterAccessory,
+  features: string[],
+): EndpointType {
+  log.info(`Auto-detected Thermostat features for ${accessory.displayName}: ${features.join(', ')}`)
+
+  const thermostatWithFeatures = (devices.ThermostatRequirements.ThermostatServer as any).with(...features)
+  return (deviceType as any).with(thermostatWithFeatures)
+}
+
+/**
  * Detect ServiceArea features from cluster attributes
  */
 export function detectServiceAreaFeatures(

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -763,7 +763,13 @@ export function applyElectricalMeasurementClusters(
     behaviors.push((requirements.PowerTopologyServer as any).with('TreeTopology'))
   }
   if (detection.hasPowerMeasurement && !existing.electricalPowerMeasurement) {
-    behaviors.push(requirements.ElectricalPowerMeasurementServer)
+    // The EPM cluster's feature conformance requires at least one of
+    // DirectCurrent/AlternatingCurrent. Follow the accessory's powerMode
+    // (already resolved by applyElectricalMeasurementDefaults: plugin value
+    // or the AC default): 1 = DC, everything else measures mains.
+    const powerMode = (accessory.clusters?.electricalPowerMeasurement as Record<string, unknown> | undefined)?.powerMode
+    const currentFeature = powerMode === 1 ? 'DirectCurrent' : 'AlternatingCurrent'
+    behaviors.push((requirements.ElectricalPowerMeasurementServer as any).with(currentFeature))
   }
   if (detection.energyFeatures.length > 0 && !existing.electricalEnergyMeasurement) {
     behaviors.push((requirements.ElectricalEnergyMeasurementServer as any).with(...detection.energyFeatures))

--- a/src/matter/serverHelpers.ts
+++ b/src/matter/serverHelpers.ts
@@ -32,9 +32,12 @@ const log = Logger.withPrefix('Matter/Server')
 export const CLUSTER_IDS = {
   AIR_QUALITY: clusters.AirQuality.Cluster.id,
   CARBON_MONOXIDE_CONCENTRATION: clusters.CarbonMonoxideConcentrationMeasurement.Cluster.id,
+  CLOSURE_CONTROL: clusters.ClosureControl.Cluster.id,
   COLOR_CONTROL: clusters.ColorControl.Cluster.id,
   DOOR_LOCK: clusters.DoorLock.Cluster.id,
+  KEYPAD_INPUT: clusters.KeypadInput.Cluster.id,
   LEVEL_CONTROL: clusters.LevelControl.Cluster.id,
+  MEDIA_PLAYBACK: clusters.MediaPlayback.Cluster.id,
   NITROGEN_DIOXIDE_CONCENTRATION: clusters.NitrogenDioxideConcentrationMeasurement.Cluster.id,
   ON_OFF: clusters.OnOff.Cluster.id,
   OZONE_CONCENTRATION: clusters.OzoneConcentrationMeasurement.Cluster.id,
@@ -219,6 +222,24 @@ export function detectBehaviorFeatures(
   }
 
   return featureExtractor(supportedFeatures)
+}
+
+/**
+ * Extract whatever features a behavior already declares, whatever the cluster.
+ *
+ * matter.js records a composed behavior's features as camelCase booleans and
+ * `.with(...)` takes the PascalCase names, so carrying a feature set across is
+ * just a capitalise - the same mapping the per-cluster extractors below do by
+ * hand (`hueSaturation` to `HueSaturation`, `xy` to `Xy`).
+ *
+ * Used for clusters whose features we have no reason to reason about. We only
+ * need them preserved when a Homebridge behavior replaces the base one, and a
+ * hand-written list would silently drop any feature matter.js adds later.
+ */
+export function extractDeclaredFeatures(supportedFeatures: Record<string, boolean>): string[] {
+  return Object.entries(supportedFeatures)
+    .filter(([, enabled]) => enabled)
+    .map(([name]) => name.charAt(0).toUpperCase() + name.slice(1))
 }
 
 /**
@@ -520,8 +541,15 @@ export function checkThermostatSetpointLimits(
   const declared = cluster.minSetpointDeadBand
   const deadBand = (declared === undefined || declared > 127 ? 20 : declared) * 10
 
+  // An unset user limit does NOT fall back to the spec default - it falls back
+  // to the accessory's own absolute limit for that mode, and only then to the
+  // spec default. matter.js does exactly this (`#userLimit` reads
+  // `min|maxXSetpointLimit ?? absMin|absMaxXSetpointLimit`), so a thermostat
+  // that widens only its absolute range would otherwise be measured against
+  // bounds it never declared - and warned about, or cleared, wrongly.
   const limit = (scope: 'Heat' | 'Cool', bound: 'min' | 'max'): number =>
     cluster[`${bound}${scope}SetpointLimit`]
+    ?? cluster[`abs${bound === 'min' ? 'Min' : 'Max'}${scope}SetpointLimit`]
     ?? THERMOSTAT_ABS_LIMITS[scope][bound]
 
   const problems: string[] = []

--- a/src/matter/sharedTypes.ts
+++ b/src/matter/sharedTypes.ts
@@ -192,6 +192,14 @@ export interface MatterServerConfig {
   /** External accessory mode - device is not bridged and so added before server starts */
   externalAccessory?: boolean
 
+  /**
+   * Deferred-online mode - the node is fully built by `start()` (aggregator
+   * created, accessory cache restored) but stays offline until `runServer()`,
+   * so initial plugin registrations apply to the offline node and its first
+   * advertisement already carries the final structure
+   */
+  deferOnline?: boolean
+
   /** Network interfaces to bind to (inherited from `bridge.bind` config) */
   networkInterfaces?: string[]
 

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -22,7 +22,7 @@ import { EventEmitter } from 'node:events'
  *
  * Why this matters:
  * - Barrel import: `import * as devices from '@matter/main/devices'` loads ALL 186+ exports (~800ms)
- * - Individual imports: Only loads the 23 devices we actually use (~50-100ms)
+ * - Individual imports: Only loads the 27 devices we actually use (~50-100ms)
  * - Result: 50-100x faster on powerful machines, even more improvement on Raspberry Pi
  *
  * This optimization is especially important for users on resource-constrained devices like
@@ -50,6 +50,8 @@ import { ValveConfigurationAndControl } from '@matter/main/clusters/valve-config
 import { WindowCovering } from '@matter/main/clusters/window-covering'
 // Direct imports from individual device files
 import { AirQualitySensorDevice } from '@matter/main/devices/air-quality-sensor'
+import { BasicVideoPlayerDevice } from '@matter/main/devices/basic-video-player'
+import { ClosureDevice, ClosureRequirements } from '@matter/main/devices/closure'
 import { ColorTemperatureLightDevice } from '@matter/main/devices/color-temperature-light'
 import { ContactSensorDevice } from '@matter/main/devices/contact-sensor'
 import { DimmableLightDevice } from '@matter/main/devices/dimmable-light'
@@ -68,6 +70,7 @@ import { PumpDevice, PumpRequirements } from '@matter/main/devices/pump'
 import { RoboticVacuumCleanerDevice, RoboticVacuumCleanerRequirements } from '@matter/main/devices/robotic-vacuum-cleaner'
 import { RoomAirConditionerDevice, RoomAirConditionerRequirements } from '@matter/main/devices/room-air-conditioner'
 import { SmokeCoAlarmDevice, SmokeCoAlarmRequirements } from '@matter/main/devices/smoke-co-alarm'
+import { SpeakerDevice } from '@matter/main/devices/speaker'
 import { TemperatureSensorDevice } from '@matter/main/devices/temperature-sensor'
 import { ThermostatDevice, ThermostatRequirements } from '@matter/main/devices/thermostat'
 import { WaterLeakDetectorDevice } from '@matter/main/devices/water-leak-detector'
@@ -534,9 +537,13 @@ const devices = {
   ThermostatDevice,
   ThermostatRequirements,
   WaterLeakDetectorDevice,
+  SpeakerDevice,
   WaterValveDevice,
   WaterValveRequirements,
   WindowCoveringDevice,
+  BasicVideoPlayerDevice,
+  ClosureDevice,
+  ClosureRequirements,
 }
 
 /**
@@ -628,6 +635,35 @@ export const deviceTypes = {
 
   // Window Coverings (features will be auto-detected based on accessory attributes)
   WindowCovering: devices.WindowCoveringDevice,
+
+  // Closures — garage doors, gates and similar. Until the Closures work landed
+  // in the spec there was no such device type, and the usual stand-in was
+  // WindowCovering, which drives the hardware correctly but presents as a blind.
+  //
+  // ⚠️ Apple Home does not support this type yet, so an accessory using it will
+  // not appear there. It is exposed for plugin authors building against Google
+  // or Alexa, and to have the groundwork done for whenever Apple catches up.
+  //
+  // ClosureControl is not part of the base device type — matter.js requires a
+  // feature to be chosen, and without one the endpoint is built carrying only
+  // Identify and any closure state a plugin supplies is silently dropped.
+  // Positioning is the one that makes open/closed/part-open meaningful, which
+  // is what a garage door or gate needs; compose your own with `.with(...)` to
+  // add Speed, Ventilation, Pedestrian or the rest.
+  Closure: devices.ClosureDevice.with(devices.ClosureRequirements.ClosureControlServer.with('Positioning')),
+
+  // Media — the name says video, but nothing in the device type is video-only:
+  // it carries MediaPlayback (play/pause/stop), MediaInput and AudioOutput
+  // (source selection), Channel, TargetNavigator and KeypadInput. An audio-only
+  // device is a legitimate use of it.
+  //
+  // Volume and mute are NOT here. In Matter those live on a separate Speaker
+  // endpoint (LevelControl + OnOff), composed alongside this one under a
+  // BridgedNode — which is why both are exposed together.
+  //
+  // ⚠️ Apple Home does not support either type yet; see the note on Closure.
+  MediaPlayer: devices.BasicVideoPlayerDevice,
+  Speaker: devices.SpeakerDevice,
 
   // Appliances
   // RVC optional clusters (RvcCleanMode, ServiceArea) are added dynamically in matterServer

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -32,12 +32,15 @@ import { EventEmitter } from 'node:events'
 import { AirQuality } from '@matter/main/clusters/air-quality'
 import { BooleanState } from '@matter/main/clusters/boolean-state'
 import { CarbonMonoxideConcentrationMeasurement } from '@matter/main/clusters/carbon-monoxide-concentration-measurement'
+import { ClosureControl } from '@matter/main/clusters/closure-control'
 import { ColorControl } from '@matter/main/clusters/color-control'
 import { DoorLock } from '@matter/main/clusters/door-lock'
 import { ElectricalEnergyMeasurement } from '@matter/main/clusters/electrical-energy-measurement'
 import { ElectricalPowerMeasurement } from '@matter/main/clusters/electrical-power-measurement'
 import { FanControl } from '@matter/main/clusters/fan-control'
+import { KeypadInput } from '@matter/main/clusters/keypad-input'
 import { LevelControl } from '@matter/main/clusters/level-control'
+import { MediaPlayback } from '@matter/main/clusters/media-playback'
 import { NitrogenDioxideConcentrationMeasurement } from '@matter/main/clusters/nitrogen-dioxide-concentration-measurement'
 import { OnOff } from '@matter/main/clusters/on-off'
 import { OzoneConcentrationMeasurement } from '@matter/main/clusters/ozone-concentration-measurement'
@@ -555,12 +558,15 @@ const clusters = {
   AirQuality,
   BooleanState,
   CarbonMonoxideConcentrationMeasurement,
+  ClosureControl,
   ColorControl,
   DoorLock,
   ElectricalEnergyMeasurement,
   ElectricalPowerMeasurement,
   FanControl,
+  KeypadInput,
   LevelControl,
+  MediaPlayback,
   NitrogenDioxideConcentrationMeasurement,
   OnOff,
   OzoneConcentrationMeasurement,
@@ -749,6 +755,14 @@ export const clusterNames = {
 
   // Valve
   ValveConfigurationAndControl: 'valveConfigurationAndControl',
+
+  // Closures — garage doors, gates and similar
+  ClosureControl: 'closureControl',
+
+  // Media — the player endpoint; volume and mute are levelControl/onOff on a
+  // separate Speaker endpoint rather than anything here
+  MediaPlayback: 'mediaPlayback',
+  KeypadInput: 'keypadInput',
 
   // Identification
   Identify: 'identify',

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -82,6 +82,9 @@ import { WindowCoveringDevice } from '@matter/main/devices/window-covering'
 import { BridgedNodeEndpoint } from '@matter/main/endpoints/bridged-node'
 import { ElectricalSensorEndpoint, ElectricalSensorRequirements } from '@matter/main/endpoints/electrical-sensor'
 
+import { DefaultClosureControlServer } from './behaviors/ClosureControlBehavior.js'
+import { DefaultKeypadInputServer } from './behaviors/KeypadInputBehavior.js'
+import { DefaultMediaPlaybackServer } from './behaviors/MediaPlaybackBehavior.js'
 import { DefaultValveConfigurationAndControlServer } from './behaviors/ValveConfigurationAndControlBehavior.js'
 
 type BehaviorType = Behavior.Type
@@ -656,7 +659,11 @@ export const deviceTypes = {
   // Positioning is the one that makes open/closed/part-open meaningful, which
   // is what a garage door or gate needs; compose your own with `.with(...)` to
   // add Speed, Ventilation, Pedestrian or the rest.
-  Closure: devices.ClosureDevice.with(devices.ClosureRequirements.ClosureControlServer.with('Positioning')),
+  //
+  // matter.js's own ClosureControlServer leaves every command unimplemented, so
+  // use ours: it records the move, and is replaced by the handler-calling
+  // version when a plugin supplies closureControl handlers.
+  Closure: devices.ClosureDevice.with(DefaultClosureControlServer.with('Positioning')),
 
   // Media — the name says video, but nothing in the device type is video-only:
   // it carries MediaPlayback (play/pause/stop), MediaInput and AudioOutput
@@ -668,7 +675,11 @@ export const deviceTypes = {
   // BridgedNode — which is why both are exposed together.
   //
   // ⚠️ Apple Home does not support either type yet; see the note on Closure.
-  MediaPlayer: devices.BasicVideoPlayerDevice,
+  //
+  // MediaPlayback and KeypadInput are the device type's two mandatory command
+  // clusters and matter.js implements neither, so the same substitution as
+  // Closure applies - otherwise every play/pause/key press would fail.
+  MediaPlayer: devices.BasicVideoPlayerDevice.with(DefaultMediaPlaybackServer, DefaultKeypadInputServer),
   Speaker: devices.SpeakerDevice,
 
   // Appliances

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -614,7 +614,13 @@ export const deviceTypes = {
   ElectricalSensor: devices.ElectricalSensorEndpoint,
 
   // HVAC
-  Thermostat: devices.ThermostatDevice.with(devices.ThermostatRequirements.ThermostatServer.with('Heating', 'Cooling', 'AutoMode', 'Occupancy')),
+  // The Thermostat cluster is feature-gated in matter.js, so the base
+  // ThermostatDevice carries no thermostat cluster. It is added at registration
+  // with the features detected from the accessory's declared setpoints — a
+  // heating-only accessory gets Heating alone rather than being forced to claim
+  // cooling it cannot do (see applyThermostatFeatures in serverHelpers.ts).
+  // Compose the cluster yourself with `.with(...)` to override the detection.
+  Thermostat: devices.ThermostatDevice,
   Fan: devices.FanDevice,
 
   // Security


### PR DESCRIPTION
### Changes

- feat: make identifying material in bonjour configurable (#3965) (@naterator)
- fix(matter): compose PowerSource for all device types (#3968) (@zbuc)
- fix(matter): restore cached accessories into the bridge before going online (#3969) (@keremerkan)
- feat(matter): expose matter status errors on `api.matter.status`
- feat(matter): detect thermostat features from the declared setpoints
- fix(matter): read cluster features from the behavior, not the cluster
- fix(matter): retry Matter server start on transient storage-lock contention
- fix(matter): retry parts-list notification on synchronous lock contention
- fix(matter): reject bridged registrations that arrive before the server is running
- test(matter): cover cache-restore attach-in-place and pre-online ordering
- fix(matter): defer bridge online until registrations settle (#3973) (@keremerkan)
- fix(matter): add FixedLabel and PowerSource to composed parents (#3972) (@keremerkan)
- feat(matter): expose commissioned fabrics in the child bridge status (#3974)
- fix(matter): read the fabric vendor id from cluster-shaped fabric entries (#3974)
- fix(matter): declare ac/dc feature on power measurement (#3977) (@keremerkan)
- feat(matter): populate bridged accessory firmware version from firmwareRevision (#3976) (@keremerkan)
- chore(deps): dependency updates
- chore(deps): bump `@matter/main` to the released v0.17.7
- feat: Support for NodeJS 26 
- feat(matter): warn when a thermostat's setpoint limits cannot satisfy its auto-mode deadband
- fix(matter): advertise the power source device type on endpoints with a battery, per the Matter spec
- fix(matter): seed a battery's unknown charge state, so a late first report is not rejected (#3982)
- chore(deps): updated `@matter/main` from `v0.17.6` to `v0.17.9`
  - [see changelog &rarr;](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md)
- feat(matter): expose the closure, media player and speaker device types to plugins
- fix(matter): expose the clusters and enums the new device types need, so plugins are not left with magic numbers

### Homebridge Dependencies

- `@homebridge/hap-nodejs` @ `v2.2.0-beta`

### Matter Dependencies

- `@matter/main` @ `v0.17.9`