### PR TITLE
perf: index accessory operations

### DIFF
--- a/src/bridgeService.spec.ts
+++ b/src/bridgeService.spec.ts
@@ -162,6 +162,20 @@ describe('bridgeService', () => {
       expect(warnedAboutDuplicate).toBe(true)
     })
 
+    it('skips duplicate UUIDs within the same registration batch', () => {
+      const service = new BridgeService(api, pluginManager, externalPortService, makeBridgeOptions(), makeBridgeConfig())
+      const addBridgedAccessoriesSpy = vi.spyOn(service.bridge, 'addBridgedAccessories').mockImplementation(() => {})
+      const original = makePlatformAccessory('Original')
+      const duplicate = makePlatformAccessory('Duplicate')
+      ;(duplicate as any)._associatedHAPAccessory.UUID = original._associatedHAPAccessory.UUID
+      ;(duplicate as any).UUID = original._associatedHAPAccessory.UUID
+
+      service.handleRegisterPlatformAccessories([original, duplicate])
+
+      expect(addBridgedAccessoriesSpy.mock.calls[0][0]).toEqual([original._associatedHAPAccessory])
+      expect((service as any).cachedPlatformAccessories).toEqual([original])
+    })
+
     it('warns when the registering plugin is not loaded', () => {
       const warnSpy = vi.spyOn(Logger.internal, 'warn').mockImplementation(() => {})
       pluginManager.getPlugin.mockReturnValue(undefined)

--- a/src/bridgeService.ts
+++ b/src/bridgeService.ts
@@ -592,13 +592,19 @@ export class BridgeService {
       log.debug(`HAP externalsOnly mode: ${accessories.length} bridged accessor${accessories.length === 1 ? 'y' : 'ies'} registered to this bridge will not be advertised (only external accessories publish).`)
     }
 
-    const hapAccessories = accessories.map((accessory) => {
+    const cachedAccessories = new Map(
+      this.cachedPlatformAccessories.map(accessory => [accessory._associatedHAPAccessory.UUID, accessory]),
+    )
+    const bridgedAccessories = new Map(
+      this.bridge.bridgedAccessories.map(accessory => [accessory.UUID, accessory]),
+    )
+    const hapAccessories: Accessory[] = []
+
+    for (const accessory of accessories) {
       const newUUID = accessory._associatedHAPAccessory.UUID
 
       // Check for UUID collision against already-cached platform accessories.
-      const cachedCollision = this.cachedPlatformAccessories.find(
-        cached => cached._associatedHAPAccessory.UUID === newUUID,
-      )
+      const cachedCollision = cachedAccessories.get(newUUID)
       if (cachedCollision) {
         log.warn(
           'Accessory \'%s\' has the same UUID as existing accessory \'%s\' (UUID: %s). Skipping duplicate.',
@@ -606,7 +612,7 @@ export class BridgeService {
           cachedCollision.displayName,
           newUUID,
         )
-        return undefined
+        continue
       }
 
       // Also check against accessories that came in via the legacy
@@ -614,9 +620,7 @@ export class BridgeService {
       // bridge, not in cachedPlatformAccessories. Without this check the
       // collision would only surface as a hard throw deep inside HAP-NodeJS
       // at addBridgedAccessories time.
-      const bridgedCollision = this.bridge.bridgedAccessories.find(
-        bridged => bridged.UUID === newUUID,
-      )
+      const bridgedCollision = bridgedAccessories.get(newUUID)
       if (bridgedCollision) {
         log.warn(
           'Accessory \'%s\' has the same UUID as existing bridged accessory \'%s\' (UUID: %s). Skipping duplicate.',
@@ -624,10 +628,11 @@ export class BridgeService {
           bridgedCollision.displayName,
           newUUID,
         )
-        return undefined
+        continue
       }
 
       this.cachedPlatformAccessories.push(accessory)
+      cachedAccessories.set(newUUID, accessory)
 
       const plugin = this.pluginManager.getPlugin(accessory._associatedPlugin!)
       if (plugin) {
@@ -642,8 +647,8 @@ export class BridgeService {
         log.warn('A platform configured a new accessory under the plugin name \'%s\'. However no loaded plugin could be found for the name!', accessory._associatedPlugin)
       }
 
-      return accessory._associatedHAPAccessory
-    }).filter((hapAccessory): hapAccessory is Accessory => hapAccessory !== undefined)
+      hapAccessories.push(accessory._associatedHAPAccessory)
+    }
 
     this.bridge.addBridgedAccessories(hapAccessories)
     this.saveCachedPlatformAccessoriesOnDisk()
@@ -655,27 +660,22 @@ export class BridgeService {
       return
     }
 
-    const nonUpdatedPlugins = this.cachedPlatformAccessories.filter(
-      cachedPlatformAccessory => (
-        !accessories.some(accessory => accessory.UUID === cachedPlatformAccessory._associatedHAPAccessory.UUID)
-      ),
+    const updatedUUIDs = new Set(accessories.map(accessory => accessory.UUID))
+    this.cachedPlatformAccessories = this.cachedPlatformAccessories.filter(
+      accessory => !updatedUUIDs.has(accessory._associatedHAPAccessory.UUID),
     )
-
-    this.cachedPlatformAccessories = [...nonUpdatedPlugins, ...accessories]
+    this.cachedPlatformAccessories.push(...accessories)
 
     // Update persisted accessories
     this.saveCachedPlatformAccessoriesOnDisk()
   }
 
   handleUnregisterPlatformAccessories(accessories: PlatformAccessory[]): void {
-    const hapAccessories = accessories.map((accessory) => {
-      const index = this.cachedPlatformAccessories.indexOf(accessory)
-      if (index >= 0) {
-        this.cachedPlatformAccessories.splice(index, 1)
-      }
-
-      return accessory._associatedHAPAccessory
-    })
+    const removedAccessories = new Set(accessories)
+    this.cachedPlatformAccessories = this.cachedPlatformAccessories.filter(
+      accessory => !removedAccessories.has(accessory),
+    )
+    const hapAccessories = accessories.map(accessory => accessory._associatedHAPAccessory)
 
     this.bridge.removeBridgedAccessories(hapAccessories)
     this.saveCachedPlatformAccessoriesOnDisk()


### PR DESCRIPTION
## :recycle: Current situation

Platform accessory registration performs linear searches through the cached and bridged accessory arrays for every incoming accessory.

As accepted accessories are added to the cache during registration, the repeated searches can produce quadratic behavior for large batches.

Accessory updates similarly combine `filter()` and `some()`, while unregistration repeatedly uses `indexOf()` and `splice()`.

## :bulb: Proposed solution

Index the existing cached and bridged accessories by UUID before processing a registration batch.

The cached UUID map is updated whenever an accessory is accepted, preserving duplicate detection within the same batch.

Updates use a UUID `Set` for membership checks, and unregistration uses an identity `Set` to preserve its existing behavior while filtering the cache once.

This changes the affected operations from quadratic to linear complexity:

- Registration: `O(existing + bridged + incoming)`
- Update: `O(cached + updated)`
- Unregistration: `O(cached + removed)`

The implementation remains inline and introduces no helpers, abstractions, public API changes, or persistent indexes.

## :gear: Release Notes

Improved platform accessory registration, update, and removal performance for bridges handling large accessory collections.

There are no breaking changes or migration requirements.

## :heavy_plus_sign: Additional Information

An indicative algorithm benchmark on the development machine produced:

| Incoming accessories | Repeated scans | UUID map |
|---:|---:|---:|
| 1,000 | 10.08 ms | 0.27 ms |
| 5,000 | 205.96 ms | 1.16 ms |
| 10,000 | 430.39 ms | 1.46 ms |

These figures isolate the lookup algorithms and are not complete Homebridge startup benchmarks.

### Testing

Added a regression test confirming that duplicate UUIDs within the same registration batch are still rejected after replacing repeated array searches with maps.

Verification:

- 72 focused `bridgeService` tests pass
- All 1,297 repository tests pass
- Build passes
- Lint passes

Existing tests continue covering:

- Duplicate UUIDs across separate registration calls
- Collisions with legacy bridged accessories
- Accessory replacement by UUID
- Accessory unregistration

### Reviewer Nudging

Start with the three methods in `BridgeService`:

- `handleRegisterPlatformAccessories`
- `handleUpdatePlatformAccessories`
- `handleUnregisterPlatformAccessories`

The main correctness detail is updating the cached UUID map immediately after accepting an accessory. This ensures another accessory with the same UUID later in the same batch is rejected.
