### PR TITLE
perf: reduce plugin discovery filesystem calls

### DIFF
--- a/src/pluginManager.spec.ts
+++ b/src/pluginManager.spec.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { HomebridgeAPI } from './api.js'
@@ -153,6 +157,39 @@ describe('pluginManager', () => {
       } finally {
         vi.doUnmock('node:child_process')
         vi.resetModules()
+      }
+    })
+  })
+
+  describe('plugin discovery', () => {
+    it('discovers direct, scoped, and linked plugin directories using directory entries', () => {
+      const searchPath = mkdtempSync(join(tmpdir(), 'homebridge-plugin-discovery-'))
+      const linkedPluginTarget = mkdtempSync(join(tmpdir(), 'homebridge-linked-plugin-'))
+
+      try {
+        mkdirSync(join(searchPath, 'homebridge-direct'))
+        mkdirSync(join(searchPath, '@example'))
+        mkdirSync(join(searchPath, '@example', 'homebridge-scoped'))
+        mkdirSync(join(searchPath, 'not-a-plugin'))
+        writeFileSync(join(searchPath, 'homebridge-file'), '')
+        symlinkSync(linkedPluginTarget, join(searchPath, 'homebridge-linked'), 'dir')
+
+        const manager = new PluginManager(new HomebridgeAPI(), {
+          customPluginPath: searchPath,
+          strictPluginResolution: true,
+        })
+        const loadPlugin = vi.spyOn(manager, 'loadPlugin').mockReturnValue({} as any)
+
+        ;(manager as any).loadInstalledPlugins()
+
+        expect(loadPlugin.mock.calls.map(([pluginPath]) => pluginPath)).toEqual([
+          join(searchPath, 'homebridge-direct'),
+          join(searchPath, 'homebridge-linked'),
+          join(searchPath, '@example', 'homebridge-scoped'),
+        ])
+      } finally {
+        rmSync(searchPath, { force: true, recursive: true })
+        rmSync(linkedPluginTarget, { force: true, recursive: true })
       }
     })
   })

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -1,3 +1,5 @@
+import type { Dirent } from 'node:fs'
+
 import type {
   AccessoryIdentifier,
   AccessoryName,
@@ -85,6 +87,30 @@ export class PluginManager {
   private readonly platformToPluginMap: Map<PlatformName, Plugin[]> = new Map()
 
   private currentInitializingPlugin?: Plugin // used to match registering plugins, see handleRegisterAccessory and handleRegisterPlatform
+
+  /**
+   * Determine whether a directory entry resolves to a directory. Dirent avoids
+   * an extra stat call for ordinary directories and files, while the fallback
+   * preserves discovery of npm-linked plugins and entries whose type is not
+   * reported by the underlying filesystem.
+   */
+  private static isDirectoryEntry(parentPath: string, entry: Dirent): boolean {
+    if (entry.isDirectory()) {
+      return true
+    }
+
+    if (entry.isFile()) {
+      return false
+    }
+
+    const absolutePath = resolve(parentPath, entry.name)
+    try {
+      return statSync(absolutePath).isDirectory()
+    } catch (error: any) {
+      log.debug(`Ignoring path ${absolutePath} - ${error.message}`)
+      return false
+    }
+  }
 
   constructor(api: HomebridgeAPI, options?: PluginManagerOptions) {
     this.api = api
@@ -380,15 +406,9 @@ export class PluginManager {
           log.warn(error.message)
         }
       } else { // read through each directory in this node_modules folder
-        let relativePluginPaths = readdirSync(searchPath) // search for directories only
-          .filter((relativePath) => {
-            try {
-              return statSync(resolve(searchPath, relativePath)).isDirectory()
-            } catch (error: any) {
-              log.debug(`Ignoring path ${resolve(searchPath, relativePath)} - ${error.message}`)
-              return false
-            }
-          })
+        let relativePluginPaths = readdirSync(searchPath, { withFileTypes: true })
+          .filter(entry => PluginManager.isDirectoryEntry(searchPath, entry))
+          .map(entry => entry.name)
 
         // expand out @scoped plugins
         const scopeDirectories = relativePluginPaths.filter(path => path.startsWith('@'))
@@ -396,17 +416,10 @@ export class PluginManager {
 
         for (const scopeDirectory of scopeDirectories) {
           const absolutePath = join(searchPath, scopeDirectory)
-          readdirSync(absolutePath)
-            .filter(name => PluginManager.isQualifiedPluginIdentifier(name))
-            .filter((name) => {
-              try {
-                return statSync(resolve(absolutePath, name)).isDirectory()
-              } catch (error: any) {
-                log.debug(`Ignoring path ${resolve(absolutePath, name)} - ${error.message}`)
-                return false
-              }
-            })
-            .forEach(name => relativePluginPaths.push(`${scopeDirectory}/${name}`))
+          readdirSync(absolutePath, { withFileTypes: true })
+            .filter(entry => PluginManager.isQualifiedPluginIdentifier(entry.name))
+            .filter(entry => PluginManager.isDirectoryEntry(absolutePath, entry))
+            .forEach(entry => relativePluginPaths.push(`${scopeDirectory}/${entry.name}`))
         }
 
         relativePluginPaths


### PR DESCRIPTION
```markdown
## :recycle: Current situation

Homebridge plugin discovery currently calls `statSync` for every entry found in each plugin search path, including entries inside npm scope directories.

This requires a separate filesystem operation for every file and directory in the scanned `node_modules` locations. The additional calls can increase startup work, particularly on systems with slow storage or large global module directories.

Plugin discovery must continue supporting symbolic links because plugins installed using `npm link` appear as symlinked directories.

## :bulb: Proposed solution

Use `readdirSync(path, { withFileTypes: true })` so the returned `Dirent` objects can identify ordinary files and directories without an additional `statSync` call.

A focused `isDirectoryEntry` helper handles directory detection:

- Ordinary directories are accepted directly from their `Dirent`.
- Ordinary files are rejected directly.
- Symbolic links and entries with an unknown filesystem type fall back to `statSync`.

The fallback preserves existing support for linked plugins and less common filesystems that do not report an entry type.

The change applies to both top-level plugin search paths and scoped npm package directories. It does not change plugin qualification, ordering, loading, or public APIs.

## :gear: Release Notes

Reduced filesystem operations during Homebridge plugin discovery, improving startup efficiency on installations with large plugin directories or slower storage.

There are no breaking changes or migration requirements.

## :heavy_plus_sign: Additional Information

This is an internal startup-path optimization. Linked plugins installed using `npm link` remain supported through the targeted `statSync` fallback.

### Testing

Added a plugin-discovery regression test covering:

- Direct Homebridge plugin directories
- Scoped Homebridge plugin directories
- Symlinked plugin directories
- Non-plugin directories
- Files whose names resemble Homebridge plugins

Existing verification results:

- Lint passes
- Build passes
- All 1,296 tests pass

The fallback error path for inaccessible or broken symbolic links is not explicitly covered by the new test, but retains the existing behavior of logging and ignoring unreadable entries.

### Reviewer Nudging

Start with `PluginManager.isDirectoryEntry`, then review the two `readdirSync` call sites in `loadInstalledPlugins`.

The main compatibility consideration is the `statSync` fallback for symbolic links and unknown entry types, which preserves `npm link` support while avoiding per-entry stats for ordinary files and directories.
```
