### PR TITLE
feat: expose RVC direct mode change capability

### DIFF
--- a/src/matter/accessoryCache.spec.ts
+++ b/src/matter/accessoryCache.spec.ts
@@ -314,6 +314,7 @@ describe('matterAccessoryCache', () => {
         UUID: 'test-uuid',
         displayName: 'Test Device',
         deviceType: { name: 'Aggregator', code: 14 } as any,
+        features: { rvcCleanMode: { directModeChange: true } },
         serialNumber: 'SN-001',
         manufacturer: 'Test',
         model: 'Test',
@@ -323,6 +324,7 @@ describe('matterAccessoryCache', () => {
             id: 'part-1',
             displayName: 'Part 1',
             deviceType: { name: 'OnOffLight', code: 256 } as any,
+            features: { rvcCleanMode: { directModeChange: true } },
             clusters: { onOff: { onOff: true } },
           },
         ],
@@ -334,8 +336,14 @@ describe('matterAccessoryCache', () => {
 
       const savedJson = mockedWriteFile.mock.calls[0][1] as string
       const savedData = JSON.parse(savedJson) as SerializedMatterAccessory[]
+      expect(savedData[0].features).toEqual({
+        rvcCleanMode: { directModeChange: true },
+      })
       expect(savedData[0].parts).toBeDefined()
       expect(savedData[0].parts![0].id).toBe('part-1')
+      expect(savedData[0].parts![0].features).toEqual({
+        rvcCleanMode: { directModeChange: true },
+      })
     })
 
     it('should ensure directory exists on first save', async () => {

--- a/src/matter/accessoryCache.ts
+++ b/src/matter/accessoryCache.ts
@@ -26,7 +26,7 @@ export interface SerializedMatterAccessoryPart {
     name?: string
     code?: number
   }
-  clusters: {
+  features?: InternalMatterAccessory['features']
     [clusterName: string]: {
       [attributeName: string]: unknown
     }
@@ -289,7 +289,7 @@ export class MatterAccessoryCache {
             name: partDeviceType?.name,
             code: partDeviceType?.code,
           },
-          clusters: structuredClone(part.clusters),
+          features: structuredClone(part.features),
         }
       })
     }
@@ -299,7 +299,7 @@ export class MatterAccessoryCache {
       platform: accessory._associatedPlatform || '',
       uuid: accessory.UUID,
       displayName: accessory.displayName,
-      deviceType: deviceTypeInfo,
+      features: structuredClone(part.features),          clusters: structuredClone(part.clusters),
       serialNumber: accessory.serialNumber,
       manufacturer: accessory.manufacturer,
       model: accessory.model,

--- a/src/matter/accessoryCache.ts
+++ b/src/matter/accessoryCache.ts
@@ -27,6 +27,7 @@ export interface SerializedMatterAccessoryPart {
     code?: number
   }
   features?: InternalMatterAccessory['features']
+  clusters: {
     [clusterName: string]: {
       [attributeName: string]: unknown
     }
@@ -46,6 +47,7 @@ export interface SerializedMatterAccessory {
     name?: string
     code?: number
   }
+  features?: InternalMatterAccessory['features']
   serialNumber: string
   manufacturer: string
   model: string
@@ -290,6 +292,7 @@ export class MatterAccessoryCache {
             code: partDeviceType?.code,
           },
           features: structuredClone(part.features),
+          clusters: structuredClone(part.clusters),
         }
       })
     }
@@ -299,7 +302,8 @@ export class MatterAccessoryCache {
       platform: accessory._associatedPlatform || '',
       uuid: accessory.UUID,
       displayName: accessory.displayName,
-      features: structuredClone(part.features),          clusters: structuredClone(part.clusters),
+      deviceType: deviceTypeInfo,
+      features: structuredClone(accessory.features),
       serialNumber: accessory.serialNumber,
       manufacturer: accessory.manufacturer,
       model: accessory.model,

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -475,7 +475,7 @@ export class MatterServer extends EventEmitter {
                 id: part.id,
                 displayName: part.displayName,
                 deviceType: typeByName.get(part.deviceType?.name ?? ''),
-                clusters: part.clusters ?? {},
+                
                 handlers: stubHandlers(part.clusters),
               }))
               .filter((part): part is typeof part & { deviceType: EndpointType } => part.deviceType !== undefined)
@@ -490,7 +490,7 @@ export class MatterServer extends EventEmitter {
               firmwareRevision: serialized.firmwareRevision,
               hardwareRevision: serialized.hardwareRevision,
               softwareVersion: serialized.softwareVersion,
-              context: serialized.context ?? {},
+              features: part.features,                clusters: part.clusters ?? {},
               clusters: serialized.clusters ?? {},
               handlers: stubHandlers(serialized.clusters),
               registered: false,

--- a/src/matter/server.ts
+++ b/src/matter/server.ts
@@ -475,7 +475,8 @@ export class MatterServer extends EventEmitter {
                 id: part.id,
                 displayName: part.displayName,
                 deviceType: typeByName.get(part.deviceType?.name ?? ''),
-                
+                features: part.features,
+                clusters: part.clusters ?? {},
                 handlers: stubHandlers(part.clusters),
               }))
               .filter((part): part is typeof part & { deviceType: EndpointType } => part.deviceType !== undefined)
@@ -490,7 +491,8 @@ export class MatterServer extends EventEmitter {
               firmwareRevision: serialized.firmwareRevision,
               hardwareRevision: serialized.hardwareRevision,
               softwareVersion: serialized.softwareVersion,
-              features: part.features,                clusters: part.clusters ?? {},
+              features: serialized.features,
+              context: serialized.context ?? {},
               clusters: serialized.clusters ?? {},
               handlers: stubHandlers(serialized.clusters),
               registered: false,

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -295,6 +295,38 @@ describe('accessoryManager', () => {
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
 
       expect((HomebridgeRvcCleanModeServer as any).with).toHaveBeenCalledWith('DirectModeChange')
+      expect(Logger.withPrefix('Matter/Server').warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('rvcCleanMode.directModeChange is declared'),
+      )
+    })
+
+    it('warns when direct clean-mode changes are declared without a change handler', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        displayName: 'Test Vacuum',
+        deviceType: createChainableDeviceType({ deviceType: 0x0074, name: 'RoboticVacuumCleaner' }),
+        clusters: {
+          rvcCleanMode: {
+            supportedModes: [{ label: 'Vacuum', mode: 0, modeTags: [{ value: 0x4000 }] }],
+            currentMode: 0,
+          },
+        },
+        handlers: {
+          rvcCleanMode: {},
+        },
+        features: {
+          rvcCleanMode: { directModeChange: true },
+        },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect(Logger.withPrefix('Matter/Server').warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'rvcCleanMode.directModeChange is declared but there is no changeToMode handler',
+        ),
+      )
+      expect((HomebridgeRvcCleanModeServer as any).with).toHaveBeenCalledWith('DirectModeChange')
     })
 
     it('leaves direct clean-mode changes disabled unless the plugin opts in', async () => {

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -461,6 +461,27 @@ describe('accessoryManager', () => {
         expect(deps.behaviorRegistry.registerHandler).toHaveBeenCalledWith('test-uuid-001', 'onOff', 'on', expect.any(Function))
       })
 
+      it('treats an omitted feature and an explicit false value as the same shape', async () => {
+        const deps = createMockDeps()
+        const restored = {
+          ...createMockAccessory({
+            features: {
+              rvcCleanMode: { directModeChange: false },
+            },
+          }),
+          endpoint: { marker: 'restored-endpoint' },
+          registered: false,
+          _restoredFromCache: true,
+        } as any
+        deps.accessories.set('test-uuid-001', restored)
+        const unregisterSpy = vi.spyOn(manager, 'unregisterAccessory')
+
+        await manager.registerAccessory('homebridge-test', 'TestPlatform', createMockAccessory(), deps)
+
+        expect(unregisterSpy).not.toHaveBeenCalled()
+        expect((deps.accessories.get('test-uuid-001') as any).endpoint).toBe(restored.endpoint)
+      })
+
       // ⚠️ The cache stores a device type as {name, code} only, so composed
       // features do not survive it - a restore rebuilds the BASE type. A plugin
       // that used api.matter.deviceRequirements to compose the cluster itself

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -6,6 +6,7 @@ import { PowerSourceServer } from '@matter/node/behaviors'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Logger } from '../../logger.js'
+import { HomebridgeRvcCleanModeServer } from '../behaviors/RvcCleanModeBehavior.js'
 import {
   applyElectricalMeasurementClusters,
   applyElectricalMeasurementDefaults,
@@ -67,7 +68,10 @@ vi.mock('../behaviors/EndpointContext.js', () => ({
   setRegistryManager: vi.fn(),
 }))
 vi.mock('../behaviors/RvcCleanModeBehavior.js', () => ({
-  HomebridgeRvcCleanModeServer: { name: 'HomebridgeRvcCleanModeServer' },
+  HomebridgeRvcCleanModeServer: {
+    name: 'HomebridgeRvcCleanModeServer',
+    with: vi.fn((...args: any[]) => ({ name: `HomebridgeRvcCleanModeServer.with(${args.join(',')})` })),
+  },
 }))
 vi.mock('../behaviors/ServiceAreaBehavior.js', () => ({
   HomebridgeServiceAreaServer: {
@@ -117,7 +121,10 @@ vi.mock('../types.js', () => {
       ThermostatDevice: { deviceType: 0x0301 },
       ElectricalSensorEndpoint: { deviceType: 0x0510 },
       RoboticVacuumCleanerRequirements: {
-        RvcCleanModeServer: { name: 'RvcCleanModeServer' },
+        RvcCleanModeServer: {
+          name: 'RvcCleanModeServer',
+          with: vi.fn((...args: any[]) => ({ name: `RvcCleanModeServer.with(${args.join(',')})` })),
+        },
         ServiceAreaServer: {
           name: 'ServiceAreaServer',
           with: vi.fn((...args: any[]) => ({ name: `ServiceAreaServer.with(${args.join(',')})` })),
@@ -264,6 +271,30 @@ describe('accessoryManager', () => {
 
       expect(deps.accessories.size).toBe(1)
       expect(deps.accessories.has('test-uuid-001')).toBe(true)
+    })
+
+    it('advertises direct clean-mode changes only when the plugin opts in', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        displayName: 'Test Vacuum',
+        deviceType: createChainableDeviceType({ deviceType: 0x0074, name: 'RoboticVacuumCleaner' }),
+        clusters: {
+          rvcCleanMode: {
+            supportedModes: [{ label: 'Vacuum', mode: 0, modeTags: [{ value: 0x4000 }] }],
+            currentMode: 0,
+          },
+        },
+        handlers: {
+          rvcCleanMode: { changeToMode: vi.fn() },
+        },
+        features: {
+          rvcCleanMode: { directModeChange: true },
+        },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect((HomebridgeRvcCleanModeServer as any).with).toHaveBeenCalledWith('DirectModeChange')
     })
 
     it('should bump the bridge configuration version when commissioned', async () => {

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -311,6 +311,33 @@ describe('accessoryManager', () => {
         handlers: {
           rvcCleanMode: { changeToMode: vi.fn() },
         },
+        features: {
+          rvcCleanMode: { directModeChange: false },
+        },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect((HomebridgeRvcCleanModeServer as any).with).not.toHaveBeenCalled()
+    })
+
+    it('does not treat a truthy non-boolean feature value as an opt-in', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        displayName: 'Test Vacuum',
+        deviceType: createChainableDeviceType({ deviceType: 0x0074, name: 'RoboticVacuumCleaner' }),
+        clusters: {
+          rvcCleanMode: {
+            supportedModes: [{ label: 'Vacuum', mode: 0, modeTags: [{ value: 0x4000 }] }],
+            currentMode: 0,
+          },
+        },
+        handlers: {
+          rvcCleanMode: { changeToMode: vi.fn() },
+        },
+        features: {
+          rvcCleanMode: { directModeChange: 'true' },
+        } as any,
       })
 
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
@@ -466,6 +493,69 @@ describe('accessoryManager', () => {
         const stored = deps.accessories.get('test-uuid-001') as any
         expect(stored.endpoint).not.toEqual({ marker: 'restored-endpoint', close: expect.anything() })
         expect(stored.registered).toBe(true)
+      })
+
+      it('re-registers when an explicit endpoint feature changes after cache restore', async () => {
+        const deps = createMockDeps()
+        const restored = {
+          ...createMockAccessory(),
+          endpoint: { marker: 'restored-endpoint', close: vi.fn() },
+          registered: false,
+          _restoredFromCache: true,
+        } as any
+        deps.accessories.set('test-uuid-001', restored)
+        const unregisterSpy = vi.spyOn(manager, 'unregisterAccessory')
+
+        const pluginAccessory = createMockAccessory({
+          features: {
+            rvcCleanMode: { directModeChange: true },
+          },
+        })
+
+        await manager.registerAccessory('homebridge-test', 'TestPlatform', pluginAccessory, deps)
+
+        expect(unregisterSpy).toHaveBeenCalledWith('test-uuid-001', deps)
+        expect((deps.accessories.get('test-uuid-001') as any).endpoint).not.toBe(restored.endpoint)
+      })
+
+      it('re-registers when a composed part feature changes after cache restore', async () => {
+        const deps = createMockDeps()
+        const part = (directModeChange?: boolean) => ({
+          id: 'vacuum-part',
+          displayName: 'Vacuum Part',
+          deviceType: createChainableDeviceType({ deviceType: 0x0074, name: 'RoboticVacuumCleaner' }),
+          features: directModeChange === undefined
+            ? undefined
+            : { rvcCleanMode: { directModeChange } },
+          clusters: {
+            rvcCleanMode: {
+              supportedModes: [{ label: 'Vacuum', mode: 0, modeTags: [{ value: 0x4000 }] }],
+              currentMode: 0,
+            },
+          },
+          handlers: {
+            rvcCleanMode: { changeToMode: vi.fn() },
+          },
+        })
+        const restoredPart = part()
+        const restored = {
+          ...createMockAccessory({ parts: [restoredPart] }),
+          endpoint: { marker: 'restored-endpoint', close: vi.fn() },
+          _parts: [restoredPart],
+          registered: false,
+          _restoredFromCache: true,
+        } as any
+        deps.accessories.set('test-uuid-001', restored)
+        const unregisterSpy = vi.spyOn(manager, 'unregisterAccessory')
+
+        const pluginAccessory = createMockAccessory({
+          parts: [part(true)],
+        } as any)
+
+        await manager.registerAccessory('homebridge-test', 'TestPlatform', pluginAccessory, deps)
+
+        expect(unregisterSpy).toHaveBeenCalledWith('test-uuid-001', deps)
+        expect((deps.accessories.get('test-uuid-001') as any).endpoint).not.toBe(restored.endpoint)
       })
 
       it('does not throw the duplicate-UUID error for a restored accessory', async () => {

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -297,6 +297,27 @@ describe('accessoryManager', () => {
       expect((HomebridgeRvcCleanModeServer as any).with).toHaveBeenCalledWith('DirectModeChange')
     })
 
+    it('leaves direct clean-mode changes disabled unless the plugin opts in', async () => {
+      const deps = createMockDeps()
+      const accessory = createMockAccessory({
+        displayName: 'Test Vacuum',
+        deviceType: createChainableDeviceType({ deviceType: 0x0074, name: 'RoboticVacuumCleaner' }),
+        clusters: {
+          rvcCleanMode: {
+            supportedModes: [{ label: 'Vacuum', mode: 0, modeTags: [{ value: 0x4000 }] }],
+            currentMode: 0,
+          },
+        },
+        handlers: {
+          rvcCleanMode: { changeToMode: vi.fn() },
+        },
+      })
+
+      await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)
+
+      expect((HomebridgeRvcCleanModeServer as any).with).not.toHaveBeenCalled()
+    })
+
     it('should bump the bridge configuration version when commissioned', async () => {
       const increaseConfigurationVersion = vi.fn()
       const deps = createMockDeps({ isCommissioned: () => true })

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -719,6 +719,11 @@ export class AccessoryManager {
           : RvcCleanModeServer
 
         if (accessory.features?.rvcCleanMode?.directModeChange === true) {
+          if (!accessory.handlers?.rvcCleanMode?.changeToMode) {
+            log.warn(
+              `[${accessory.displayName}] rvcCleanMode.directModeChange is declared but there is no changeToMode handler - controllers will offer mid-run mode changes that nothing implements`,
+            )
+          }
           behaviorClass = (behaviorClass as any).with('DirectModeChange')
           log.info('RvcCleanMode DirectModeChange feature enabled')
         }

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -133,13 +133,14 @@ export class AccessoryManager {
         const featureShape = (features?: MatterAccessory['features']) => JSON.stringify(
           Object.entries(features ?? {})
             .sort(([left], [right]) => left.localeCompare(right))
-            .map(([clusterName, clusterFeatures]) => [
+            .map(([clusterName, clusterFeatures]) => ({
               clusterName,
-              Object.entries(clusterFeatures ?? {})
+              enabledFeatures: Object.entries(clusterFeatures ?? {})
                 .filter(([, enabled]) => enabled === true)
                 .map(([featureName]) => featureName)
                 .sort(),
-            ]),
+            }))
+            .filter(({ enabledFeatures }) => enabledFeatures.length > 0),
         )
         const partShape = (list?: { id: string, features?: MatterAccessory['features'] }[]) => JSON.stringify(
           (list ?? [])

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -487,7 +487,8 @@ export class AccessoryManager {
     return {
       UUID: partEndpointId,
       displayName: part.displayName || part.id,
-      
+      deviceType: part.deviceType,
+      features: part.features,
       serialNumber: '',
       manufacturer: '',
       model: '',
@@ -696,13 +697,17 @@ export class AccessoryManager {
       const { RvcCleanModeServer, ServiceAreaServer } = devices.RoboticVacuumCleanerRequirements
 
       if (accessory.clusters?.rvcCleanMode) {
-        if (accessory.handlers?.rvcCleanMode) {
-          deviceType: part.deviceType,      features: part.features,
-          log.info('Adding custom RvcCleanMode behavior with handlers')
-        } else {
-          customBehaviors.push(accessory.features?.rvcCleanMode?.directModeChange            ? (HomebridgeRvcCleanModeServer as any).with('DirectModeChange')            : HomebridgeRvcCleanModeServer)
-          log.info('Adding base RvcCleanMode server')
+        let behaviorClass: BehaviorType = accessory.handlers?.rvcCleanMode
+          ? HomebridgeRvcCleanModeServer
+          : RvcCleanModeServer
+
+        if (accessory.features?.rvcCleanMode?.directModeChange) {
+          behaviorClass = (behaviorClass as any).with('DirectModeChange')
+          log.info('RvcCleanMode DirectModeChange feature enabled')
         }
+
+        customBehaviors.push(behaviorClass)
+        log.info(`Adding ${accessory.handlers?.rvcCleanMode ? 'custom' : 'base'} RvcCleanMode server`)
       }
 
       if (accessory.clusters?.serviceArea) {

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -487,7 +487,7 @@ export class AccessoryManager {
     return {
       UUID: partEndpointId,
       displayName: part.displayName || part.id,
-      deviceType: part.deviceType,
+      
       serialNumber: '',
       manufacturer: '',
       model: '',
@@ -697,10 +697,10 @@ export class AccessoryManager {
 
       if (accessory.clusters?.rvcCleanMode) {
         if (accessory.handlers?.rvcCleanMode) {
-          customBehaviors.push(HomebridgeRvcCleanModeServer)
+          deviceType: part.deviceType,      features: part.features,
           log.info('Adding custom RvcCleanMode behavior with handlers')
         } else {
-          customBehaviors.push(RvcCleanModeServer)
+          customBehaviors.push(accessory.features?.rvcCleanMode?.directModeChange            ? (HomebridgeRvcCleanModeServer as any).with('DirectModeChange')            : HomebridgeRvcCleanModeServer)
           log.info('Adding base RvcCleanMode server')
         }
       }

--- a/src/matter/server/AccessoryManager.ts
+++ b/src/matter/server/AccessoryManager.ts
@@ -130,7 +130,22 @@ export class AccessoryManager {
       // churns); the plugin's registration attaches its handlers and metadata
       // in place. Structural changes fall through to a fresh registration.
       if (existing?._restoredFromCache) {
-        const partIds = (list?: { id: string }[]) => JSON.stringify((list ?? []).map(part => part.id).sort())
+        const featureShape = (features?: MatterAccessory['features']) => JSON.stringify(
+          Object.entries(features ?? {})
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([clusterName, clusterFeatures]) => [
+              clusterName,
+              Object.entries(clusterFeatures ?? {})
+                .filter(([, enabled]) => enabled === true)
+                .map(([featureName]) => featureName)
+                .sort(),
+            ]),
+        )
+        const partShape = (list?: { id: string, features?: MatterAccessory['features'] }[]) => JSON.stringify(
+          (list ?? [])
+            .map(part => ({ id: part.id, features: featureShape(part.features) }))
+            .sort((left, right) => left.id.localeCompare(right.id)),
+        )
         // ⚠️ The name is not enough. The cache stores a device type as
         // {name, code}, so a restore rebuilds the BASE type - anything the
         // plugin composed itself (via api.matter.deviceRequirements) is gone,
@@ -141,7 +156,8 @@ export class AccessoryManager {
         const behaviorKeys = (deviceType: unknown) =>
           Object.keys((deviceType as { behaviors?: Record<string, unknown> })?.behaviors ?? {}).sort().join(',')
         const sameShape = (existing.deviceType as { name?: string })?.name === (accessory.deviceType as { name?: string })?.name
-          && partIds(existing._parts ?? existing.parts) === partIds(accessory.parts)
+          && partShape(existing._parts ?? existing.parts) === partShape(accessory.parts)
+          && featureShape(existing.features) === featureShape(accessory.features)
           && behaviorKeys(existing.deviceType) === behaviorKeys(accessory.deviceType)
         if (sameShape) {
           log.info(`Attached plugin registration to restored accessory ${accessory.displayName} (${accessory.UUID})`)
@@ -701,7 +717,7 @@ export class AccessoryManager {
           ? HomebridgeRvcCleanModeServer
           : RvcCleanModeServer
 
-        if (accessory.features?.rvcCleanMode?.directModeChange) {
+        if (accessory.features?.rvcCleanMode?.directModeChange === true) {
           behaviorClass = (behaviorClass as any).with('DirectModeChange')
           log.info('RvcCleanMode DirectModeChange feature enabled')
         }

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -469,7 +469,7 @@ export interface InternalMatterAccessory extends MatterAccessory {
    * True while this accessory was rebuilt from the accessory cache at startup
    * and its plugin has not re-registered yet. The plugin's registration
    * attaches handlers to the existing endpoint instead of erroring.
-   */
+   *
   _restoredFromCache?: boolean
 
   /** Platform name (set when registered) */

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -93,10 +93,6 @@ type BehaviorType = Behavior.Type
 export type { EndpointType }
 
 /**
- * Handler context information
- * Provides information about which part of a composed device triggered the handler
- */
-/**
  * Optional Matter cluster features a plugin can explicitly advertise.
  *
  * Features are capabilities, not cluster state. Only enable a feature when the
@@ -109,6 +105,10 @@ export interface MatterAccessoryFeatures {
   }
 }
 
+/**
+ * Handler context information
+ * Provides information about which part of a composed device triggered the handler
+ */
 export interface MatterHandlerContext {
   /** Parent accessory UUID */
   uuid: string

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -96,7 +96,7 @@ export type { EndpointType }
  * Handler context information
  * Provides information about which part of a composed device triggered the handler
  */
-export interface MatterHandlerContext {
+
   /** Parent accessory UUID */
   uuid: string
 
@@ -141,7 +141,7 @@ export interface MatterAccessoryPart {
   displayName?: string
 
   /** Matter device type for this part */
-  deviceType: EndpointType
+  /** * Optional Matter cluster features a plugin can explicitly advertise. * * Features are capabilities, not cluster state. Only enable a feature when the * physical device and the plugin handler implement the corresponding behavior. */export interface MatterAccessoryFeatures {  rvcCleanMode?: {    /** Allow clean-mode changes while the RVC is not idle. */    directModeChange?: boolean  }}export interface MatterHandlerContext {
 
   /**
    * Initial cluster states for this part
@@ -185,7 +185,7 @@ export interface MatterAccessory<T extends UnknownContext = UnknownContext> {
   displayName: string
 
   /** Matter device type (e.g., OnOffLightDevice, DimmableLightDevice, etc.) */
-  deviceType: EndpointType
+  /** * Optional Matter cluster features a plugin can explicitly advertise. * * Features are capabilities, not cluster state. Only enable a feature when the * physical device and the plugin handler implement the corresponding behavior. */export interface MatterAccessoryFeatures {  rvcCleanMode?: {    /** Allow clean-mode changes while the RVC is not idle. */    directModeChange?: boolean  }}export interface MatterHandlerContext {
 
   /** Serial number for the device */
   serialNumber: string
@@ -470,7 +470,7 @@ export interface InternalMatterAccessory extends MatterAccessory {
    * and its plugin has not re-registered yet. The plugin's registration
    * attaches handlers to the existing endpoint instead of erroring.
    *
-  _restoredFromCache?: boolean
+  deviceType: EndpointType  /** Optional Matter cluster features implemented by this endpoint. */  features?: MatterAccessoryFeatures
 
   /** Platform name (set when registered) */
   _associatedPlatform?: string

--- a/src/matter/types.ts
+++ b/src/matter/types.ts
@@ -96,7 +96,20 @@ export type { EndpointType }
  * Handler context information
  * Provides information about which part of a composed device triggered the handler
  */
+/**
+ * Optional Matter cluster features a plugin can explicitly advertise.
+ *
+ * Features are capabilities, not cluster state. Only enable a feature when the
+ * physical device and the plugin handler implement the corresponding behavior.
+ */
+export interface MatterAccessoryFeatures {
+  rvcCleanMode?: {
+    /** Allow clean-mode changes while the RVC is not idle. */
+    directModeChange?: boolean
+  }
+}
 
+export interface MatterHandlerContext {
   /** Parent accessory UUID */
   uuid: string
 
@@ -141,7 +154,10 @@ export interface MatterAccessoryPart {
   displayName?: string
 
   /** Matter device type for this part */
-  /** * Optional Matter cluster features a plugin can explicitly advertise. * * Features are capabilities, not cluster state. Only enable a feature when the * physical device and the plugin handler implement the corresponding behavior. */export interface MatterAccessoryFeatures {  rvcCleanMode?: {    /** Allow clean-mode changes while the RVC is not idle. */    directModeChange?: boolean  }}export interface MatterHandlerContext {
+  deviceType: EndpointType
+
+  /** Optional Matter cluster features implemented by this endpoint. */
+  features?: MatterAccessoryFeatures
 
   /**
    * Initial cluster states for this part
@@ -185,7 +201,10 @@ export interface MatterAccessory<T extends UnknownContext = UnknownContext> {
   displayName: string
 
   /** Matter device type (e.g., OnOffLightDevice, DimmableLightDevice, etc.) */
-  /** * Optional Matter cluster features a plugin can explicitly advertise. * * Features are capabilities, not cluster state. Only enable a feature when the * physical device and the plugin handler implement the corresponding behavior. */export interface MatterAccessoryFeatures {  rvcCleanMode?: {    /** Allow clean-mode changes while the RVC is not idle. */    directModeChange?: boolean  }}export interface MatterHandlerContext {
+  deviceType: EndpointType
+
+  /** Optional Matter cluster features implemented by this endpoint. */
+  features?: MatterAccessoryFeatures
 
   /** Serial number for the device */
   serialNumber: string
@@ -469,8 +488,8 @@ export interface InternalMatterAccessory extends MatterAccessory {
    * True while this accessory was rebuilt from the accessory cache at startup
    * and its plugin has not re-registered yet. The plugin's registration
    * attaches handlers to the existing endpoint instead of erroring.
-   *
-  deviceType: EndpointType  /** Optional Matter cluster features implemented by this endpoint. */  features?: MatterAccessoryFeatures
+   */
+  _restoredFromCache?: boolean
 
   /** Platform name (set when registered) */
   _associatedPlatform?: string


### PR DESCRIPTION
## Summary

- add an explicit per-accessory RVC Clean Mode feature declaration
- compose the standard Matter `DirectModeChange` feature only when a plugin explicitly opts in
- persist and restore feature metadata for root accessories and composed parts
- rebuild cached endpoints immediately when an enabled feature changes
- cover opt-in, default-disabled, runtime validation, cache persistence, and restart transitions

## Why

Matter RVC Clean Mode defines `DirectModeChange` for vacuums that can change clean mode while the RVC is not idle. Homebridge currently has no plugin API for advertising that capability, so controllers may disable the mode picker during an active run even when the physical robot and its plugin support live changes.

Handlers alone do not prove that a device can change modes while running, so this remains an explicit capability rather than being inferred.

## Plugin API

A compatible plugin opts in on the accessory:

```ts
features: {
  rvcCleanMode: {
    directModeChange: true,
  },
},
```

Only the literal boolean `true` enables the feature. Accessories that omit the declaration or set it to `false` retain the existing behavior.

## Persistence and restart behavior

Feature metadata is cached and restored for both root accessories and composed parts so the endpoint is rebuilt with the same Matter feature set before its plugin re-registers after a restart.

Enabled feature declarations are also part of Homebridge's restored-endpoint shape comparison. If a plugin adds or removes a feature, Homebridge rebuilds the endpoint during that same startup instead of retaining a stale endpoint until a later restart. Omitted and explicitly disabled features are normalized as the same shape to avoid unnecessary endpoint churn.

## Validation

- branch is current with `homebridge:latest`
- positive coverage verifies that opting in composes `DirectModeChange`
- negative coverage verifies that the feature remains disabled by default and for non-boolean runtime values
- cache coverage verifies feature persistence for root accessories and composed parts
- restart coverage verifies that changed features rebuild endpoints and equivalent disabled declarations do not
- dependent plugin draft: mathiashornbek/homebridge-roborock-matter#18
- the dependent plugin's existing CI matrix is green

The full Homebridge workflow matrix is awaiting maintainer approval because this PR originates from a fork.