### PR TITLE
fix: coalesce child bridge port requests

### DIFF
--- a/src/childBridgeFork.spec.ts
+++ b/src/childBridgeFork.spec.ts
@@ -79,6 +79,66 @@ describe('childBridgeFork - Matter Accessory Guard', () => {
   })
 })
 
+describe('childBridgeFork - port requests', () => {
+  it('coalesces concurrent requests for the same external port', async () => {
+    const fork = new ChildBridgeFork()
+    const sendMessage = vi.spyOn(fork, 'sendMessage').mockImplementation(() => {})
+    const username = 'AA:BB:CC:DD:EE:FF'
+
+    const firstRequest = fork.requestExternalPort(username)
+    const secondRequest = fork.requestExternalPort(username)
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(ChildProcessMessageEventType.PORT_REQUEST, { username })
+
+    fork.handleExternalResponse({ username, port: 51000 })
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([51000, 51000])
+    expect((fork as any).pendingPortRequests.size).toBe(0)
+  })
+
+  it('coalesces concurrent Matter port requests and preserves their type', async () => {
+    const fork = new ChildBridgeFork()
+    const sendMessage = vi.spyOn(fork, 'sendMessage').mockImplementation(() => {})
+    const uniqueId = 'AABBCCDDEEFF'
+
+    const firstRequest = fork.requestMatterPort(uniqueId)
+    const secondRequest = fork.requestMatterPort(uniqueId)
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(ChildProcessMessageEventType.PORT_REQUEST, {
+      username: uniqueId,
+      portType: 'matter',
+    })
+
+    fork.handleExternalResponse({ username: uniqueId, port: 5550 })
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([5550, 5550])
+  })
+
+  it('resolves every coalesced caller when the parent times out', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(Logger.internal, 'warn').mockImplementation(() => {})
+    try {
+      const fork = new ChildBridgeFork()
+      const sendMessage = vi.spyOn(fork, 'sendMessage').mockImplementation(() => {})
+      const username = 'AA:BB:CC:DD:EE:FF'
+
+      const firstRequest = fork.requestExternalPort(username)
+      const secondRequest = fork.requestExternalPort(username)
+      await vi.advanceTimersByTimeAsync(5000)
+
+      await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([undefined, undefined])
+      expect(sendMessage).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect((fork as any).pendingPortRequests.size).toBe(0)
+    } finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe('childBridgeFork - shutdown', () => {
   it('does not throw when a signal arrives before bridgeService is assigned', () => {
     const fork = new ChildBridgeFork()

--- a/src/childBridgeFork.ts
+++ b/src/childBridgeFork.ts
@@ -45,6 +45,11 @@ process.title = 'homebridge: child bridge'
 
 const matterLogger = Logger.withPrefix('Matter/ChildManager')
 
+interface PendingPortRequest {
+  promise: Promise<number | undefined>
+  complete: (port: number | undefined) => void
+}
+
 export class ChildBridgeFork {
   private bridgeService!: BridgeService
   private api!: HomebridgeAPI
@@ -64,7 +69,7 @@ export class ChildBridgeFork {
   private bridgeConfig!: BridgeConfiguration
   private bridgeOptions!: BridgeOptions
 
-  private portRequestCallback: Map<MacAddress, (port: number | undefined) => void> = new Map()
+  private pendingPortRequests = new Map<MacAddress, PendingPortRequest>()
 
   constructor() {
     // tell the parent process we are ready to accept plugin config
@@ -313,56 +318,45 @@ export class ChildBridgeFork {
    * Request the next available external HAP port from the parent process
    * @param username
    */
-  public async requestExternalPort(username: MacAddress): Promise<number | undefined> {
-    return new Promise((resolve) => {
-      const requestTimeout = setTimeout(() => {
-        Logger.internal.warn('Parent process did not respond to port allocation request within 5 seconds - assigning random port.')
-        this.portRequestCallback.delete(username)
-        resolve(undefined)
-      }, 5000)
-
-      // setup callback
-      const callback = (port: number | undefined) => {
-        clearTimeout(requestTimeout)
-        this.portRequestCallback.delete(username)
-        resolve(port)
-      }
-      this.portRequestCallback.set(username, callback)
-
-      // send port request
-      this.sendMessage<ChildProcessPortRequestEventData>(ChildProcessMessageEventType.PORT_REQUEST, { username })
-    })
+  public requestExternalPort(username: MacAddress): Promise<number | undefined> {
+    return this.requestPort({ username })
   }
 
   /**
    * Request the next available Matter port from the parent process
    * @param uniqueId - MAC-derived identifier (without colons)
    */
-  public async requestMatterPort(uniqueId: string): Promise<number | undefined> {
-    return new Promise((resolve) => {
-      // Use uniqueId as the key for the callback map
-      const mac = uniqueId as MacAddress
+  public requestMatterPort(uniqueId: string): Promise<number | undefined> {
+    return this.requestPort({ username: uniqueId as MacAddress, portType: 'matter' })
+  }
 
-      const requestTimeout = setTimeout(() => {
-        matterLogger.warn('Parent process did not respond to Matter port allocation request within 5 seconds - assigning random port.')
-        this.portRequestCallback.delete(mac)
-        resolve(undefined)
-      }, 5000)
+  private requestPort(request: ChildProcessPortRequestEventData): Promise<number | undefined> {
+    const existingRequest = this.pendingPortRequests.get(request.username)
+    if (existingRequest) {
+      return existingRequest.promise
+    }
 
-      // setup callback
-      const callback = (port: number | undefined) => {
-        clearTimeout(requestTimeout)
-        this.portRequestCallback.delete(mac)
-        resolve(port)
-      }
-      this.portRequestCallback.set(mac, callback)
-
-      // send Matter port request
-      this.sendMessage<ChildProcessPortRequestEventData>(ChildProcessMessageEventType.PORT_REQUEST, {
-        username: mac,
-        portType: 'matter',
-      })
+    let resolveRequest: (port: number | undefined) => void
+    const promise = new Promise<number | undefined>((resolve) => {
+      resolveRequest = resolve
     })
+    const requestTimeout = setTimeout(() => {
+      if (request.portType === 'matter') {
+        matterLogger.warn('Parent process did not respond to Matter port allocation request within 5 seconds - assigning random port.')
+      } else {
+        Logger.internal.warn('Parent process did not respond to port allocation request within 5 seconds - assigning random port.')
+      }
+      this.pendingPortRequests.get(request.username)?.complete(undefined)
+    }, 5000)
+    const complete = (port: number | undefined) => {
+      clearTimeout(requestTimeout)
+      this.pendingPortRequests.delete(request.username)
+      resolveRequest(port)
+    }
+
+    this.pendingPortRequests.set(request.username, { promise, complete })
+    this.sendMessage<ChildProcessPortRequestEventData>(ChildProcessMessageEventType.PORT_REQUEST, request)
+    return promise
   }
 
   /**
@@ -370,10 +364,7 @@ export class ChildBridgeFork {
    * @param data
    */
   public handleExternalResponse(data: ChildProcessPortAllocatedEventData): void {
-    const callback = this.portRequestCallback.get(data.username)
-    if (callback) {
-      callback(data.port)
-    }
+    this.pendingPortRequests.get(data.username)?.complete(data.port)
   }
 
   /**


### PR DESCRIPTION
## :recycle: Current situation
Child bridges request HAP and Matter ports from the parent process through IPC.
Each pending request is currently stored in a callback map keyed by its username or unique identifier:
```
this.portRequestCallback.set(username, callback)
```

If two requests for the same key are active concurrently, the second request replaces the first callback.
This can produce several failure modes:
- Only the most recently stored callback receives the parent response.
- An earlier caller can remain unresolved until its timeout.
- The first timeout can delete the newer callback.
- A valid parent response can consequently be ignored.
- Duplicate IPC requests perform unnecessary parent-side allocation work.
The HAP and Matter request implementations also duplicate their promise, timeout, callback cleanup and IPC dispatch logic.

## :bulb: Proposed solution
Track one pending request per allocation key. Each entry contains:
- The shared promise returned to concurrent callers
- A completion callback responsible for cleanup and resolution

When another request arrives for the same key while one is pending, Homebridge returns the existing promise instead of replacing its callback or sending another IPC message.
```
const existingRequest = this.pendingPortRequests.get(request.username)
if (existingRequest) {
  return existingRequest.promise
}
```

Both HAP and Matter requests now delegate to one private request path:
```
requestExternalPort(username)
  → requestPort({ username })

requestMatterPort(uniqueId)
  → requestPort({ username: uniqueId, portType: 'matter' })
```
Successful responses and timeouts both complete the shared request, resolve every caller and remove the pending entry.
The existing parent/child IPC message format remains unchanged.

## :gear: Release Notes
Fixed concurrent child-bridge port requests potentially overwriting each other and delaying or losing allocation responses.
Duplicate requests for the same port allocation now share one parent request and resolve consistently.
There are no configuration changes, breaking changes or migration requirements.

## :heavy_plus_sign: Additional Information
This change also consolidates the duplicated HAP and Matter request implementations.
Requests for different allocation keys remain independent. Once a request completes or times out, its pending entry is removed and a later request can create a new allocation request normally.
The existing five-second timeout behavior and warning messages are preserved.

### Testing
Added tests covering:
- Two concurrent HAP port requests using the same username
- A single IPC request being sent for coalesced HAP callers
- Both HAP callers receiving the same allocated port
- Cleanup of the pending request after a successful response
- Two concurrent Matter port requests using the same identifier
- Preservation of portType: 'matter' in the IPC request
- Both Matter callers receiving the same allocated port
- Multiple coalesced callers resolving to undefined after a timeout
- A single timeout warning for a coalesced request
- Cleanup of the pending request after a timeout
Verification completed:
- npm run typecheck passes
- npm run lint passes
- npm run build passes
- Focused child-bridge tests pass
- All 60 test files pass
- All 1,300 tests pass

### Reviewer Nudging
Start with the new PendingPortRequest structure and requestPort() method in src/childBridgeFork.ts.
The primary correctness points are:
- The pending entry is installed before the IPC message is sent.
- Concurrent callers receive the existing promise.
- Both responses and timeouts use the same completion path.
- Completion clears the timeout and removes the pending entry.

Then review the new port-request tests in src/childBridgeFork.spec.ts, particularly the concurrent-request and shared-timeout cases.
