### PR TITLE
test: restore and enforce type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint-docs": "typedoc --emit none --treatWarningsAsErrors",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",
+    "pretest": "npm run typecheck",
     "test": "vitest run",
     "test-coverage": "npm run test -- --coverage",
     "typecheck": "tsc -p tsconfig.typecheck.json",

--- a/src/matter/behaviors/EndpointContext.ts
+++ b/src/matter/behaviors/EndpointContext.ts
@@ -16,9 +16,9 @@ import type { RegistryManager } from './RegistryManager.js'
 const REGISTRY_MANAGER_KEY = Symbol('homebridgeRegistryManager')
 
 /**
- * Extended Endpoint interface with Homebridge context
+ * Minimal endpoint surface used to store Homebridge context.
  */
-export interface EndpointWithContext extends Endpoint {
+export type EndpointWithContext = Pick<Endpoint, 'id'> & {
   [REGISTRY_MANAGER_KEY]?: RegistryManager
 }
 
@@ -26,16 +26,16 @@ export interface EndpointWithContext extends Endpoint {
  * Attach a RegistryManager to an endpoint.
  * Behaviors can then access their registry via this endpoint context.
  */
-export function setRegistryManager(endpoint: Endpoint, registryManager: RegistryManager): void {
-  (endpoint as EndpointWithContext)[REGISTRY_MANAGER_KEY] = registryManager
+export function setRegistryManager(endpoint: EndpointWithContext, registryManager: RegistryManager): void {
+  endpoint[REGISTRY_MANAGER_KEY] = registryManager
 }
 
 /**
  * Get the RegistryManager attached to an endpoint
  * Throws if no RegistryManager is attached (programming error)
  */
-export function getRegistryManager(endpoint: Endpoint): RegistryManager {
-  const registryManager = (endpoint as EndpointWithContext)[REGISTRY_MANAGER_KEY]
+export function getRegistryManager(endpoint: EndpointWithContext): RegistryManager {
+  const registryManager = endpoint[REGISTRY_MANAGER_KEY]
   if (!registryManager) {
     throw new Error(`No RegistryManager attached to endpoint ${endpoint.id}. This is a programming error.`)
   }

--- a/src/matter/server/AccessoryManager.spec.ts
+++ b/src/matter/server/AccessoryManager.spec.ts
@@ -636,7 +636,7 @@ describe('accessoryManager', () => {
           behaviors: { windowCovering: {} },
         }),
         clusters: wcClusters,
-        handlers: { windowCovering: { upOrOpenLogic: vi.fn() } },
+        handlers: { windowCovering: { upOrOpen: vi.fn() } },
       })
 
       await manager.registerAccessory('homebridge-test', 'TestPlatform', accessory, deps)

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -711,10 +711,11 @@ describe('server', () => {
       }
 
       function notFoundResponses(sendSpy: ReturnType<typeof vi.spyOn>) {
-        return sendSpy.mock.calls.filter(([id, payload]) =>
+        interface MatterEventPayload { type?: string, data?: { error?: string } }
+        return (sendSpy.mock.calls as [string, MatterEventPayload][]).filter(([id, payload]) =>
           id === 'matterEvent'
-          && (payload as any)?.type === 'accessoryControlResponse'
-          && (payload as any)?.data?.error === 'Accessory not found',
+          && payload?.type === 'accessoryControlResponse'
+          && payload?.data?.error === 'Accessory not found',
         )
       }
 


### PR DESCRIPTION
## :recycle: Current situation

Homebridge provides an `npm run typecheck` command, but it currently reports six errors in test sources:

- Three lightweight Matter endpoint fixtures do not satisfy the complete Matter `Endpoint` type.
- A window-covering fixture uses the stale `upOrOpenLogic` handler name.
- An IPC spy callback implicitly assigns `any` to its destructured arguments.

Production builds still succeed because test files are excluded from the production TypeScript configuration.

The existing shared CI workflow runs build and tests but does not invoke the repository's separate typecheck command. This allows test-source type errors and API drift to reach `latest`.

## :bulb: Proposed solution

Restore a clean repository-wide typecheck and connect it to the existing test lifecycle.

Changes include:

- Narrow `EndpointWithContext` to the endpoint surface actually required by the registry context: the endpoint ID and optional registry symbol.
- Use that minimal type directly in `setRegistryManager` and `getRegistryManager`, removing unnecessary assertions.
- Replace the stale `upOrOpenLogic` fixture with the current `upOrOpen` handler.
- Give the mocked Matter IPC payload an explicit local interface.
- Add a `pretest` script that runs `npm run typecheck`.

Using `pretest` means existing local and CI test commands enforce type safety automatically without introducing another CI job or dependency installation.

## :gear: Release Notes

Improved development and CI validation by checking test-source TypeScript before running the test suite.

There are no runtime, public API or migration changes.

## :heavy_plus_sign: Additional Information

The endpoint context previously required the complete Matter endpoint type even though it only stores and reads a registry symbol and uses the endpoint ID in error messages.

Narrowing this type fixes the test fixtures at the actual boundary instead of casting incomplete objects to full Matter endpoints.

### Testing

Verification completed:

- `npm run typecheck` passes
- `npm run lint` passes
- `npm run build` passes
- `npm test` automatically runs the new `pretest` typecheck
- All 60 test files pass
- All 1,296 tests pass

No new runtime tests were necessary. Existing fixtures were corrected and continue exercising the same behavior.

### Reviewer Nudging

Start with `EndpointContext.ts`, where `EndpointWithContext` now describes the minimal endpoint surface required by the registry context.

Then review:

- The corrected window-covering handler fixture
- The typed IPC spy payload
- The `pretest` entry in `package.json`