### PR TITLE
perf: cache Homebridge package metadata

### DIFF
--- a/src/version.spec.ts
+++ b/src/version.spec.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 
 import { readJsonSync } from 'fs-extra'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import getVersion, { getRequiredNodeVersion } from './version.js'
 
@@ -20,5 +20,27 @@ describe('version', () => {
       const version = getRequiredNodeVersion()
       expect(version).toBe(realPackageJson.engines.node)
     })
+  })
+
+  it('should read package metadata once per module load', async () => {
+    const readFileSync = vi.fn(() => JSON.stringify({
+      version: '1.2.3',
+      engines: { node: '^24' },
+    }))
+    vi.resetModules()
+    vi.doMock('node:fs', () => ({ readFileSync }))
+
+    try {
+      const versionModule = await import('./version.js')
+
+      expect(versionModule.default()).toBe('1.2.3')
+      expect(versionModule.default()).toBe('1.2.3')
+      expect(versionModule.getRequiredNodeVersion()).toBe('^24')
+      expect(versionModule.getRequiredNodeVersion()).toBe('^24')
+      expect(readFileSync).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.doUnmock('node:fs')
+      vi.resetModules()
+    }
   })
 })

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,15 +5,20 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-function loadPackageJson(): any {
-  const packageJSONPath = join(__dirname, '../package.json')
-  return JSON.parse(readFileSync(packageJSONPath, { encoding: 'utf8' }))
+interface PackageMetadata {
+  version: string
+  engines: {
+    node: string
+  }
 }
 
+const packageJSONPath = join(__dirname, '../package.json')
+const packageMetadata = JSON.parse(readFileSync(packageJSONPath, 'utf8')) as PackageMetadata
+
 export default function getVersion(): string {
-  return loadPackageJson().version
+  return packageMetadata.version
 }
 
 export function getRequiredNodeVersion(): string {
-  return loadPackageJson().engines.node
+  return packageMetadata.engines.node
 }


### PR DESCRIPTION
## :recycle: Current situation
Homebridge obtains its version and required Node.js version through version.ts.
Each call currently reads and parses package.json synchronously:
```
function loadPackageJson(): any {
  const packageJSONPath = join(__dirname, '../package.json')
  return JSON.parse(readFileSync(packageJSONPath, { encoding: 'utf8' }))
}

export default function getVersion(): string {
  return loadPackageJson().version
}

export function getRequiredNodeVersion(): string {
  return loadPackageJson().engines.node
}
```

getVersion() is called from several startup paths, including:
- CLI initialization
- API construction
- Bridge publication
- Plugin compatibility checks
- Main and child Matter bridge initialization
- Matter server lifecycle setup
Plugin compatibility validation calls it for each loaded plugin and may call it again when producing a compatibility warning.
This results in repeated synchronous filesystem reads and JSON parsing for metadata that cannot change while Homebridge is running. The loader also returns any, leaving the expected package metadata structure unchecked.
## :bulb: Proposed solution
Read and parse package.json once when the version module is loaded:
```
interface PackageMetadata {
  version: string
  engines: {
    node: string
  }
}

const packageMetadata = JSON.parse(
  readFileSync(packageJSONPath, 'utf8'),
) as PackageMetadata
```

The exported getters then return cached properties:
```
export default function getVersion(): string {
  return packageMetadata.version
}

export function getRequiredNodeVersion(): string {
  return packageMetadata.engines.node
}
```
This removes repeated synchronous filesystem access and JSON parsing while retaining the existing getter API.
The package metadata is immutable for the lifetime of a running Homebridge process, so rereading the file cannot provide a meaningful runtime update.

## :gear: Release Notes
Reduced repeated synchronous filesystem operations during Homebridge startup and plugin compatibility checks by caching package metadata.
There are no public API changes, breaking changes or migration requirements.

## :heavy_plus_sign: Additional Information
The metadata remains loaded from Homebridge’s installed package.json. This change does not introduce generated constants or duplicate version values.
Both existing getter functions retain their current signatures and return values.
Matter lazy-loading behavior is unaffected.

### Testing
Added a regression test that loads the version module with a mocked filesystem reader and calls both getters repeatedly.
The test verifies that:
- getVersion() continues returning the package version.
- getRequiredNodeVersion() continues returning the Node.js engine requirement.
- Repeated calls to both getters result in exactly one readFileSync operation per module load.
The existing tests comparing returned values against the real package.json remain in place.
Verification completed:
- npm run typecheck passes
- npm run lint passes
- npm run build passes
- Version tests pass
- Matter lazy-loading tests pass
- All 60 test files pass
- All 1,298 tests pass

### Reviewer Nudging
Start with src/version.ts.
The primary review point is that package metadata is process-static and is now read once at module initialization while the existing getter API remains unchanged.
Then review the new version.spec.ts case, which verifies that repeated getter calls perform only one filesystem read.
