### PR TITLE
fix: validate stored Matter credentials

### DIFF
--- a/src/matter/server/CommissioningManager.spec.ts
+++ b/src/matter/server/CommissioningManager.spec.ts
@@ -139,13 +139,24 @@ describe('commissioningManager', () => {
 
   describe('loadOrGenerateCredentials', () => {
     it('should load existing credentials from file', async () => {
-      const credentials = { passcode: 12345678, discriminator: 1234 }
+      const credentials = { passcode: 29384756, discriminator: 1234 }
       mockedReadFile.mockResolvedValue(JSON.stringify(credentials) as any)
 
       await manager.loadOrGenerateCredentials('/mock/storage')
 
-      expect(manager.passcode).toBe(12345678)
+      expect(manager.passcode).toBe(29384756)
       expect(manager.discriminator).toBe(1234)
+      expect(mockedWriteFile).not.toHaveBeenCalled()
+    })
+
+    it('should load a valid zero discriminator', async () => {
+      const credentials = { passcode: 29384756, discriminator: 0 }
+      mockedReadFile.mockResolvedValue(JSON.stringify(credentials) as any)
+
+      await manager.loadOrGenerateCredentials('/mock/storage')
+
+      expect(manager.passcode).toBe(29384756)
+      expect(manager.discriminator).toBe(0)
       expect(mockedWriteFile).not.toHaveBeenCalled()
     })
 
@@ -183,6 +194,27 @@ describe('commissioningManager', () => {
       await manager.loadOrGenerateCredentials('/mock/storage')
 
       // Should generate new because discriminator is missing
+      expect(mockedWriteFile).toHaveBeenCalled()
+    })
+
+    it.each([
+      ['an invalid passcode', { passcode: 12345678, discriminator: 1234 }],
+      ['a string passcode', { passcode: '29384756', discriminator: 1234 }],
+      ['a fractional passcode', { passcode: 29384756.5, discriminator: 1234 }],
+      ['a negative discriminator', { passcode: 29384756, discriminator: -1 }],
+      ['an oversized discriminator', { passcode: 29384756, discriminator: 4096 }],
+      ['a fractional discriminator', { passcode: 29384756, discriminator: 1.5 }],
+      ['a string discriminator', { passcode: 29384756, discriminator: '1234' }],
+    ])('should regenerate credentials containing %s', async (_description, credentials) => {
+      mockedReadFile.mockResolvedValue(JSON.stringify(credentials) as any)
+      mockedWriteFile.mockResolvedValue(undefined)
+      vi.spyOn(manager, 'generateSecurePasscode').mockReturnValue(50213467)
+      vi.spyOn(manager, 'generateRandomDiscriminator').mockReturnValue(432)
+
+      await manager.loadOrGenerateCredentials('/mock/storage')
+
+      expect(manager.passcode).toBe(50213467)
+      expect(manager.discriminator).toBe(432)
       expect(mockedWriteFile).toHaveBeenCalled()
     })
   })

--- a/src/matter/server/CommissioningManager.ts
+++ b/src/matter/server/CommissioningManager.ts
@@ -188,7 +188,13 @@ export class CommissioningManager {
     try {
       const { readFile } = await import('node:fs/promises')
       const data = JSON.parse(await readFile(credentialsPath, 'utf-8'))
-      if (data.passcode && data.discriminator) {
+      if (
+        Number.isInteger(data.passcode)
+        && this.isValidPasscode(data.passcode)
+        && Number.isInteger(data.discriminator)
+        && data.discriminator >= 0
+        && data.discriminator <= 4095
+      ) {
         log.info('Loading existing commissioning credentials from storage')
         this.passcode = data.passcode
         this.discriminator = data.discriminator


### PR DESCRIPTION
# :recycle: Current situation

Persisted Matter commissioning credentials are currently accepted using truthiness checks:

```ts
if (data.passcode && data.discriminator) {
  this.passcode = data.passcode
  this.discriminator = data.discriminator
}
```

This causes two problems:
1. A discriminator of 0 is valid under the Matter specification but is falsy in JavaScript. Homebridge therefore discards valid stored credentials and generates replacements after restart. Because discriminators are 12-bit values, this can affect approximately one in every 4,096 generated configurations.
2. Persisted values are not validated before use. Strings, fractional values, out-of-range discriminators and invalid Matter passcodes can be accepted if they are truthy.
This differs from newly generated credentials, where Homebridge already validates passcodes and constrains discriminators to the 12-bit range.

# :bulb: Proposed solution
Replace the truthiness check with explicit credential validation.
A stored credential pair is loaded only when:
- The passcode is an integer.
- The passcode passes the existing isValidPasscode() validation.
- The discriminator is an integer.
- The discriminator is between 0 and 4095, inclusive.
If either value is invalid, Homebridge follows its existing recovery path and generates a new valid credential pair.
No new validation helpers or persistence formats are introduced. The change reuses the existing passcode validator and aligns persisted credential validation with credential generation.

# :gear: Release Notes
Fixed Matter commissioning credentials being regenerated after restart when their valid discriminator was zero.
Homebridge now also rejects malformed or out-of-range stored Matter commissioning credentials and replaces them with valid values.
There are no breaking changes or migration requirements. Existing valid credentials continue to load unchanged.
# :heavy_plus_sign: Additional Information
The credential file format remains unchanged:
{
  "passcode": 29384756,
  "discriminator": 1234
}
Only validation of the stored values has changed.
A persisted credential pair is regenerated if it contains values that Homebridge could not validly generate itself.
Testing
Updated the existing valid-credential fixture to use a passcode accepted by the existing Matter passcode validator.
Added coverage for:
- Loading an ordinary valid credential pair
- Loading a valid discriminator of zero
- Rejecting an invalid Matter passcode
- Rejecting a string passcode
- Rejecting a fractional passcode
- Rejecting a negative discriminator
- Rejecting a discriminator above 4095
- Rejecting a fractional discriminator
- Rejecting a string discriminator
- Generating and persisting replacement credentials after validation fails
Verification completed:
- npm run typecheck passes
- npm run lint passes
- npm run build passes
- All 60 test files pass
- All 1,305 tests pass
No known credential boundary cases remain uncovered.

# Reviewer Nudging
Start with CommissioningManager.loadOrGenerateCredentials().
The key review point is the replacement of truthiness checks with explicit integer, passcode and discriminator-range validation.
Then review the loadOrGenerateCredentials tests, particularly the valid zero-discriminator case and the table of malformed stored values.
