### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <a href="https://github.com/homebridge/homebridge/wiki/How-To-Change-Homebridge-Version#manage-beta-version"><img title="npm version" src="https://img.shields.io/npm/v/homebridge/alpha?label=alpha"></a><br>
 <a href="https://www.npmjs.com/package/homebridge"><img title="npm downloads" src="https://img.shields.io/npm/dt/homebridge"></a>
 <a href="https://github.com/homebridge/homebridge/actions/workflows/build.yml"><img title="Node Build" src="https://github.com/homebridge/homebridge/actions/workflows/build.yml/badge.svg"></a>
+<a href="https://inspect.software/software/homebridge/homebridge"><img src="https://raw.githubusercontent.com/inspect-software/badges/main/v1/h/homebridge/homebridge.svg" alt="inspect.software score badge for homebridge/homebridge" /></a>
 
 </span>
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/homebridge/homebridge), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
