### PR TITLE
fix: guard child bridge shutdown before bridgeService is assigned

### DIFF
--- a/src/childBridgeFork.spec.ts
+++ b/src/childBridgeFork.spec.ts
@@ -79,6 +79,13 @@ describe('childBridgeFork - Matter Accessory Guard', () => {
   })
 })
 
+describe('childBridgeFork - shutdown', () => {
+  it('does not throw when a signal arrives before bridgeService is assigned', () => {
+    const fork = new ChildBridgeFork()
+    expect(() => fork.shutdown()).not.toThrow()
+  })
+})
+
 describe('childBridgeFork - Matter Handlers', () => {
   let childBridgeFork: ChildBridgeFork
   let mockMatterManager: any

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -460,7 +460,9 @@ export class ChildBridgeFork {
   }
 
   shutdown(): void {
-    this.bridgeService.teardown()
+    // bridgeService is only assigned once the bridge has started, and a signal
+    // can arrive before that.
+    this.bridgeService?.teardown()
 
     // Teardown Matter servers (main bridge and external accessories)
     if (this.matterManager) {


### PR DESCRIPTION
## :recycle: Current situation

`ChildBridgeFork.shutdown()` calls `this.bridgeService.teardown()` unguarded, but `bridgeService` is only assigned once the child bridge has finished initialising. A SIGTERM in the window between the fork starting and that assignment throws `TypeError: Cannot read properties of undefined (reading 'teardown')` inside the signal handler (#3998).

## :bulb: Proposed solution

Use optional chaining, matching how `sendPairedStatusEvent` already accesses `bridgeService`. The Matter teardown directly below is already guarded the same way.

## :gear: Release Notes

Fixed a TypeError during child bridge shutdown when a termination signal arrived before the bridge finished starting.

## :heavy_plus_sign: Additional Information

Fixes #3998

### Testing

Added a spec that calls `shutdown()` on a fresh `ChildBridgeFork` and expects no throw; it fails without the fix. `npm run lint` and the existing childBridgeFork specs pass.

### Reviewer Nudging

`src/childBridgeFork.ts`, `shutdown()`.
