### PR TITLE
perf: remove shell from npm prefix lookup

### DIFF
--- a/src/pluginManager.spec.ts
+++ b/src/pluginManager.spec.ts
@@ -107,15 +107,14 @@ describe('pluginManager', () => {
 
   describe('addNpmPrefixToSearchPaths env composition (POSIX)', () => {
     it('passes process.env first then overrides the silencing keys', async () => {
-      // Smoke through a fresh module import so we can intercept execSync.
+      // Smoke through a fresh module import so we can intercept execFileSync.
       vi.resetModules()
-      const { Buffer } = await import('node:buffer')
-      const execMock = vi.fn(() => Buffer.from('/usr/local/lib/node_modules', 'utf8'))
+      const execMock = vi.fn(() => '/usr/local\n')
       // The bare vi.fn() infers a zero-arg call signature, so mock.calls is
-      // typed as empty tuples. Cast to the (command, options) shape we actually
-      // invoke execSync with so the assertions below can read calls[0][1].env.
-      type ExecSyncCall = [command: string, options: { env: Record<string, string | undefined> }]
-      vi.doMock('node:child_process', () => ({ execSync: execMock }))
+      // typed as empty tuples. Cast to the (file, arguments, options) shape we actually
+      // invoke execFileSync with so the assertions below can inspect its environment.
+      type ExecFileSyncCall = [file: string, args: string[], options: { env: Record<string, string | undefined> }]
+      vi.doMock('node:child_process', () => ({ execFileSync: execMock }))
 
       try {
         const { PluginManager: FreshPM } = await import('./pluginManager.js')
@@ -131,8 +130,9 @@ describe('pluginManager', () => {
         }
         ;(manager as any).addNpmPrefixToSearchPaths()
 
-        expect(execMock).toHaveBeenCalled()
-        const env = (execMock.mock.calls as unknown as ExecSyncCall[])[0][1].env
+        expect(execMock).toHaveBeenCalledWith('npm', ['-g', 'prefix'], expect.objectContaining({ encoding: 'utf8' }))
+        expect((manager as any).searchPaths.has('/usr/local/lib/node_modules')).toBe(true)
+        const env = (execMock.mock.calls as unknown as ExecFileSyncCall[])[0][2].env
 
         // process.env values must come through, but the silencing keys must
         // win even when the user exported a noisy value.
@@ -148,7 +148,7 @@ describe('pluginManager', () => {
           process.env = { ...originalEnv, npm_config_loglevel: 'info', PATH: '/custom/path' } as any
           execMock.mockClear()
           ;(manager as any).addNpmPrefixToSearchPaths()
-          const env2 = (execMock.mock.calls as unknown as ExecSyncCall[])[0][1].env
+          const env2 = (execMock.mock.calls as unknown as ExecFileSyncCall[])[0][2].env
           expect(env2.PATH).toBe('/custom/path') // user value preserved
           expect(env2.npm_config_loglevel).toBe('silent') // user value overridden
         } finally {

--- a/src/pluginManager.ts
+++ b/src/pluginManager.ts
@@ -12,7 +12,7 @@ import type {
   PluginName,
 } from './api.js'
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { delimiter, join, resolve } from 'node:path'
@@ -531,13 +531,15 @@ export class PluginManager {
       // Spread process.env first so our explicit silencing keys actually
       // override anything the user has exported (e.g. npm_config_loglevel=info)
       // — otherwise startup gets noisy npm output we tried to suppress.
-      this.searchPaths.add(execSync('/bin/echo -n "$(npm -g prefix)/lib/node_modules"', {
+      const npmPrefix = execFileSync('npm', ['-g', 'prefix'], {
+        encoding: 'utf8',
         env: {
           ...process.env,
           npm_config_loglevel: 'silent',
           npm_update_notifier: 'false',
         },
-      }).toString('utf8'))
+      }).trim()
+      this.searchPaths.add(join(npmPrefix, 'lib', 'node_modules'))
     }
   }
 }


### PR DESCRIPTION
## :recycle: Current situation

Homebridge locates the global npm modules directory on POSIX systems using a synchronous shell command:
```sh
/bin/echo -n "$(npm -g prefix)/lib/node_modules"
```

This launches a shell to perform command substitution and path construction, even though Homebridge only needs to execute npm with a fixed argument list.
The command contains no user-controlled arguments, so this is not a direct command-injection vulnerability. However, the shell invocation adds unnecessary parsing, process overhead, quoting, and platform assumptions to the startup path.

:bulb: Proposed solution

Execute npm directly using:
```
execFileSync('npm', ['-g', 'prefix'])
```

The returned prefix is trimmed and the global module path is constructed with Node's path.join.
This:
- Avoids shell parsing and command substitution
- Uses an explicit executable and argument vector
- Constructs paths using Node's platform-aware path utilities
- Preserves existing npm logging and update-notifier environment overrides
- Introduces no helpers or public API changes
Windows behavior remains unchanged.

:gear: Release Notes
Simplified and slightly reduced the startup work used to locate globally installed Homebridge plugins on POSIX systems.
There are no breaking changes or migration requirements.

:heavy_plus_sign: Additional Information
A local ten-run comparison measured:
- Direct execFileSync: approximately 45.99 ms
- Existing shell command: approximately 50.84 ms
- Difference: approximately 4.85 ms
The primary benefit is simpler and safer process execution rather than a significant startup-time reduction. npm process startup remains the dominant cost.
Testing
Adapted the existing npm-prefix test to verify:
- npm is invoked directly
- The exact -g prefix argument vector is used
- No trailing newline enters the search path
- /lib/node_modules is constructed correctly
- Existing process environment variables are preserved
- Homebridge's npm logging overrides take precedence
Verification:
- All 19 focused plugin-manager tests pass
- All 1,296 repository tests pass
- Build passes
- Lint passes
The repository-wide typecheck retains the same six unrelated pre-existing test-source errors.
Reviewer Nudging
Start with PluginManager.addNpmPrefixToSearchPaths.
The main points are the replacement of execSync with execFileSync, trimming npm's output, and constructing the final path with path.join.
