### PR TITLE
v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `homebridge` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v2.3.1 (Pending Release)
+
+### Changes
+
+- fix(matter): stop rejecting the bridge's own storage path on windows (#3987)
+
+### Homebridge Dependencies
+
+- `@homebridge/hap-nodejs` @ `v2.2.0`
+
+### Matter Dependencies
+
+- `@matter/main` @ `v0.17.9`
+
 ## v2.3.0 (2026-08-08)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `homebridge` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
-## v2.3.1 (Pending Release)
+## v2.3.1 (2026-08-10)
 
 ### Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/hap-nodejs": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "type": "module",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "HomeKit support for the impatient",
   "author": "Nick Farina",
   "license": "Apache-2.0",

--- a/src/matter/server/ServerLifecycle.spec.ts
+++ b/src/matter/server/ServerLifecycle.spec.ts
@@ -2,7 +2,7 @@ import type { ServerLifecycleDeps } from './ServerLifecycle.js'
 
 import process from 'node:process'
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * Tests for the network.interface env-var handling added in
@@ -1095,5 +1095,63 @@ describe('serverLifecycle.createServerNodeWithRecovery — transient storage-loc
     ).rejects.toThrow('boom')
 
     expect(MatterServerNode.create).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * Regression cover for #3987: every Matter child bridge on Windows crashed at
+ * startup with "Storage path not allowed". The allowlist guessed at three
+ * likely storage locations instead of asking `User.storagePath()` - so any
+ * custom `-U` path failed outright, and a Windows path that differed from the
+ * guess by nothing more than letter case failed the raw `startsWith` check.
+ */
+describe('setupStorage path validation', () => {
+  let storageBase: string
+
+  beforeAll(async () => {
+    const { mkdtemp } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { User } = await import('../../user.js')
+    // A tmp dir is deliberately OUTSIDE every guessed base (homedir, cwd,
+    // /var/lib/homebridge), so only the configured-path entry can admit it
+    storageBase = await mkdtemp(join(tmpdir(), 'hb-matter-storage-'))
+    User.setStoragePath(storageBase)
+  })
+
+  afterAll(async () => {
+    const { rm } = await import('node:fs/promises')
+    await rm(storageBase, { recursive: true, force: true })
+  })
+
+  it('accepts the matter directory under the configured storage path', async () => {
+    const { join } = await import('node:path')
+    const lifecycle = new ServerLifecycle()
+
+    const cache = await lifecycle.setupStorage({
+      storagePath: join(storageBase, 'matter'),
+      uniqueId: 'TEST3987',
+    } as never)
+
+    expect(cache).toBeDefined()
+    expect(lifecycle.matterStoragePath).toBe(join(storageBase, 'matter', 'TEST3987'))
+  })
+
+  it('still rejects a sibling that merely shares the prefix', async () => {
+    const { join } = await import('node:path')
+    const lifecycle = new ServerLifecycle()
+
+    await expect(lifecycle.setupStorage({
+      storagePath: join(`${storageBase}-evil`, 'matter'),
+      uniqueId: 'TEST3987',
+    } as never)).rejects.toThrow('Storage path not allowed')
+  })
+
+  it('rests on relative() comparing windows paths case-insensitively', async () => {
+    // Pin the node behaviour the windows fix relies on, since this suite
+    // cannot run the win32 path rules natively
+    const { win32 } = await import('node:path')
+    expect(win32.relative('C:\\Users\\Ben\\.homebridge', 'c:\\users\\ben\\.homebridge\\matter')).toBe('matter')
+    expect(win32.relative('C:\\Users\\Ben\\.homebridge', 'C:\\Users\\Ben\\.homebridge-evil\\matter').startsWith('..')).toBe(true)
   })
 })

--- a/src/matter/server/ServerLifecycle.ts
+++ b/src/matter/server/ServerLifecycle.ts
@@ -16,7 +16,7 @@ import type { FabricManager } from './FabricManager.js'
 import { constants } from 'node:fs'
 import { access, mkdir, rm, stat } from 'node:fs/promises'
 import { homedir, release } from 'node:os'
-import { join, normalize, resolve } from 'node:path'
+import { isAbsolute, join, normalize, relative, resolve } from 'node:path'
 import process from 'node:process'
 
 import { Filesystem } from '@matter/general'
@@ -31,6 +31,7 @@ import { NodeJsFilesystem } from '@matter/nodejs'
 
 import { DEFAULT_BRIDGE_DEFAULTS } from '../../bridgeService.js'
 import { Logger } from '../../logger.js'
+import { User } from '../../user.js'
 import getVersion from '../../version.js'
 import { errorHandler } from '../errorHandler.js'
 import { MatterDeviceError } from '../types.js'
@@ -215,18 +216,28 @@ export class ServerLifecycle {
     const storagePath = resolve(config.storagePath)
     const normalizedPath = normalize(storagePath)
 
-    // Ensure path is within allowed directories
+    // Ensure path is within allowed directories. The instance's own configured
+    // storage path (the `-U` flag) is the authoritative base - the old list
+    // only guessed at three likely locations, so any custom storage path, and
+    // every Windows setup whose stored path differed from the guess by nothing
+    // more than letter case, crashed here at startup (#3987).
     const allowedBasePaths = [
+      resolve(User.storagePath()),
       resolve(homedir(), '.homebridge'),
       resolve(process.cwd()),
       '/var/lib/homebridge',
     ]
 
-    const isAllowed = allowedBasePaths.some(basePath =>
-      normalizedPath.startsWith(basePath),
-    )
+    // `relative` rather than a raw prefix: it compares Windows paths
+    // case-insensitively (`C:\` and `c:\` are the same directory), and a
+    // sibling that merely shares the prefix (`.homebridge-evil`) resolves to a
+    // `..` escape rather than passing as `startsWith` would have let it.
+    const isAllowed = allowedBasePaths.some((basePath) => {
+      const relativePath = relative(basePath, normalizedPath)
+      return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+    })
 
-    if (!isAllowed || normalizedPath.includes('..')) {
+    if (!isAllowed) {
       throw new Error(`Storage path not allowed: ${normalizedPath}. Must be within homebridge directories.`)
     }
 


### PR DESCRIPTION
### Changes

- fix(matter): stop rejecting the bridge's own storage path on windows (#3987)

### Homebridge Dependencies

- `@homebridge/hap-nodejs` @ `v2.2.0`

### Matter Dependencies

- `@matter/main` @ `v0.17.9`